### PR TITLE
fix(ci): drop install -D for BSD compat in release workflows

### DIFF
--- a/.github/workflows/release-alertd.yml
+++ b/.github/workflows/release-alertd.yml
@@ -112,11 +112,11 @@ jobs:
           fi
 
           mkdir -p staging
-          install -Dm644 crates/alertd/USAGE.md "staging/USAGE.md"
-          install -Dm644 crates/alertd/ALERTS.md "staging/ALERTS.md"
-          install -Dm644 crates/alertd/TARGETS.md "staging/TARGETS.md"
-          install -Dm644 COPYING "staging/COPYING"
-          install -Dm755 "$src_dir/bestool-alertd${ext}" "staging/bestool-alertd${ext}"
+          install -m644 crates/alertd/USAGE.md "staging/USAGE.md"
+          install -m644 crates/alertd/ALERTS.md "staging/ALERTS.md"
+          install -m644 crates/alertd/TARGETS.md "staging/TARGETS.md"
+          install -m644 COPYING "staging/COPYING"
+          install -m755 "$src_dir/bestool-alertd${ext}" "staging/bestool-alertd${ext}"
 
           tar -C staging --zstd -cf "${name}.tar.zst" .
           echo "asset=${name}.tar.zst" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-psql.yml
+++ b/.github/workflows/release-psql.yml
@@ -112,12 +112,12 @@ jobs:
           fi
 
           mkdir -p staging
-          install -Dm644 crates/psql/README.md "staging/README.md"
-          install -Dm644 crates/psql/EXAMPLES.md "staging/EXAMPLES.md"
-          install -Dm644 crates/psql/USAGE.md "staging/USAGE.md"
-          install -Dm644 COPYING "staging/COPYING"
-          install -Dm755 "$src_dir/bestool-psql${ext}" "staging/bestool-psql${ext}"
-          install -Dm755 "$src_dir/bestool-psql-audit${ext}" "staging/bestool-psql-audit${ext}"
+          install -m644 crates/psql/README.md "staging/README.md"
+          install -m644 crates/psql/EXAMPLES.md "staging/EXAMPLES.md"
+          install -m644 crates/psql/USAGE.md "staging/USAGE.md"
+          install -m644 COPYING "staging/COPYING"
+          install -m755 "$src_dir/bestool-psql${ext}" "staging/bestool-psql${ext}"
+          install -m755 "$src_dir/bestool-psql-audit${ext}" "staging/bestool-psql-audit${ext}"
 
           tar -C staging --zstd -cf "${name}.tar.zst" .
           echo "asset=${name}.tar.zst" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `bestool-psql` and `bestool-alertd` release workflows used `install -Dm…` to stage files into the archive. The `-D` flag is GNU-coreutils-only and macOS's BSD `install` rejects it:

```
install: illegal option -- D
```

This broke the package step on the `x86_64-apple-darwin` runner.

Since the staging directory is created up front with `mkdir -p staging`, `-D`'s "create parents" behavior is redundant. Dropped it from both workflows so they work on BSD `install` too.

## Test plan

- [ ] Re-run the release workflow for an existing tag (via `workflow_dispatch`) and confirm the `x86_64-apple-darwin` and `aarch64-apple-darwin` jobs now reach the upload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)