### PR TITLE
ci: tune dependabot for safer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,23 +7,28 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      actions-patches:
+        update-types:
+          - patch
+          - minor
+
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
     commit-message:
       prefix: deps
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
-      deps:
+      deps-patches:
         patterns:
           - "*"
-  - package-ecosystem: cargo
-    directory: /crates/bestool
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: deps
-    groups:
-      deps:
-        patterns:
-          - "*"
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
- Add cooldown windows (7 days for patch/minor, 14 for majors) so freshly released versions have time to be yanked or fixed before we pull them in.
- Group patches and minors per ecosystem; let majors fall through to individual PRs so a single bad major doesn't block the others.
- Drop redundant /crates/bestool entry; cargo ecosystem scans workspace members from the root manifest.