### PR TITLE
feat(tamanu): TAM-6782: add reload subcommand for safe rolling restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Ensure rustup is installed
+        shell: bash
+        run: |
+          if ! command -v rustup >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --default-toolchain none --profile minimal --no-modify-path
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
       - name: Configure toolchain
+        shell: bash
         run: |
           rustup toolchain install --profile minimal --no-self-update stable
           rustup target add ${{ matrix.target }}

--- a/crates/alertd/src/state_file.rs
+++ b/crates/alertd/src/state_file.rs
@@ -84,7 +84,7 @@ fn state_base_dir() -> Option<PathBuf> {
 /// Read and parse the state file.
 ///
 /// If the file is missing, returns an empty state — that's the first-run path.
-/// If the file is unreadable or unparseable, logs a warning, deletes the
+/// If the file is unreadable or unparsable, logs a warning, deletes the
 /// file, and returns an empty state. Persistence is best-effort; a corrupted
 /// file should not block the daemon.
 pub fn read(path: &Path) -> PersistedState {

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -144,7 +144,7 @@ tamanu-find = ["__tamanu"]
 tamanu-greenmask = ["__tamanu", "tamanu-config", "dep:bestool-psql", "dep:dunce", "dep:serde_yaml", "dep:walkdir"]
 tamanu-meta-ticket = ["__tamanu", "tamanu-config", "dep:base64", "dep:bestool-psql", "dep:p256", "dep:sysinfo"]
 tamanu-psql = ["__tamanu", "tamanu-config", "dep:bestool-psql"]
-tamanu-reload = ["__tamanu"]
+tamanu-reload = ["__tamanu", "dep:privilege"]
 __tamanu = [ # internal feature to enable the tamanu subcommand common code
 	"dep:dirs",
 	"dep:glob",

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -117,6 +117,7 @@ tamanu = [ # enable all tamanu subcommands
 	"tamanu-greenmask",
 	"tamanu-meta-ticket",
 	"tamanu-psql",
+	"tamanu-reload",
 ]
 tamanu-alerts = [
 	"__tamanu",
@@ -143,6 +144,7 @@ tamanu-find = ["__tamanu"]
 tamanu-greenmask = ["__tamanu", "tamanu-config", "dep:bestool-psql", "dep:dunce", "dep:serde_yaml", "dep:walkdir"]
 tamanu-meta-ticket = ["__tamanu", "tamanu-config", "dep:base64", "dep:bestool-psql", "dep:p256", "dep:sysinfo"]
 tamanu-psql = ["__tamanu", "tamanu-config", "dep:bestool-psql"]
+tamanu-reload = ["__tamanu"]
 __tamanu = [ # internal feature to enable the tamanu subcommand common code
 	"dep:dirs",
 	"dep:glob",

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1,3 +1,4 @@
+2026-05-17T23:32:01.016425Z  INFO bestool::download: A new version of bestool is available. Run 'bestool self-update' to update. current="1.7.1" latest="1.8.0"
 # Command-Line Help for `bestool`
 
 This document contains the help content for the `bestool` command-line program.
@@ -123,7 +124,7 @@ Export audit database entries as JSON
 
 ###### **Options:**
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
 * `-n`, `--limit <LIMIT>` — Number of entries to return (0 = unlimited)
 
   Default value: `100`
@@ -1439,7 +1440,7 @@ Aliases: p, pg, sql
   - `auto`:
     Auto-detect terminal theme
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
 * `--no-redact` — Don't redact data
 
    This will also skip loading redactions.
@@ -1450,13 +1451,13 @@ Aliases: p, pg, sql
 
 Restart Tamanu services one at a time.
 
-On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). After each restart, the strict readiness signal is:
+On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). After each restart, the readiness signal is:
 
 1. systemd reports the unit `active` 2. the unit's podman container responds on port 3000 (HTTP services only; workers like `*-tasks` and `*-fhir-*` skip this step)
 
 Then caddy is reloaded and systemd-resolved flushed (so caddy picks up the new container IP), a configurable cooldown is awaited, and optionally an external HTTP URL is probed.
 
-On Windows, restarts every `online` pm2 process one pm_id at a time (so scaled apps like `tamanu-api` roll instance-by-instance, not all at once). Strict readiness is `pm2` reporting `online` plus an HTTP probe of `http://127.0.0.1:<PORT>/` where `<PORT>` is the process's resolved `PORT` env var. Processes without a `PORT` (workers like `tamanu-tasks`, `tamanu-sync`, `tamanu-fhir-*`) skip the HTTP probe.
+On Windows, restarts every `online` pm2 process one pm_id at a time (so scaled apps like `tamanu-api` roll instance-by-instance, not all at once). Readiness is `pm2` reporting `online` plus an HTTP probe of `http://127.0.0.1:<PORT>/` where `<PORT>` is the process's resolved `PORT` env var. Processes without a `PORT` (workers like `tamanu-tasks`, `tamanu-sync`, `tamanu-fhir-*`) skip the HTTP probe.
 
 Examples: bestool tamanu reload bestool tamanu reload --filter '^tamanu-frontend@' bestool tamanu reload --check-url https://central.example.org --wait 15
 
@@ -1477,10 +1478,10 @@ Examples: bestool tamanu reload bestool tamanu reload --filter '^tamanu-frontend
   Default value: `10`
 * `--check-url <CHECK_URL>` — External HTTP URL to probe after each restart.
 
-   If set, after each service is restarted and reported ready, this URL is requested. A connection failure or 5xx response aborts the rollout. This is independent of the strict per-container probe (see --no-strict).
-* `--no-strict` — Skip the strict HTTP probe after each restart.
+   If set, after each service is restarted and reported ready, this URL is requested. A connection failure or 5xx response aborts the rollout. This is independent of the per-container probe (see --no-probe-http).
+* `--no-probe-http` — Skip the per-service HTTP probe after each restart.
 
-   On Linux the strict probe hits the unit's podman container directly on port 3000. On Windows it hits `http://127.0.0.1:<PORT>/` where `<PORT>` is the pm2 process's resolved `PORT` env var (workers without a PORT are skipped). With strict off, readiness only checks that the process manager reports the service running.
+   On Linux the probe hits the unit's podman container directly on port 3000. On Windows it hits `http://127.0.0.1:<PORT>/` where `<PORT>` is the pm2 process's resolved `PORT` env var (workers without a PORT are skipped). When set, readiness only checks that the process manager reports the service running.
 * `--timeout <TIMEOUT>` — Per-step timeout in seconds (readiness polling and HTTP probe)
 
   Default value: `30`

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1456,7 +1456,7 @@ On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus shared ones
 
 Then caddy is reloaded and systemd-resolved flushed (so caddy picks up the new container IP), a configurable cooldown is awaited, and optionally an external HTTP URL is probed.
 
-On Windows, restarts every `online` pm2 process.
+On Windows, restarts every `online` pm2 process one pm_id at a time (so scaled apps like `tamanu-api` roll instance-by-instance, not all at once). Strict readiness is `pm2` reporting `online` plus an HTTP probe of `http://127.0.0.1:<PORT>/` where `<PORT>` is the process's resolved `PORT` env var. Processes without a `PORT` (workers like `tamanu-tasks`, `tamanu-sync`, `tamanu-fhir-*`) skip the HTTP probe.
 
 Examples: bestool tamanu reload bestool tamanu reload --filter '^tamanu-frontend@' bestool tamanu reload --check-url https://central.example.org --wait 15
 
@@ -1478,9 +1478,9 @@ Examples: bestool tamanu reload bestool tamanu reload --filter '^tamanu-frontend
 * `--check-url <CHECK_URL>` — External HTTP URL to probe after each restart.
 
    If set, after each service is restarted and reported ready, this URL is requested. A connection failure or 5xx response aborts the rollout. This is independent of the strict per-container probe (see --no-strict).
-* `--no-strict` — Skip the strict per-container HTTP probe (Linux/podman only).
+* `--no-strict` — Skip the strict HTTP probe after each restart.
 
-   With strict off, readiness only checks `systemctl is-active`, which only proves the container started, not that the app inside is serving.
+   On Linux the strict probe hits the unit's podman container directly on port 3000. On Windows it hits `http://127.0.0.1:<PORT>/` where `<PORT>` is the pm2 process's resolved `PORT` env var (workers without a PORT are skipped). With strict off, readiness only checks that the process manager reports the service running.
 * `--timeout <TIMEOUT>` — Per-step timeout in seconds (readiness polling and HTTP probe)
 
   Default value: `30`

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1,4 +1,3 @@
-2026-05-17T23:32:01.016425Z  INFO bestool::download: A new version of bestool is available. Run 'bestool self-update' to update. current="1.7.1" latest="1.8.0"
 # Command-Line Help for `bestool`
 
 This document contains the help content for the `bestool` command-line program.
@@ -124,7 +123,7 @@ Export audit database entries as JSON
 
 ###### **Options:**
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
 * `-n`, `--limit <LIMIT>` — Number of entries to return (0 = unlimited)
 
   Default value: `100`
@@ -1440,7 +1439,7 @@ Aliases: p, pg, sql
   - `auto`:
     Auto-detect terminal theme
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
 * `--no-redact` — Don't redact data
 
    This will also skip loading redactions.

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -123,7 +123,7 @@ Export audit database entries as JSON
 
 ###### **Options:**
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
 * `-n`, `--limit <LIMIT>` — Number of entries to return (0 = unlimited)
 
   Default value: `100`
@@ -1439,7 +1439,7 @@ Aliases: p, pg, sql
   - `auto`:
     Auto-detect terminal theme
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
 * `--no-redact` — Don't redact data
 
    This will also skip loading redactions.

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -50,6 +50,7 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool tamanu greenmask-config`↴](#bestool-tamanu-greenmask-config)
 * [`bestool tamanu meta-ticket`↴](#bestool-tamanu-meta-ticket)
 * [`bestool tamanu psql`↴](#bestool-tamanu-psql)
+* [`bestool tamanu reload`↴](#bestool-tamanu-reload)
 
 ## `bestool`
 
@@ -122,7 +123,7 @@ Export audit database entries as JSON
 
 ###### **Options:**
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
 * `-n`, `--limit <LIMIT>` — Number of entries to return (0 = unlimited)
 
   Default value: `100`
@@ -804,6 +805,7 @@ Alias: t
 * `greenmask-config` — Generate a Greenmask config file
 * `meta-ticket` — Generate a meta-ticket for this Tamanu server
 * `psql` — Connect to Tamanu's database
+* `reload` — Restart Tamanu services one at a time
 
 ###### **Options:**
 
@@ -1437,10 +1439,54 @@ Aliases: p, pg, sql
   - `auto`:
     Auto-detect terminal theme
 
-* `--audit-path <PATH>` — Path to audit database directory (default: ~/.local/state/bestool-psql)
+* `--audit-path <PATH>` — Path to audit database directory (default: ~/Library/Application Support/bestool-psql)
 * `--no-redact` — Don't redact data
 
    This will also skip loading redactions.
+
+
+
+## `bestool tamanu reload`
+
+Restart Tamanu services one at a time.
+
+On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). After each restart, the strict readiness signal is:
+
+1. systemd reports the unit `active` 2. the unit's podman container responds on port 3000 (HTTP services only; workers like `*-tasks` and `*-fhir-*` skip this step)
+
+Then caddy is reloaded and systemd-resolved flushed (so caddy picks up the new container IP), a configurable cooldown is awaited, and optionally an external HTTP URL is probed.
+
+On Windows, restarts every `online` pm2 process.
+
+Examples: bestool tamanu reload bestool tamanu reload --filter '^tamanu-frontend@' bestool tamanu reload --check-url https://central.example.org --wait 15
+
+**Usage:** `bestool tamanu reload [OPTIONS]`
+
+###### **Options:**
+
+* `--kind <KIND>` — Override the detected server kind
+
+  Possible values:
+  - `central`:
+    Central server
+  - `facility`:
+    Facility server
+
+* `--wait <WAIT>` — Seconds to wait between restarts
+
+  Default value: `10`
+* `--check-url <CHECK_URL>` — External HTTP URL to probe after each restart.
+
+   If set, after each service is restarted and reported ready, this URL is requested. A connection failure or 5xx response aborts the rollout. This is independent of the strict per-container probe (see --no-strict).
+* `--no-strict` — Skip the strict per-container HTTP probe (Linux/podman only).
+
+   With strict off, readiness only checks `systemctl is-active`, which only proves the container started, not that the app inside is serving.
+* `--timeout <TIMEOUT>` — Per-step timeout in seconds (readiness polling and HTTP probe)
+
+  Default value: `30`
+* `--filter <FILTER>` — Only restart services whose name matches this regex
+* `--no-caddy-reload` — Don't reload caddy / flush resolved between restarts
+* `--dry-run` — Print the plan and exit without restarting anything
 
 
 

--- a/crates/bestool/src/actions/tamanu.rs
+++ b/crates/bestool/src/actions/tamanu.rs
@@ -71,7 +71,9 @@ super::subcommands! {
 	meta_ticket => MetaTicket(MetaTicketArgs),
 	#[cfg(feature = "tamanu-psql")]
 	#[clap(aliases = ["p", "pg", "sql"])]
-	psql => Psql(PsqlArgs)
+	psql => Psql(PsqlArgs),
+	#[cfg(feature = "tamanu-reload")]
+	reload => Reload(ReloadArgs)
 }
 
 /// What kind of server to interact with.

--- a/crates/bestool/src/actions/tamanu/reload.rs
+++ b/crates/bestool/src/actions/tamanu/reload.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use miette::{IntoDiagnostic, Result, bail};
 use regex::Regex;
 use reqwest::{Client, Url};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use tracing::{debug, info, warn};
 
 use crate::actions::Context;
@@ -19,7 +19,7 @@ use super::{ApiServerKind, TamanuArgs, find_package, find_tamanu};
 ///
 /// On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus
 /// shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). After each
-/// restart, the strict readiness signal is:
+/// restart, the readiness signal is:
 ///
 ///   1. systemd reports the unit `active`
 ///   2. the unit's podman container responds on port 3000 (HTTP services only;
@@ -31,7 +31,7 @@ use super::{ApiServerKind, TamanuArgs, find_package, find_tamanu};
 ///
 /// On Windows, restarts every `online` pm2 process one pm_id at a time (so
 /// scaled apps like `tamanu-api` roll instance-by-instance, not all at once).
-/// Strict readiness is `pm2` reporting `online` plus an HTTP probe of
+/// Readiness is `pm2` reporting `online` plus an HTTP probe of
 /// `http://127.0.0.1:<PORT>/` where `<PORT>` is the process's resolved `PORT`
 /// env var. Processes without a `PORT` (workers like `tamanu-tasks`,
 /// `tamanu-sync`, `tamanu-fhir-*`) skip the HTTP probe.
@@ -54,19 +54,19 @@ pub struct ReloadArgs {
 	///
 	/// If set, after each service is restarted and reported ready, this URL is
 	/// requested. A connection failure or 5xx response aborts the rollout.
-	/// This is independent of the strict per-container probe (see --no-strict).
+	/// This is independent of the per-container probe (see --no-probe-http).
 	#[arg(long)]
 	pub check_url: Option<Url>,
 
-	/// Skip the strict HTTP probe after each restart.
+	/// Skip the per-service HTTP probe after each restart.
 	///
-	/// On Linux the strict probe hits the unit's podman container directly on
+	/// On Linux the probe hits the unit's podman container directly on
 	/// port 3000. On Windows it hits `http://127.0.0.1:<PORT>/` where `<PORT>`
 	/// is the pm2 process's resolved `PORT` env var (workers without a PORT
-	/// are skipped). With strict off, readiness only checks that the process
+	/// are skipped). When set, readiness only checks that the process
 	/// manager reports the service running.
 	#[arg(long)]
-	pub no_strict: bool,
+	pub no_probe_http: bool,
 
 	/// Per-step timeout in seconds (readiness polling and HTTP probe).
 	#[arg(long, default_value = "30")]
@@ -149,7 +149,7 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 		None
 	};
 
-	let strict_client = if !ctx.args_sub.no_strict {
+	let probe_client = if !ctx.args_sub.no_probe_http {
 		Some(
 			Client::builder()
 				.timeout(Duration::from_secs(2))
@@ -169,7 +169,7 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 			Service::Systemd(name) => {
 				restart_systemd(name)?;
 				wait_active_systemd(name, timeout).await?;
-				if let Some(client) = &strict_client {
+				if let Some(client) = &probe_client {
 					wait_container_ready(name, client, timeout).await?;
 				}
 				if !ctx.args_sub.no_caddy_reload {
@@ -179,7 +179,7 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 			Service::Pm2(proc) => {
 				restart_pm2(proc.pm_id)?;
 				wait_online_pm2(proc.pm_id, timeout).await?;
-				if let Some(client) = &strict_client {
+				if let Some(client) = &probe_client {
 					wait_pm2_port_ready(proc, client, timeout).await?;
 				}
 			}
@@ -220,10 +220,10 @@ fn detect_kind_systemd() -> Result<Option<ApiServerKind>> {
 	let units = list_systemd_units()?;
 	let has_central = units
 		.iter()
-		.any(|u| u.unit.starts_with("tamanu-central-") && u.active == "active");
+		.any(|u| u.unit.starts_with("tamanu-central-") && u.active);
 	let has_facility = units
 		.iter()
-		.any(|u| u.unit.starts_with("tamanu-facility-") && u.active == "active");
+		.any(|u| u.unit.starts_with("tamanu-facility-") && u.active);
 	match (has_central, has_facility) {
 		(true, false) => Ok(Some(ApiServerKind::Central)),
 		(false, true) => Ok(Some(ApiServerKind::Facility)),
@@ -248,9 +248,8 @@ fn detect_kind_pm2() -> Result<Option<ApiServerKind>> {
 
 fn detect_backend() -> Result<Backend> {
 	if cfg!(windows) {
-		return Ok(Backend::Pm2);
-	}
-	if cmd_available("systemctl", "--version") {
+		Ok(Backend::Pm2)
+	} else if cmd_available("systemctl", "--version") {
 		Ok(Backend::Systemd)
 	} else if cmd_available(pm2_cmd(), "--version") {
 		Ok(Backend::Pm2)
@@ -274,7 +273,13 @@ fn pm2_cmd() -> &'static str {
 #[derive(Debug, Deserialize)]
 struct SystemdUnit {
 	unit: String,
-	active: String,
+	#[serde(deserialize_with = "deserialize_is_active")]
+	active: bool,
+}
+
+fn deserialize_is_active<'de, D: Deserializer<'de>>(d: D) -> Result<bool, D::Error> {
+	let s = String::deserialize(d)?;
+	Ok(s == "active")
 }
 
 fn list_systemd_units() -> Result<Vec<SystemdUnit>> {
@@ -309,7 +314,7 @@ fn list_services_systemd(kind: ApiServerKind, filter: Option<&Regex>) -> Result<
 
 	let mut services: Vec<String> = units
 		.into_iter()
-		.filter(|u| u.active == "active")
+		.filter(|u| u.active)
 		.filter(|u| {
 			let name = u.unit.trim_end_matches(".service");
 			(name.starts_with(kind_prefix)

--- a/crates/bestool/src/actions/tamanu/reload.rs
+++ b/crates/bestool/src/actions/tamanu/reload.rs
@@ -1,4 +1,5 @@
 use std::{
+	net::IpAddr,
 	process::Command,
 	time::{Duration, Instant},
 };
@@ -17,11 +18,18 @@ use super::{ApiServerKind, TamanuArgs, find_package, find_tamanu};
 /// Restart Tamanu services one at a time.
 ///
 /// On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus
-/// shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). Between each
-/// restart, waits for the unit to become active, reloads caddy and flushes
-/// systemd-resolved (so caddy picks up the new container IP), waits a
-/// configurable cooldown, and optionally probes an HTTP URL. On Windows,
-/// restarts every `online` pm2 process.
+/// shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). After each
+/// restart, the strict readiness signal is:
+///
+///   1. systemd reports the unit `active`
+///   2. the unit's podman container responds on port 3000 (HTTP services only;
+///      workers like `*-tasks` and `*-fhir-*` skip this step)
+///
+/// Then caddy is reloaded and systemd-resolved flushed (so caddy picks up the
+/// new container IP), a configurable cooldown is awaited, and optionally an
+/// external HTTP URL is probed.
+///
+/// On Windows, restarts every `online` pm2 process.
 ///
 /// Examples:
 ///   bestool tamanu reload
@@ -37,12 +45,20 @@ pub struct ReloadArgs {
 	#[arg(long, default_value = "10")]
 	pub wait: u64,
 
-	/// HTTP URL to probe after each restart.
+	/// External HTTP URL to probe after each restart.
 	///
 	/// If set, after each service is restarted and reported ready, this URL is
 	/// requested. A connection failure or 5xx response aborts the rollout.
+	/// This is independent of the strict per-container probe (see --no-strict).
 	#[arg(long)]
 	pub check_url: Option<Url>,
+
+	/// Skip the strict per-container HTTP probe (Linux/podman only).
+	///
+	/// With strict off, readiness only checks `systemctl is-active`, which only
+	/// proves the container started, not that the app inside is serving.
+	#[arg(long)]
+	pub no_strict: bool,
 
 	/// Per-step timeout in seconds (readiness polling and HTTP probe).
 	#[arg(long, default_value = "30")]
@@ -104,6 +120,17 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 		None
 	};
 
+	let strict_client = if matches!(backend, Backend::Systemd) && !ctx.args_sub.no_strict {
+		Some(
+			Client::builder()
+				.timeout(Duration::from_secs(2))
+				.build()
+				.into_diagnostic()?,
+		)
+	} else {
+		None
+	};
+
 	let total = services.len();
 	for (idx, service) in services.iter().enumerate() {
 		let n = idx + 1;
@@ -112,6 +139,9 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 			Backend::Systemd => {
 				restart_systemd(service)?;
 				wait_active_systemd(service, timeout).await?;
+				if let Some(client) = &strict_client {
+					wait_container_ready(service, client, timeout).await?;
+				}
 				if !ctx.args_sub.no_caddy_reload {
 					reload_caddy();
 				}
@@ -369,6 +399,95 @@ async fn wait_online_pm2(name: &str, timeout: Duration) -> Result<()> {
 		}
 		tokio::time::sleep(Duration::from_millis(500)).await;
 	}
+}
+
+/// Skip the per-container HTTP probe for known workers — they don't listen on
+/// a port. Matches the quadlets in ops repo (no NetworkAlias on these).
+fn is_worker_unit(unit: &str) -> bool {
+	let name = unit.trim_end_matches(".service");
+	name.ends_with("-tasks") || name.contains("-fhir-")
+}
+
+async fn wait_container_ready(unit: &str, client: &Client, timeout: Duration) -> Result<()> {
+	if is_worker_unit(unit) {
+		debug!(service = %unit, "worker service; skipping HTTP probe");
+		return Ok(());
+	}
+	let Some(ip) = container_ip_for_unit(unit)? else {
+		warn!(service = %unit, "container IP not found, falling back to is-active only");
+		return Ok(());
+	};
+	let url = format!("http://{ip}:3000/");
+	let deadline = Instant::now() + timeout;
+	loop {
+		let last_err = match client.get(&url).send().await {
+			Ok(resp) => {
+				debug!(service = %unit, status = %resp.status(), %url, "container responded");
+				return Ok(());
+			}
+			Err(e) => e.to_string(),
+		};
+		if Instant::now() >= deadline {
+			bail!(
+				"{unit} did not start responding on {url} within {}s: {last_err}",
+				timeout.as_secs()
+			);
+		}
+		tokio::time::sleep(Duration::from_millis(500)).await;
+	}
+}
+
+fn container_ip_for_unit(unit: &str) -> Result<Option<IpAddr>> {
+	let ps = Command::new("podman")
+		.args([
+			"ps",
+			"--filter",
+			&format!("label=PODMAN_SYSTEMD_UNIT={unit}"),
+			"--format",
+			"json",
+		])
+		.output();
+	let ps = match ps {
+		Ok(o) if o.status.success() => o,
+		Ok(o) => {
+			warn!(
+				"podman ps failed: {}",
+				String::from_utf8_lossy(&o.stderr).trim()
+			);
+			return Ok(None);
+		}
+		Err(e) => {
+			debug!("podman not available: {e}");
+			return Ok(None);
+		}
+	};
+
+	let entries: Vec<serde_json::Value> = serde_json::from_slice(&ps.stdout).into_diagnostic()?;
+	let Some(id) = entries.first().and_then(|c| c["Id"].as_str()) else {
+		return Ok(None);
+	};
+
+	let inspect = Command::new("podman")
+		.args(["inspect", id])
+		.output()
+		.into_diagnostic()?;
+	if !inspect.status.success() {
+		bail!(
+			"podman inspect failed: {}",
+			String::from_utf8_lossy(&inspect.stderr).trim()
+		);
+	}
+	let inspects: Vec<serde_json::Value> =
+		serde_json::from_slice(&inspect.stdout).into_diagnostic()?;
+	let ip = inspects
+		.first()
+		.and_then(|c| c["NetworkSettings"]["Networks"].as_object())
+		.and_then(|nets| nets.values().find_map(|n| n["IPAddress"].as_str()))
+		.filter(|s| !s.is_empty())
+		.map(|s| s.parse::<IpAddr>())
+		.transpose()
+		.into_diagnostic()?;
+	Ok(ip)
 }
 
 async fn probe_http(client: &Client, url: &Url, timeout: Duration) -> Result<()> {

--- a/crates/bestool/src/actions/tamanu/reload.rs
+++ b/crates/bestool/src/actions/tamanu/reload.rs
@@ -1,0 +1,391 @@
+use std::{
+	process::Command,
+	time::{Duration, Instant},
+};
+
+use clap::Parser;
+use miette::{IntoDiagnostic, Result, bail};
+use regex::Regex;
+use reqwest::{Client, Url};
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use crate::actions::Context;
+
+use super::{ApiServerKind, TamanuArgs, find_package, find_tamanu};
+
+/// Restart Tamanu services one at a time.
+///
+/// On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus
+/// shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). Between each
+/// restart, waits for the unit to become active, reloads caddy and flushes
+/// systemd-resolved (so caddy picks up the new container IP), waits a
+/// configurable cooldown, and optionally probes an HTTP URL. On Windows,
+/// restarts every `online` pm2 process.
+///
+/// Examples:
+///   bestool tamanu reload
+///   bestool tamanu reload --filter '^tamanu-frontend@'
+///   bestool tamanu reload --check-url https://central.example.org --wait 15
+#[derive(Debug, Clone, Parser)]
+pub struct ReloadArgs {
+	/// Override the detected server kind.
+	#[arg(long, value_enum)]
+	pub kind: Option<ApiServerKind>,
+
+	/// Seconds to wait between restarts.
+	#[arg(long, default_value = "10")]
+	pub wait: u64,
+
+	/// HTTP URL to probe after each restart.
+	///
+	/// If set, after each service is restarted and reported ready, this URL is
+	/// requested. A connection failure or 5xx response aborts the rollout.
+	#[arg(long)]
+	pub check_url: Option<Url>,
+
+	/// Per-step timeout in seconds (readiness polling and HTTP probe).
+	#[arg(long, default_value = "30")]
+	pub timeout: u64,
+
+	/// Only restart services whose name matches this regex.
+	#[arg(long)]
+	pub filter: Option<Regex>,
+
+	/// Don't reload caddy / flush resolved between restarts.
+	#[arg(long)]
+	pub no_caddy_reload: bool,
+
+	/// Print the plan and exit without restarting anything.
+	#[arg(long)]
+	pub dry_run: bool,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Backend {
+	Systemd,
+	Pm2,
+}
+
+pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
+	let backend = detect_backend()?;
+	let kind = resolve_kind(&ctx, backend)?;
+	info!(?backend, ?kind, "rolling tamanu services");
+
+	let services = match backend {
+		Backend::Systemd => list_services_systemd(kind, ctx.args_sub.filter.as_ref())?,
+		Backend::Pm2 => list_services_pm2(ctx.args_sub.filter.as_ref())?,
+	};
+
+	if services.is_empty() {
+		bail!("no running tamanu services match the selection");
+	}
+
+	info!("will restart {} service(s):", services.len());
+	for s in &services {
+		info!("  - {s}");
+	}
+
+	if ctx.args_sub.dry_run {
+		return Ok(());
+	}
+
+	let timeout = Duration::from_secs(ctx.args_sub.timeout);
+	let wait = Duration::from_secs(ctx.args_sub.wait);
+
+	let http = if ctx.args_sub.check_url.is_some() {
+		Some(
+			Client::builder()
+				.timeout(timeout)
+				.build()
+				.into_diagnostic()?,
+		)
+	} else {
+		None
+	};
+
+	let total = services.len();
+	for (idx, service) in services.iter().enumerate() {
+		let n = idx + 1;
+		info!("[{n}/{total}] restarting {service}");
+		match backend {
+			Backend::Systemd => {
+				restart_systemd(service)?;
+				wait_active_systemd(service, timeout).await?;
+				if !ctx.args_sub.no_caddy_reload {
+					reload_caddy();
+				}
+			}
+			Backend::Pm2 => {
+				restart_pm2(service)?;
+				wait_online_pm2(service, timeout).await?;
+			}
+		}
+
+		if let (Some(http), Some(url)) = (&http, &ctx.args_sub.check_url) {
+			probe_http(http, url, timeout).await?;
+		}
+
+		if n < total && !wait.is_zero() {
+			info!("waiting {}s before next restart", wait.as_secs());
+			tokio::time::sleep(wait).await;
+		}
+	}
+
+	info!("rolled {total} service(s)");
+	Ok(())
+}
+
+fn resolve_kind(ctx: &Context<TamanuArgs, ReloadArgs>, backend: Backend) -> Result<ApiServerKind> {
+	if let Some(kind) = ctx.args_sub.kind {
+		return Ok(kind);
+	}
+	if let Ok((_, root)) = find_tamanu(&ctx.args_top) {
+		return Ok(find_package(root));
+	}
+	if let Backend::Systemd = backend
+		&& let Some(kind) = detect_kind_systemd()?
+	{
+		return Ok(kind);
+	}
+	bail!("could not detect server kind: pass --kind central|facility")
+}
+
+fn detect_kind_systemd() -> Result<Option<ApiServerKind>> {
+	let units = list_systemd_units()?;
+	let has_central = units
+		.iter()
+		.any(|u| u.unit.starts_with("tamanu-central-") && u.active == "active");
+	let has_facility = units
+		.iter()
+		.any(|u| u.unit.starts_with("tamanu-facility-") && u.active == "active");
+	match (has_central, has_facility) {
+		(true, false) => Ok(Some(ApiServerKind::Central)),
+		(false, true) => Ok(Some(ApiServerKind::Facility)),
+		(true, true) => bail!("both central and facility services are running; pass --kind"),
+		(false, false) => Ok(None),
+	}
+}
+
+fn detect_backend() -> Result<Backend> {
+	if cfg!(windows) {
+		return Ok(Backend::Pm2);
+	}
+	if cmd_available("systemctl", "--version") {
+		Ok(Backend::Systemd)
+	} else if cmd_available(pm2_cmd(), "--version") {
+		Ok(Backend::Pm2)
+	} else {
+		bail!("neither systemctl nor pm2 is available on this host");
+	}
+}
+
+fn cmd_available(cmd: &str, arg: &str) -> bool {
+	Command::new(cmd)
+		.arg(arg)
+		.output()
+		.map(|o| o.status.success())
+		.unwrap_or(false)
+}
+
+fn pm2_cmd() -> &'static str {
+	if cfg!(windows) { "pm2.cmd" } else { "pm2" }
+}
+
+#[derive(Debug, Deserialize)]
+struct SystemdUnit {
+	unit: String,
+	active: String,
+}
+
+fn list_systemd_units() -> Result<Vec<SystemdUnit>> {
+	let output = Command::new("systemctl")
+		.args([
+			"list-units",
+			"--type=service",
+			"--all",
+			"--no-legend",
+			"--plain",
+			"--no-pager",
+			"-o",
+			"json",
+		])
+		.output()
+		.into_diagnostic()?;
+	if !output.status.success() {
+		bail!(
+			"systemctl list-units failed: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+	serde_json::from_slice(&output.stdout).into_diagnostic()
+}
+
+fn list_services_systemd(kind: ApiServerKind, filter: Option<&Regex>) -> Result<Vec<String>> {
+	let units = list_systemd_units()?;
+	let kind_prefix = match kind {
+		ApiServerKind::Central => "tamanu-central-",
+		ApiServerKind::Facility => "tamanu-facility-",
+	};
+
+	let mut services: Vec<String> = units
+		.into_iter()
+		.filter(|u| u.active == "active")
+		.filter(|u| {
+			let name = u.unit.trim_end_matches(".service");
+			(name.starts_with(kind_prefix)
+				|| name.starts_with("tamanu-frontend@")
+				|| name == "tamanu-patientportal")
+				&& !u.unit.ends_with("@.service")
+		})
+		.map(|u| u.unit)
+		.filter(|n| filter.is_none_or(|r| r.is_match(n)))
+		.collect();
+
+	services.sort();
+	Ok(services)
+}
+
+fn restart_systemd(name: &str) -> Result<()> {
+	let status = Command::new("systemctl")
+		.args(["restart", name])
+		.status()
+		.into_diagnostic()?;
+	if !status.success() {
+		bail!("systemctl restart {name} exited with {status}");
+	}
+	Ok(())
+}
+
+async fn wait_active_systemd(name: &str, timeout: Duration) -> Result<()> {
+	let deadline = Instant::now() + timeout;
+	loop {
+		let output = Command::new("systemctl")
+			.args(["is-active", name])
+			.output()
+			.into_diagnostic()?;
+		let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+		debug!(service = %name, state = %state, "systemctl is-active");
+		if state == "active" {
+			return Ok(());
+		}
+		if Instant::now() >= deadline {
+			bail!(
+				"{name} did not become active within {}s (current state: {state})",
+				timeout.as_secs()
+			);
+		}
+		tokio::time::sleep(Duration::from_millis(500)).await;
+	}
+}
+
+/// Mirror the ansible "Reload caddy" handler: `systemctl reload caddy` plus
+/// `resolvectl flush-caches`. Without this, caddy keeps routing to the
+/// container IP of the process we just restarted. Best-effort: warn and
+/// continue on failure.
+fn reload_caddy() {
+	let status = Command::new("systemctl")
+		.args(["reload", "caddy"])
+		.status();
+	match status {
+		Ok(s) if s.success() => debug!("caddy reloaded"),
+		Ok(s) => warn!("systemctl reload caddy exited with {s}"),
+		Err(e) => warn!("could not reload caddy: {e}"),
+	}
+	let status = Command::new("resolvectl").arg("flush-caches").status();
+	match status {
+		Ok(s) if s.success() => debug!("resolvectl flush-caches OK"),
+		Ok(s) => warn!("resolvectl flush-caches exited with {s}"),
+		Err(e) => debug!("resolvectl not available: {e}"),
+	}
+}
+
+#[derive(Debug, Deserialize)]
+struct Pm2Proc {
+	name: String,
+	pm2_env: Pm2Env,
+}
+
+#[derive(Debug, Deserialize)]
+struct Pm2Env {
+	status: String,
+}
+
+fn pm2_jlist() -> Result<Vec<Pm2Proc>> {
+	let output = Command::new(pm2_cmd())
+		.arg("jlist")
+		.output()
+		.into_diagnostic()?;
+	if !output.status.success() {
+		bail!(
+			"pm2 jlist failed: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+	serde_json::from_slice(&output.stdout).into_diagnostic()
+}
+
+fn list_services_pm2(filter: Option<&Regex>) -> Result<Vec<String>> {
+	let procs = pm2_jlist()?;
+	let mut names: Vec<String> = procs
+		.into_iter()
+		.filter(|p| p.pm2_env.status == "online")
+		.map(|p| p.name)
+		.filter(|n| filter.is_none_or(|r| r.is_match(n)))
+		.collect();
+	names.sort();
+	Ok(names)
+}
+
+fn restart_pm2(name: &str) -> Result<()> {
+	let status = Command::new(pm2_cmd())
+		.args(["restart", name])
+		.status()
+		.into_diagnostic()?;
+	if !status.success() {
+		bail!("pm2 restart {name} exited with {status}");
+	}
+	Ok(())
+}
+
+async fn wait_online_pm2(name: &str, timeout: Duration) -> Result<()> {
+	let deadline = Instant::now() + timeout;
+	loop {
+		let procs = pm2_jlist()?;
+		let status = procs
+			.iter()
+			.find(|p| p.name == name)
+			.map(|p| p.pm2_env.status.as_str())
+			.unwrap_or("missing");
+		debug!(service = %name, status, "pm2 status");
+		if status == "online" {
+			return Ok(());
+		}
+		if Instant::now() >= deadline {
+			bail!(
+				"{name} did not become online within {}s (current status: {status})",
+				timeout.as_secs()
+			);
+		}
+		tokio::time::sleep(Duration::from_millis(500)).await;
+	}
+}
+
+async fn probe_http(client: &Client, url: &Url, timeout: Duration) -> Result<()> {
+	let deadline = Instant::now() + timeout;
+	loop {
+		let last_err = match client.get(url.clone()).send().await {
+			Ok(resp) if !resp.status().is_server_error() => {
+				debug!(status = %resp.status(), url = %url, "probe OK");
+				return Ok(());
+			}
+			Ok(resp) => format!("HTTP {}", resp.status()),
+			Err(e) => e.to_string(),
+		};
+		if Instant::now() >= deadline {
+			bail!("HTTP probe of {url} failed: {last_err}");
+		}
+		warn!(url = %url, err = %last_err, "HTTP probe not ready, retrying");
+		tokio::time::sleep(Duration::from_millis(500)).await;
+	}
+}

--- a/crates/bestool/src/actions/tamanu/reload.rs
+++ b/crates/bestool/src/actions/tamanu/reload.rs
@@ -29,7 +29,12 @@ use super::{ApiServerKind, TamanuArgs, find_package, find_tamanu};
 /// new container IP), a configurable cooldown is awaited, and optionally an
 /// external HTTP URL is probed.
 ///
-/// On Windows, restarts every `online` pm2 process.
+/// On Windows, restarts every `online` pm2 process one pm_id at a time (so
+/// scaled apps like `tamanu-api` roll instance-by-instance, not all at once).
+/// Strict readiness is `pm2` reporting `online` plus an HTTP probe of
+/// `http://127.0.0.1:<PORT>/` where `<PORT>` is the process's resolved `PORT`
+/// env var. Processes without a `PORT` (workers like `tamanu-tasks`,
+/// `tamanu-sync`, `tamanu-fhir-*`) skip the HTTP probe.
 ///
 /// Examples:
 ///   bestool tamanu reload
@@ -53,10 +58,13 @@ pub struct ReloadArgs {
 	#[arg(long)]
 	pub check_url: Option<Url>,
 
-	/// Skip the strict per-container HTTP probe (Linux/podman only).
+	/// Skip the strict HTTP probe after each restart.
 	///
-	/// With strict off, readiness only checks `systemctl is-active`, which only
-	/// proves the container started, not that the app inside is serving.
+	/// On Linux the strict probe hits the unit's podman container directly on
+	/// port 3000. On Windows it hits `http://127.0.0.1:<PORT>/` where `<PORT>`
+	/// is the pm2 process's resolved `PORT` env var (workers without a PORT
+	/// are skipped). With strict off, readiness only checks that the process
+	/// manager reports the service running.
 	#[arg(long)]
 	pub no_strict: bool,
 
@@ -83,14 +91,35 @@ enum Backend {
 	Pm2,
 }
 
+#[derive(Debug, Clone)]
+enum Service {
+	Systemd(String),
+	Pm2(Pm2Proc),
+}
+
+impl Service {
+	fn label(&self) -> String {
+		match self {
+			Self::Systemd(name) => name.clone(),
+			Self::Pm2(p) => format!("{} #{}", p.name, p.pm_id),
+		}
+	}
+}
+
 pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 	let backend = detect_backend()?;
 	let kind = resolve_kind(&ctx, backend)?;
 	info!(?backend, ?kind, "rolling tamanu services");
 
-	let services = match backend {
-		Backend::Systemd => list_services_systemd(kind, ctx.args_sub.filter.as_ref())?,
-		Backend::Pm2 => list_services_pm2(ctx.args_sub.filter.as_ref())?,
+	let services: Vec<Service> = match backend {
+		Backend::Systemd => list_services_systemd(kind, ctx.args_sub.filter.as_ref())?
+			.into_iter()
+			.map(Service::Systemd)
+			.collect(),
+		Backend::Pm2 => list_services_pm2(ctx.args_sub.filter.as_ref())?
+			.into_iter()
+			.map(Service::Pm2)
+			.collect(),
 	};
 
 	if services.is_empty() {
@@ -99,7 +128,7 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 
 	info!("will restart {} service(s):", services.len());
 	for s in &services {
-		info!("  - {s}");
+		info!("  - {}", s.label());
 	}
 
 	if ctx.args_sub.dry_run {
@@ -120,7 +149,7 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 		None
 	};
 
-	let strict_client = if matches!(backend, Backend::Systemd) && !ctx.args_sub.no_strict {
+	let strict_client = if !ctx.args_sub.no_strict {
 		Some(
 			Client::builder()
 				.timeout(Duration::from_secs(2))
@@ -134,21 +163,25 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 	let total = services.len();
 	for (idx, service) in services.iter().enumerate() {
 		let n = idx + 1;
-		info!("[{n}/{total}] restarting {service}");
-		match backend {
-			Backend::Systemd => {
-				restart_systemd(service)?;
-				wait_active_systemd(service, timeout).await?;
+		let label = service.label();
+		info!("[{n}/{total}] restarting {label}");
+		match service {
+			Service::Systemd(name) => {
+				restart_systemd(name)?;
+				wait_active_systemd(name, timeout).await?;
 				if let Some(client) = &strict_client {
-					wait_container_ready(service, client, timeout).await?;
+					wait_container_ready(name, client, timeout).await?;
 				}
 				if !ctx.args_sub.no_caddy_reload {
 					reload_caddy();
 				}
 			}
-			Backend::Pm2 => {
-				restart_pm2(service)?;
-				wait_online_pm2(service, timeout).await?;
+			Service::Pm2(proc) => {
+				restart_pm2(proc.pm_id)?;
+				wait_online_pm2(proc.pm_id, timeout).await?;
+				if let Some(client) = &strict_client {
+					wait_pm2_port_ready(proc, client, timeout).await?;
+				}
 			}
 		}
 
@@ -173,9 +206,11 @@ fn resolve_kind(ctx: &Context<TamanuArgs, ReloadArgs>, backend: Backend) -> Resu
 	if let Ok((_, root)) = find_tamanu(&ctx.args_top) {
 		return Ok(find_package(root));
 	}
-	if let Backend::Systemd = backend
-		&& let Some(kind) = detect_kind_systemd()?
-	{
+	let detected = match backend {
+		Backend::Systemd => detect_kind_systemd()?,
+		Backend::Pm2 => detect_kind_pm2()?,
+	};
+	if let Some(kind) = detected {
 		return Ok(kind);
 	}
 	bail!("could not detect server kind: pass --kind central|facility")
@@ -194,6 +229,20 @@ fn detect_kind_systemd() -> Result<Option<ApiServerKind>> {
 		(false, true) => Ok(Some(ApiServerKind::Facility)),
 		(true, true) => bail!("both central and facility services are running; pass --kind"),
 		(false, false) => Ok(None),
+	}
+}
+
+/// `tamanu-sync` only runs on facilities, so its presence in pm2 implies a
+/// facility install. This is a last-resort fallback after the config-based
+/// detection in [`find_tamanu`].
+fn detect_kind_pm2() -> Result<Option<ApiServerKind>> {
+	let procs = pm2_jlist()?;
+	if procs.iter().any(|p| p.name == "tamanu-sync") {
+		Ok(Some(ApiServerKind::Facility))
+	} else if procs.iter().any(|p| p.name.starts_with("tamanu-")) {
+		Ok(Some(ApiServerKind::Central))
+	} else {
+		Ok(None)
 	}
 }
 
@@ -330,15 +379,27 @@ fn reload_caddy() {
 	}
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct Pm2Proc {
+	pm_id: u32,
 	name: String,
 	pm2_env: Pm2Env,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct Pm2Env {
 	status: String,
+	#[serde(default)]
+	env: serde_json::Map<String, serde_json::Value>,
+}
+
+impl Pm2Proc {
+	fn port(&self) -> Option<u16> {
+		let v = self.pm2_env.env.get("PORT")?;
+		v.as_str()
+			.and_then(|s| s.parse().ok())
+			.or_else(|| v.as_u64().and_then(|n| u16::try_from(n).ok()))
+	}
 }
 
 fn pm2_jlist() -> Result<Vec<Pm2Proc>> {
@@ -355,45 +416,70 @@ fn pm2_jlist() -> Result<Vec<Pm2Proc>> {
 	serde_json::from_slice(&output.stdout).into_diagnostic()
 }
 
-fn list_services_pm2(filter: Option<&Regex>) -> Result<Vec<String>> {
-	let procs = pm2_jlist()?;
-	let mut names: Vec<String> = procs
+fn list_services_pm2(filter: Option<&Regex>) -> Result<Vec<Pm2Proc>> {
+	let mut procs: Vec<Pm2Proc> = pm2_jlist()?
 		.into_iter()
 		.filter(|p| p.pm2_env.status == "online")
-		.map(|p| p.name)
-		.filter(|n| filter.is_none_or(|r| r.is_match(n)))
+		.filter(|p| filter.is_none_or(|r| r.is_match(&p.name)))
 		.collect();
-	names.sort();
-	Ok(names)
+	procs.sort_by(|a, b| a.name.cmp(&b.name).then(a.pm_id.cmp(&b.pm_id)));
+	Ok(procs)
 }
 
-fn restart_pm2(name: &str) -> Result<()> {
+fn restart_pm2(pm_id: u32) -> Result<()> {
 	let status = Command::new(pm2_cmd())
-		.args(["restart", name])
+		.args(["restart", &pm_id.to_string()])
 		.status()
 		.into_diagnostic()?;
 	if !status.success() {
-		bail!("pm2 restart {name} exited with {status}");
+		bail!("pm2 restart {pm_id} exited with {status}");
 	}
 	Ok(())
 }
 
-async fn wait_online_pm2(name: &str, timeout: Duration) -> Result<()> {
+async fn wait_online_pm2(pm_id: u32, timeout: Duration) -> Result<()> {
 	let deadline = Instant::now() + timeout;
 	loop {
 		let procs = pm2_jlist()?;
 		let status = procs
 			.iter()
-			.find(|p| p.name == name)
+			.find(|p| p.pm_id == pm_id)
 			.map(|p| p.pm2_env.status.as_str())
 			.unwrap_or("missing");
-		debug!(service = %name, status, "pm2 status");
+		debug!(pm_id, status, "pm2 status");
 		if status == "online" {
 			return Ok(());
 		}
 		if Instant::now() >= deadline {
 			bail!(
-				"{name} did not become online within {}s (current status: {status})",
+				"pm2 process #{pm_id} did not become online within {}s (current status: {status})",
+				timeout.as_secs()
+			);
+		}
+		tokio::time::sleep(Duration::from_millis(500)).await;
+	}
+}
+
+async fn wait_pm2_port_ready(proc: &Pm2Proc, client: &Client, timeout: Duration) -> Result<()> {
+	let Some(port) = proc.port() else {
+		debug!(name = %proc.name, pm_id = proc.pm_id, "no PORT env; skipping HTTP probe");
+		return Ok(());
+	};
+	let url = format!("http://127.0.0.1:{port}/");
+	let deadline = Instant::now() + timeout;
+	loop {
+		let last_err = match client.get(&url).send().await {
+			Ok(resp) => {
+				debug!(name = %proc.name, pm_id = proc.pm_id, status = %resp.status(), %url, "pm2 process responded");
+				return Ok(());
+			}
+			Err(e) => e.to_string(),
+		};
+		if Instant::now() >= deadline {
+			bail!(
+				"{} #{} did not start responding on {url} within {}s: {last_err}",
+				proc.name,
+				proc.pm_id,
 				timeout.as_secs()
 			);
 		}

--- a/crates/bestool/src/actions/tamanu/reload.rs
+++ b/crates/bestool/src/actions/tamanu/reload.rs
@@ -108,6 +108,9 @@ impl Service {
 
 pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 	let backend = detect_backend()?;
+	if matches!(backend, Backend::Systemd) {
+		ensure_root_or_reexec()?;
+	}
 	let kind = resolve_kind(&ctx, backend)?;
 	info!(?backend, ?kind, "rolling tamanu services");
 
@@ -246,6 +249,27 @@ fn detect_kind_pm2() -> Result<Option<ApiServerKind>> {
 	}
 }
 
+/// Re-exec the current process under `sudo` if we're not root.
+///
+/// `systemctl restart`, `systemctl reload caddy` and `resolvectl flush-caches`
+/// all need root, so we re-launch the same arguments via sudo and exit with
+/// its status. Users who already invoked `sudo bestool tamanu reload` hit the
+/// fast-path and keep running.
+fn ensure_root_or_reexec() -> Result<()> {
+	if privilege::user::privileged() {
+		return Ok(());
+	}
+	info!("not running as root, re-executing under sudo");
+	let exe = std::env::current_exe().into_diagnostic()?;
+	let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+	let status = privilege::runas::Command::new(exe)
+		.args(&args)
+		.force_prompt(false)
+		.run()
+		.into_diagnostic()?;
+	std::process::exit(status.code().unwrap_or(1));
+}
+
 fn detect_backend() -> Result<Backend> {
 	if cfg!(windows) {
 		Ok(Backend::Pm2)
@@ -343,6 +367,7 @@ fn restart_systemd(name: &str) -> Result<()> {
 
 async fn wait_active_systemd(name: &str, timeout: Duration) -> Result<()> {
 	let deadline = Instant::now() + timeout;
+	info!("  waiting for {name} to become active");
 	loop {
 		let output = Command::new("systemctl")
 			.args(["is-active", name])
@@ -351,6 +376,7 @@ async fn wait_active_systemd(name: &str, timeout: Duration) -> Result<()> {
 		let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
 		debug!(service = %name, state = %state, "systemctl is-active");
 		if state == "active" {
+			info!("  {name} is active");
 			return Ok(());
 		}
 		if Instant::now() >= deadline {
@@ -372,13 +398,13 @@ fn reload_caddy() {
 		.args(["reload", "caddy"])
 		.status();
 	match status {
-		Ok(s) if s.success() => debug!("caddy reloaded"),
+		Ok(s) if s.success() => info!("  caddy reloaded"),
 		Ok(s) => warn!("systemctl reload caddy exited with {s}"),
 		Err(e) => warn!("could not reload caddy: {e}"),
 	}
 	let status = Command::new("resolvectl").arg("flush-caches").status();
 	match status {
-		Ok(s) if s.success() => debug!("resolvectl flush-caches OK"),
+		Ok(s) if s.success() => info!("  resolvectl flush-caches OK"),
 		Ok(s) => warn!("resolvectl flush-caches exited with {s}"),
 		Err(e) => debug!("resolvectl not available: {e}"),
 	}
@@ -444,6 +470,7 @@ fn restart_pm2(pm_id: u32) -> Result<()> {
 
 async fn wait_online_pm2(pm_id: u32, timeout: Duration) -> Result<()> {
 	let deadline = Instant::now() + timeout;
+	info!("  waiting for pm2 #{pm_id} to come online");
 	loop {
 		let procs = pm2_jlist()?;
 		let status = procs
@@ -453,6 +480,7 @@ async fn wait_online_pm2(pm_id: u32, timeout: Duration) -> Result<()> {
 			.unwrap_or("missing");
 		debug!(pm_id, status, "pm2 status");
 		if status == "online" {
+			info!("  pm2 #{pm_id} is online");
 			return Ok(());
 		}
 		if Instant::now() >= deadline {
@@ -467,15 +495,24 @@ async fn wait_online_pm2(pm_id: u32, timeout: Duration) -> Result<()> {
 
 async fn wait_pm2_port_ready(proc: &Pm2Proc, client: &Client, timeout: Duration) -> Result<()> {
 	let Some(port) = proc.port() else {
-		debug!(name = %proc.name, pm_id = proc.pm_id, "no PORT env; skipping HTTP probe");
+		info!(
+			"  {} #{} has no PORT env, skipping HTTP probe",
+			proc.name, proc.pm_id
+		);
 		return Ok(());
 	};
 	let url = format!("http://127.0.0.1:{port}/");
+	info!("  waiting for {} #{} on {url}", proc.name, proc.pm_id);
 	let deadline = Instant::now() + timeout;
 	loop {
 		let last_err = match client.get(&url).send().await {
 			Ok(resp) => {
-				debug!(name = %proc.name, pm_id = proc.pm_id, status = %resp.status(), %url, "pm2 process responded");
+				info!(
+					"  {} #{} responded on {url} ({})",
+					proc.name,
+					proc.pm_id,
+					resp.status()
+				);
 				return Ok(());
 			}
 			Err(e) => e.to_string(),
@@ -501,19 +538,20 @@ fn is_worker_unit(unit: &str) -> bool {
 
 async fn wait_container_ready(unit: &str, client: &Client, timeout: Duration) -> Result<()> {
 	if is_worker_unit(unit) {
-		debug!(service = %unit, "worker service; skipping HTTP probe");
+		info!("  {unit} is a worker, skipping HTTP probe");
 		return Ok(());
 	}
 	let Some(ip) = container_ip_for_unit(unit)? else {
-		warn!(service = %unit, "container IP not found, falling back to is-active only");
+		warn!("  container IP for {unit} not found, skipping HTTP probe");
 		return Ok(());
 	};
 	let url = format!("http://{ip}:3000/");
+	info!("  waiting for {unit} to respond on {url}");
 	let deadline = Instant::now() + timeout;
 	loop {
 		let last_err = match client.get(&url).send().await {
 			Ok(resp) => {
-				debug!(service = %unit, status = %resp.status(), %url, "container responded");
+				info!("  {unit} responded on {url} ({})", resp.status());
 				return Ok(());
 			}
 			Err(e) => e.to_string(),

--- a/crates/bestool/src/actions/tamanu/reload.rs
+++ b/crates/bestool/src/actions/tamanu/reload.rs
@@ -17,9 +17,10 @@ use super::{ApiServerKind, TamanuArgs, find_package, find_tamanu};
 
 /// Restart Tamanu services one at a time.
 ///
-/// On Linux, restarts the running `tamanu-{kind}-*` systemd units, plus
-/// shared ones (`tamanu-frontend@*`, `tamanu-patientportal`). After each
-/// restart, the readiness signal is:
+/// On Linux, restarts every active `tamanu-*` systemd unit (apis, workers,
+/// `tamanu-frontend@*`, `tamanu-patientportal`, etc), skipping templates and
+/// non-app units (`tamanu-meta*`, `tamanu-alertd`). After each restart, the
+/// readiness signal is:
 ///
 ///   1. systemd reports the unit `active`
 ///   2. the unit's podman container responds on port 3000 (HTTP services only;
@@ -115,7 +116,7 @@ pub async fn run(ctx: Context<TamanuArgs, ReloadArgs>) -> Result<()> {
 	info!(?backend, ?kind, "rolling tamanu services");
 
 	let services: Vec<Service> = match backend {
-		Backend::Systemd => list_services_systemd(kind, ctx.args_sub.filter.as_ref())?
+		Backend::Systemd => list_services_systemd(ctx.args_sub.filter.as_ref())?
 			.into_iter()
 			.map(Service::Systemd)
 			.collect(),
@@ -219,19 +220,23 @@ fn resolve_kind(ctx: &Context<TamanuArgs, ReloadArgs>, backend: Backend) -> Resu
 	bail!("could not detect server kind: pass --kind central|facility")
 }
 
+/// `tamanu-sync` only runs on facilities, so its presence implies a facility
+/// install. Last-resort fallback after the config-based detection in
+/// [`find_tamanu`].
 fn detect_kind_systemd() -> Result<Option<ApiServerKind>> {
 	let units = list_systemd_units()?;
-	let has_central = units
+	if units
 		.iter()
-		.any(|u| u.unit.starts_with("tamanu-central-") && u.active);
-	let has_facility = units
+		.any(|u| u.unit == "tamanu-sync.service" && u.active)
+	{
+		Ok(Some(ApiServerKind::Facility))
+	} else if units
 		.iter()
-		.any(|u| u.unit.starts_with("tamanu-facility-") && u.active);
-	match (has_central, has_facility) {
-		(true, false) => Ok(Some(ApiServerKind::Central)),
-		(false, true) => Ok(Some(ApiServerKind::Facility)),
-		(true, true) => bail!("both central and facility services are running; pass --kind"),
-		(false, false) => Ok(None),
+		.any(|u| u.unit.starts_with("tamanu-") && u.active)
+	{
+		Ok(Some(ApiServerKind::Central))
+	} else {
+		Ok(None)
 	}
 }
 
@@ -329,22 +334,16 @@ fn list_systemd_units() -> Result<Vec<SystemdUnit>> {
 	serde_json::from_slice(&output.stdout).into_diagnostic()
 }
 
-fn list_services_systemd(kind: ApiServerKind, filter: Option<&Regex>) -> Result<Vec<String>> {
+fn list_services_systemd(filter: Option<&Regex>) -> Result<Vec<String>> {
 	let units = list_systemd_units()?;
-	let kind_prefix = match kind {
-		ApiServerKind::Central => "tamanu-central-",
-		ApiServerKind::Facility => "tamanu-facility-",
-	};
-
 	let mut services: Vec<String> = units
 		.into_iter()
 		.filter(|u| u.active)
 		.filter(|u| {
 			let name = u.unit.trim_end_matches(".service");
-			(name.starts_with(kind_prefix)
-				|| name.starts_with("tamanu-frontend@")
-				|| name == "tamanu-patientportal")
+			name.starts_with("tamanu-")
 				&& !u.unit.ends_with("@.service")
+				&& !is_excluded_unit(name)
 		})
 		.map(|u| u.unit)
 		.filter(|n| filter.is_none_or(|r| r.is_match(n)))
@@ -352,6 +351,15 @@ fn list_services_systemd(kind: ApiServerKind, filter: Option<&Regex>) -> Result<
 
 	services.sort();
 	Ok(services)
+}
+
+/// Tamanu-prefixed services that aren't part of the app rollout.
+///
+/// `tamanu-meta` runs on dedicated meta hosts; `tamanu-alertd` is bestool's
+/// own alerting daemon. Excluding them keeps the rollout focused on the API
+/// / worker / frontend stack.
+fn is_excluded_unit(name: &str) -> bool {
+	name.starts_with("tamanu-meta") || name == "tamanu-alertd"
 }
 
 fn restart_systemd(name: &str) -> Result<()> {


### PR DESCRIPTION
Restarts running tamanu services one at a time with a wait between each,
mirroring the approach in the ops repo's tamanu-single-upgrade playbook.
On Linux, drives systemd units `tamanu-{kind}-*`, `tamanu-frontend@*` and
`tamanu-patientportal`, reloading caddy + flushing systemd-resolved
between restarts so caddy picks up the new container IP. On Windows,
restarts every online pm2 process. Optional HTTP probe via --check-url.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>