### PR TITLE
ci: use macos-15 for x86_64-apple-darwin builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
           - target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
The `macos-14` runner image rolled out `20260512.0058.1` breaks `cargo auditable build` — the invocation hits `rustup-init` instead of dispatching properly, exploding with `Usage: rustup-init[EXE] [OPTIONS]`. Yesterday's image `20260427.0019.1` worked. `macos-15` is unaffected — `aarch64-apple-darwin` has been on it the whole time and is still green.

Both darwin targets cross-compile from an Apple Silicon host, so the host macOS version is incidental. Flipping `x86_64-apple-darwin` to `macos-15` unblocks until the upstream image regression is resolved.

Unblocks #309 and #310.