### PR TITLE
fix(rdp): identify kicked user from stored session state

### DIFF
--- a/crates/bestool/src/actions/rdp/events.rs
+++ b/crates/bestool/src/actions/rdp/events.rs
@@ -23,7 +23,7 @@ pub struct Event {
 impl Event {
 	/// Parse [`Self::address`] as an [`IpAddr`], stripping any `%<zone>` scope
 	/// identifier (which Rust's stdlib parser rejects). Returns `None` for
-	/// missing addresses, the sentinel `LOCAL`, or unparseable values.
+	/// missing addresses, the sentinel `LOCAL`, or unparsable values.
 	pub fn ip(&self) -> Option<IpAddr> {
 		let raw = self.address.as_deref()?;
 		parse_address(raw)

--- a/crates/bestool/src/actions/rdp/monitor.rs
+++ b/crates/bestool/src/actions/rdp/monitor.rs
@@ -112,29 +112,44 @@ pub(super) async fn handle_event(
 	audit: &mut AuditLog,
 	tailscale_only: bool,
 ) {
-	let (tailscale_user, tailscale_source) = resolve_tailscale(&ev).await;
-
-	if let Err(err) = audit
-		.append(&ev, tailscale_user.as_deref(), tailscale_source)
-		.await
-	{
-		warn!(?err, "audit log write failed");
-	}
-
 	let is_tailscale = ev.ip().map(is_tailscale_ip).unwrap_or(false);
 
 	match ev.kind {
 		EventKind::Logon | EventKind::Reconnect => {
-			if let Some(kick) = tracker.on_connect(&ev)
+			// Resolve Tailscale identity *now*: at logon time the most recent
+			// wireguard handshake on the tailnet is the incoming user's. The
+			// identity is then stashed in the tracker so the matching
+			// disconnect (e.g. the old user getting kicked) can retrieve it.
+			let (tailscale_user, tailscale_source) = resolve_tailscale(&ev).await;
+			write_audit(audit, &ev, tailscale_user.as_deref(), tailscale_source).await;
+
+			if let Some(kick) = tracker.on_connect(&ev, tailscale_user.clone())
 				&& (!tailscale_only || is_tailscale || tailscale_user.is_some())
 			{
 				emit_kick(&ev, kick);
 			}
 		}
 		EventKind::Disconnect | EventKind::Logoff => {
-			tracker.on_disconnect(&ev, tailscale_user);
+			// Don't query Tailscale here: at disconnect time the freshest
+			// handshake belongs to the *incoming* user whose RDP connection
+			// triggered the kick, not the departing user. Use the identity we
+			// stored when this session logged on.
+			let stored = tracker.on_disconnect(&ev);
+			let source = stored.as_ref().map(|_| "session_tracker");
+			write_audit(audit, &ev, stored.as_deref(), source).await;
 		}
 		EventKind::ShellStart => {}
+	}
+}
+
+async fn write_audit(
+	audit: &mut AuditLog,
+	ev: &Event,
+	tailscale_user: Option<&str>,
+	tailscale_source: Option<&str>,
+) {
+	if let Err(err) = audit.append(ev, tailscale_user, tailscale_source).await {
+		warn!(?err, "audit log write failed");
 	}
 }
 

--- a/crates/bestool/src/actions/rdp/state.rs
+++ b/crates/bestool/src/actions/rdp/state.rs
@@ -19,6 +19,7 @@ pub struct Tracker {
 #[derive(Debug, Clone)]
 struct SessionState {
 	user: String,
+	tailscale: Option<String>,
 	connect_time: DateTime<Utc>,
 }
 
@@ -50,36 +51,46 @@ impl Tracker {
 
 	/// Process a disconnect/logoff event. Records session duration (when known)
 	/// so a subsequent logon can be identified as a kick.
-	pub fn on_disconnect(&mut self, ev: &Event, tailscale: Option<String>) {
+	///
+	/// Returns the Tailscale identity that was recorded for this session at
+	/// logon time, so the caller can emit it into the audit log. We look it up
+	/// here (rather than re-querying Tailscale on the disconnect event) because
+	/// at disconnect time the freshest handshake on the tailnet is typically
+	/// the *incoming* user whose RDP connection just triggered the kick.
+	pub fn on_disconnect(&mut self, ev: &Event) -> Option<String> {
 		let prior = self.sessions.remove(&ev.session_id);
-		let (user, connected_for) = match prior {
+		let (user, tailscale, connected_for) = match prior {
 			Some(s) => {
 				let dur = (ev.time - s.connect_time)
 					.to_std()
 					.unwrap_or(Duration::ZERO);
-				(s.user, dur)
+				(s.user, s.tailscale, dur)
 			}
-			None => (ev.user.clone(), Duration::ZERO),
+			None => (ev.user.clone(), None, Duration::ZERO),
 		};
 
 		self.recent_disconnects.push_back(RecentDisconnect {
 			when: ev.time,
 			user,
-			tailscale,
+			tailscale: tailscale.clone(),
 			connected_for,
 		});
 		self.prune(ev.time);
+		tailscale
 	}
 
-	/// Process a logon/reconnect event. If a *different* user disconnected
-	/// within the kick window, returns a [`KickDetection`].
-	pub fn on_connect(&mut self, ev: &Event) -> Option<KickDetection> {
+	/// Process a logon/reconnect event with the Tailscale identity resolved for
+	/// the incoming user. If a *different* user disconnected within the kick
+	/// window, returns a [`KickDetection`] carrying the previously-stored
+	/// identity of the kicked user.
+	pub fn on_connect(&mut self, ev: &Event, tailscale: Option<String>) -> Option<KickDetection> {
 		self.prune(ev.time);
 
 		self.sessions.insert(
 			ev.session_id,
 			SessionState {
 				user: ev.user.clone(),
+				tailscale,
 				connect_time: ev.time,
 			},
 		);
@@ -146,13 +157,23 @@ mod tests {
 	#[test]
 	fn detects_kick_within_window() {
 		let mut tr = Tracker::new(Duration::from_secs(60));
-		tr.on_connect(&ev(EventKind::Logon, 2, r"CORP\alice", "2026-04-22T10:00:00Z"));
-		tr.on_disconnect(
-			&ev(EventKind::Disconnect, 2, r"CORP\alice", "2026-04-22T10:24:00Z"),
+		tr.on_connect(
+			&ev(EventKind::Logon, 2, r"CORP\alice", "2026-04-22T10:00:00Z"),
 			Some("alice@bes.au".into()),
 		);
+		let stored = tr.on_disconnect(&ev(
+			EventKind::Disconnect,
+			2,
+			r"CORP\alice",
+			"2026-04-22T10:24:00Z",
+		));
+		assert_eq!(stored.as_deref(), Some("alice@bes.au"));
+
 		let kick = tr
-			.on_connect(&ev(EventKind::Logon, 3, r"CORP\bob", "2026-04-22T10:24:10Z"))
+			.on_connect(
+				&ev(EventKind::Logon, 3, r"CORP\bob", "2026-04-22T10:24:10Z"),
+				Some("bob@bes.au".into()),
+			)
 			.expect("should detect kick");
 		assert_eq!(kick.kicked_user, r"CORP\alice");
 		assert_eq!(kick.kicked_tailscale.as_deref(), Some("alice@bes.au"));
@@ -162,30 +183,59 @@ mod tests {
 	#[test]
 	fn no_kick_when_same_user_reconnects() {
 		let mut tr = Tracker::new(Duration::from_secs(60));
-		tr.on_connect(&ev(EventKind::Logon, 2, r"CORP\alice", "2026-04-22T10:00:00Z"));
-		tr.on_disconnect(
-			&ev(EventKind::Disconnect, 2, r"CORP\alice", "2026-04-22T10:10:00Z"),
+		tr.on_connect(
+			&ev(EventKind::Logon, 2, r"CORP\alice", "2026-04-22T10:00:00Z"),
 			None,
 		);
+		tr.on_disconnect(&ev(
+			EventKind::Disconnect,
+			2,
+			r"CORP\alice",
+			"2026-04-22T10:10:00Z",
+		));
 		assert!(
-			tr.on_connect(&ev(EventKind::Reconnect, 2, r"CORP\alice", "2026-04-22T10:10:05Z"))
-				.is_none()
+			tr.on_connect(
+				&ev(EventKind::Reconnect, 2, r"CORP\alice", "2026-04-22T10:10:05Z"),
+				None,
+			)
+			.is_none()
 		);
 	}
 
 	#[test]
 	fn no_kick_outside_window() {
 		let mut tr = Tracker::new(Duration::from_secs(30));
-		tr.on_connect(&ev(EventKind::Logon, 2, r"CORP\alice", "2026-04-22T10:00:00Z"));
-		tr.on_disconnect(
-			&ev(EventKind::Disconnect, 2, r"CORP\alice", "2026-04-22T10:10:00Z"),
+		tr.on_connect(
+			&ev(EventKind::Logon, 2, r"CORP\alice", "2026-04-22T10:00:00Z"),
 			None,
 		);
+		tr.on_disconnect(&ev(
+			EventKind::Disconnect,
+			2,
+			r"CORP\alice",
+			"2026-04-22T10:10:00Z",
+		));
 		// New user logs in 45s later — outside 30s window.
 		assert!(
-			tr.on_connect(&ev(EventKind::Logon, 3, r"CORP\bob", "2026-04-22T10:10:45Z"))
-				.is_none()
+			tr.on_connect(
+				&ev(EventKind::Logon, 3, r"CORP\bob", "2026-04-22T10:10:45Z"),
+				None,
+			)
+			.is_none()
 		);
+	}
+
+	#[test]
+	fn disconnect_of_untracked_session_yields_none() {
+		let mut tr = Tracker::new(Duration::from_secs(60));
+		// Monitor started mid-session; we never saw the logon.
+		let stored = tr.on_disconnect(&ev(
+			EventKind::Disconnect,
+			2,
+			r"CORP\alice",
+			"2026-04-22T10:00:00Z",
+		));
+		assert!(stored.is_none());
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
- At disconnect time, the freshest wireguard handshake on the tailnet belongs to the **incoming** user whose RDP connection just triggered the kick, not the departing user — so the peer_handshake fallback was confidently identifying the wrong person on disconnect events.
- Resolve Tailscale identity on logon (where "most recent handshake" correctly points at the arriving user), stash it in the tracker's `SessionState`, and on disconnect retrieve the stored identity instead of re-querying.
- If the monitor started mid-session and never saw the logon, the stored identity is `None` — better than confidently wrong.

## Test plan
- [x] `cargo test -p bestool rdp::` — 13 tests pass including new `disconnect_of_untracked_session_yields_none`
- [x] `cargo clippy` clean on both x86_64-unknown-linux-gnu and x86_64-pc-windows-gnu
- [ ] Run `bestool rdp monitor` on the server, disconnect + kick from a second Tailscale peer, verify the toast names the right person and the audit log's `tailscale_source` is `"session_tracker"` on disconnect events

🤖 Generated with [Claude Code](https://claude.com/claude-code)