### PR TITLE
feat(repo): add jj-aware cargo-release wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,4 +22,5 @@
 - Never write long summaries at the end of responses. Maximum 50 words if absolutely necessary.
 - To silence a warning, use `#[expect(..., reason = "...")]` instead of `#[allow(...)]`.
 - When changing Windows-specific code, run `cargo check` with a Windows GNU target (unless currently running on Windows).
+- To cut a release, run `./release.sh` (wraps `cargo release` and keeps jj in sync); don't invoke `cargo release` directly in a jj-colocated checkout.
 <!-- end rules -->

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")"
+
+# cargo-release wrapper for colocated jj+git repos.
+#
+# cargo-release drives git directly. In a colocated jj+git repo, jj's
+# working-copy commit (@) sits on top of the git branch and holds any
+# uncommitted changes. If @ is non-empty, or its parent is not the branch
+# cargo-release expects, the release commit lands in the wrong place or trips
+# cargo-release's dirty-state checks. After cargo-release moves the branch, jj
+# still thinks @ is based on the old parent, which leaves stale state on the
+# next jj command.
+#
+# This wrapper, when jj is present:
+#   1. Refuses to run if @ has any changes.
+#   2. Places @ as a fresh empty commit on main, so git HEAD == main.
+#   3. Runs `cargo release "$@"`.
+#   4. Imports the new git state into jj and re-parents @ onto the new main.
+#
+# When jj is absent (e.g. CI), it just execs cargo-release.
+
+has_jj() {
+	command -v jj >/dev/null 2>&1 && [ -d .jj ]
+}
+
+if ! has_jj; then
+	exec cargo release "$@"
+fi
+
+if [ -n "$(jj diff -r @ --summary)" ]; then
+	echo "error: jj @ has uncommitted changes; commit or abandon before releasing" >&2
+	exit 1
+fi
+
+jj new main >/dev/null
+
+set +e
+cargo release "$@"
+status=$?
+set -e
+
+jj git import >/dev/null
+jj new main >/dev/null
+
+exit "$status"


### PR DESCRIPTION
## Summary

- Adds `release.sh`, a wrapper around `cargo release` that keeps a colocated jj+git checkout in a sensible state.
- Before invocation it refuses to run if jj's `@` has uncommitted changes, then places `@` as a fresh empty commit on `main` so git HEAD lines up with what `cargo release` expects.
- After invocation it imports the new git state into jj and re-parents `@` onto the new `main`.
- When jj isn't present (e.g. CI), the wrapper just execs `cargo release` straight through.

## Test plan

- [ ] `./release.sh --help` from a clean jj `@` passes through to `cargo release --help`.
- [ ] `./release.sh patch` (dry-run; no `-x`) from a clean jj `@` on `main` runs cargo-release's preview and leaves jj pointing at a fresh `@` on the current main afterwards.
- [ ] Running with a dirty jj `@` is rejected with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)