### PR TITLE
fix(ci): drop unsupported semver-major-days for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
       prefix: ci
       include: scope
     cooldown:
-      default-days: 7
-      semver-major-days: 14
+      default-days: 14
     groups:
       actions-patches:
         update-types:


### PR DESCRIPTION
That field isn't supported in the github-actions ecosystem (only default-days is). Set default-days to 14 since action bumps are nearly always major-shaped — pinned to `@vN` refs — so the major-tier value matches the spirit of the org cooldown standard.