### PR TITLE
feat(alerts): KAM-402: send internal errors as alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "rppal",
  "serde",
  "serde_json",
+ "serde_regex",
  "serde_yml",
  "ssh-key",
  "sysinfo",
@@ -4360,6 +4361,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -66,6 +66,7 @@ rpi-st7789v2-driver = { version = "0.3.7", path = "../rpi-st7789v2-driver", feat
 rppal = { version = "0.22.1", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.139"
+serde_regex = { version = "1.1.0", optional = true }
 serde_yml = { version = "0.0.12", optional = true }
 ssh-key = { version = "0.6.6", optional = true }
 sysinfo = { version = "0.33.1", optional = true }
@@ -156,6 +157,8 @@ tamanu-alerts = [
 	"dep:humantime",
 	"dep:mailgun-rs",
 	"dep:pulldown-cmark",
+	"dep:regex",
+	"dep:serde_regex",
 	"dep:serde_yml",
 	"dep:sysinfo",
 	"dep:tera",

--- a/crates/bestool/src/actions/tamanu/alerts/templates.rs
+++ b/crates/bestool/src/actions/tamanu/alerts/templates.rs
@@ -21,6 +21,7 @@ const DEFAULT_SUBJECT_TEMPLATE: &str = "[Tamanu Alert] {{ filename }} ({{ hostna
 #[derive(serde::Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TemplateField {
+	Now,
 	Filename,
 	Subject,
 	Body,
@@ -32,6 +33,7 @@ pub enum TemplateField {
 impl TemplateField {
 	pub fn as_str(self) -> &'static str {
 		match self {
+			Self::Now => "now",
 			Self::Filename => "filename",
 			Self::Subject => "subject",
 			Self::Body => "body",
@@ -110,7 +112,7 @@ pub fn build_context(alert: &AlertDefinition, now: chrono::DateTime<chrono::Utc>
 		TemplateField::Filename.as_str(),
 		&alert.file.file_name().unwrap().to_string_lossy(),
 	);
-	context.insert("now", &now.to_string());
+	context.insert(TemplateField::Now.as_str(), &now.to_string());
 
 	context
 }

--- a/crates/bestool/src/actions/tamanu/alerts/tests.rs
+++ b/crates/bestool/src/actions/tamanu/alerts/tests.rs
@@ -74,6 +74,30 @@ run: echo foobar
 }
 
 #[test]
+fn test_alert_parse_errors() {
+	let alert = r#"
+errors:
+- timeout
+- send.+
+"#;
+	let alert: AlertDefinition = serde_yml::from_str(&alert).unwrap();
+	let alert = alert.normalise(&Default::default());
+	assert_eq!(alert.interval, std::time::Duration::default());
+	assert!(matches!(alert.source, TicketSource::Errors { .. }));
+}
+
+#[test]
+fn test_alert_parse_errors_empty() {
+	let alert = r#"
+errors: []
+"#;
+	let alert: AlertDefinition = serde_yml::from_str(&alert).unwrap();
+	let alert = alert.normalise(&Default::default());
+	assert_eq!(alert.interval, std::time::Duration::default());
+	assert!(matches!(alert.source, TicketSource::Errors { .. }));
+}
+
+#[test]
 fn test_alert_parse_invalid_source() {
 	let alert = r#"
 shell: bash


### PR DESCRIPTION
We add a new special alert source:

```yaml
errors: []
```

which can either be an empty array (match all errors) or a list of regex to match error messages:

```yaml
errors:
- timeout
- send.+
```

This can then be set up in its own alert definition file with its own send targets, e.g.

```yaml
errors: [timeout]
send:
  - target: external
    id: default
    subject: "TEST Tamanu Alert Timeouts - {{ now }}"
    template: |
      Some alerts on {{ hostname }} have timed out:

      {% for message in errors %}
      {{ message }}

      ---
      {% endfor %}
```