### PR TITLE
feat(rdp): only toast when the kicker has a Tailscale identity

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -660,9 +660,6 @@ Intended to run as a Windows service or startup task with sufficient privilege t
 * `--kick-window <KICK_WINDOW>` — Max seconds between a disconnect and a new logon to count as a "kick" and raise a toast
 
   Default value: `60`
-* `--tailscale-only` — Only consider Tailscale source IPs (100.64.0.0/10) for kick detection. When false, any source IP can trigger the notification
-
-  Default value: `false`
 
 
 
@@ -693,7 +690,6 @@ Register the service with the Service Control Manager (auto-start)
 * `--audit-log <AUDIT_LOG>` — Path to append-only JSONL audit log of every RDP session event
 * `--poll-interval <POLL_INTERVAL>` — Seconds between event log polls
 * `--kick-window <KICK_WINDOW>` — Max seconds between a disconnect and a new logon to count as a "kick"
-* `--tailscale-only` — Only consider Tailscale source IPs for kick detection
 
 
 

--- a/crates/bestool/src/actions/rdp/events.rs
+++ b/crates/bestool/src/actions/rdp/events.rs
@@ -1,5 +1,3 @@
-use std::net::IpAddr;
-
 use chrono::{DateTime, Utc};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use serde::{Deserialize, Serialize};
@@ -18,23 +16,6 @@ pub struct Event {
 	pub address: Option<String>,
 	pub time: DateTime<Utc>,
 	pub record_id: u64,
-}
-
-impl Event {
-	/// Parse [`Self::address`] as an [`IpAddr`], stripping any `%<zone>` scope
-	/// identifier (which Rust's stdlib parser rejects). Returns `None` for
-	/// missing addresses, the sentinel `LOCAL`, or unparsable values.
-	pub fn ip(&self) -> Option<IpAddr> {
-		let raw = self.address.as_deref()?;
-		parse_address(raw)
-	}
-}
-
-pub(crate) fn parse_address(raw: &str) -> Option<IpAddr> {
-	if raw.is_empty() || raw.eq_ignore_ascii_case("LOCAL") {
-		return None;
-	}
-	raw.split('%').next().unwrap_or(raw).parse().ok()
 }
 
 /// The subset of event IDs we care about.
@@ -280,7 +261,6 @@ mod tests {
 		assert_eq!(events[0].session_id, 2);
 		assert_eq!(events[0].user, r"CORP\alice");
 		assert_eq!(events[0].address.as_deref(), Some("100.64.1.5"));
-		assert_eq!(events[0].ip(), "100.64.1.5".parse::<IpAddr>().ok());
 
 		assert_eq!(events[1].kind, EventKind::Logon);
 		assert_eq!(events[1].session_id, 3);
@@ -288,7 +268,7 @@ mod tests {
 	}
 
 	#[test]
-	fn parses_ipv6_with_zone_suffix() {
+	fn preserves_ipv6_zone_suffix_verbatim() {
 		let xml = r#"<Events>
 <Event><System><EventID>25</EventID><TimeCreated SystemTime='2026-04-22T10:00:00Z'/><EventRecordID>1</EventRecordID></System><UserData><EventXML><User>CORP\alice</User><SessionID>2</SessionID><Address>0:0:fd7a:115c:a1e0::%2318139703</Address></EventXML></UserData></Event>
 </Events>"#;
@@ -298,14 +278,6 @@ mod tests {
 			events[0].address.as_deref(),
 			Some("0:0:fd7a:115c:a1e0::%2318139703")
 		);
-		// Zone suffix is stripped for IpAddr parsing, so this returns Some(...)
-		assert!(events[0].ip().is_some());
-	}
-
-	#[test]
-	fn local_address_parses_to_none() {
-		assert_eq!(parse_address("LOCAL"), None);
-		assert_eq!(parse_address(""), None);
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/rdp/monitor.rs
+++ b/crates/bestool/src/actions/rdp/monitor.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, path::PathBuf, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use chrono::{DateTime, Utc};
 use clap::Parser;
@@ -40,11 +40,6 @@ pub struct MonitorArgs {
 	/// and raise a toast.
 	#[arg(long, default_value_t = 60)]
 	pub kick_window: u64,
-
-	/// Only consider Tailscale source IPs (100.64.0.0/10) for kick detection.
-	/// When false, any source IP can trigger the notification.
-	#[arg(long, default_value_t = false)]
-	pub tailscale_only: bool,
 
 	/// Internal: set when launched by the Windows Service Control Manager.
 	/// Routes through the service dispatcher so the SCM sees a properly
@@ -101,19 +96,12 @@ pub async fn run(ctx: Context<RdpArgs, MonitorArgs>) -> Result<()> {
 				continue;
 			}
 			last_record_id = ev.record_id;
-			handle_event(ev, &mut tracker, &mut audit, args.tailscale_only).await;
+			handle_event(ev, &mut tracker, &mut audit).await;
 		}
 	}
 }
 
-pub(super) async fn handle_event(
-	ev: Event,
-	tracker: &mut Tracker,
-	audit: &mut AuditLog,
-	tailscale_only: bool,
-) {
-	let is_tailscale = ev.ip().map(is_tailscale_ip).unwrap_or(false);
-
+pub(super) async fn handle_event(ev: Event, tracker: &mut Tracker, audit: &mut AuditLog) {
 	match ev.kind {
 		EventKind::Logon | EventKind::Reconnect => {
 			// Resolve Tailscale identity *now*: at logon time the most recent
@@ -123,8 +111,12 @@ pub(super) async fn handle_event(
 			let (tailscale_user, tailscale_source) = resolve_tailscale(&ev).await;
 			write_audit(audit, &ev, tailscale_user.as_deref(), tailscale_source).await;
 
+			// Only raise a toast when the *incoming* user is identifiable on
+			// Tailscale. A connection from console / LAN / unknown source
+			// can't be addressed back to a person, so the notification would
+			// have nowhere useful to go.
 			if let Some(kick) = tracker.on_connect(&ev, tailscale_user.clone())
-				&& (!tailscale_only || is_tailscale || tailscale_user.is_some())
+				&& tailscale_user.is_some()
 			{
 				emit_kick(&ev, kick);
 			}
@@ -190,21 +182,6 @@ async fn resolve_tailscale(ev: &Event) -> (Option<String>, Option<&'static str>)
 }
 
 const HANDSHAKE_WINDOW_SECS: i64 = 300;
-
-/// Tailscale's CGNAT range is `100.64.0.0/10` (IPv4) and
-/// `fd7a:115c:a1e0::/48` (IPv6 ULA).
-fn is_tailscale_ip(ip: IpAddr) -> bool {
-	match ip {
-		IpAddr::V4(v4) => {
-			let [a, b, ..] = v4.octets();
-			a == 100 && (64..128).contains(&b)
-		}
-		IpAddr::V6(v6) => {
-			let s = v6.segments();
-			s[0] == 0xfd7a && s[1] == 0x115c && s[2] == 0xa1e0
-		}
-	}
-}
 
 fn emit_kick(ev: &Event, kick: KickDetection) {
 	info!(

--- a/crates/bestool/src/actions/rdp/service.rs
+++ b/crates/bestool/src/actions/rdp/service.rs
@@ -51,10 +51,6 @@ pub struct InstallArgs {
 	/// Max seconds between a disconnect and a new logon to count as a "kick".
 	#[arg(long)]
 	pub kick_window: Option<u64>,
-
-	/// Only consider Tailscale source IPs for kick detection.
-	#[arg(long)]
-	pub tailscale_only: bool,
 }
 
 pub async fn run(ctx: Context<RdpArgs, ServiceArgs>) -> Result<()> {
@@ -143,9 +139,6 @@ mod imp {
 		if let Some(n) = args.kick_window {
 			launch.push("--kick-window".into());
 			launch.push(n.to_string().into());
-		}
-		if args.tailscale_only {
-			launch.push("--tailscale-only".into());
 		}
 
 		let m = manager(ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE)?;
@@ -319,7 +312,7 @@ mod imp {
 							for ev in events {
 								if ev.record_id <= last_record_id { continue; }
 								last_record_id = ev.record_id;
-								handle_event(ev, &mut tracker, &mut audit, args.tailscale_only).await;
+								handle_event(ev, &mut tracker, &mut audit).await;
 							}
 						}
 						Err(err) => warn!(?err, "failed to poll event log; will retry"),


### PR DESCRIPTION
## Summary
- Skip the kick toast entirely when the incoming user can't be resolved to a Tailscale login. A kick from a non-Tailscale source (LAN/console/unknown) can't be addressed back to a real person, so the notification has nowhere useful to go.
- Removes the now-redundant \`--tailscale-only\` flag (its weaker source-IP-range check is no longer used).
- Drops \`Event::ip()\` and \`parse_address\` since their only caller (\`is_tailscale_ip\`) is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)