### PR TITLE
fix(alerts): swap canopy event message/description to match contract

### DIFF
--- a/crates/alertd/src/targets/canopy.rs
+++ b/crates/alertd/src/targets/canopy.rs
@@ -88,8 +88,8 @@ impl TargetCanopy {
 				NewEvent {
 					source: &self.canopy.source,
 					r#ref: &r#ref,
-					message: subject,
-					description: Some(body),
+					message: body,
+					description: Some(subject),
 					severity: Some(self.canopy.severity.unwrap_or(Severity::Error)),
 					occurred_at: Some(Timestamp::now()),
 					active: Some(true),

--- a/crates/bestool/src/actions/tamanu/alerts/targets/canopy.rs
+++ b/crates/bestool/src/actions/tamanu/alerts/targets/canopy.rs
@@ -73,8 +73,8 @@ impl TargetCanopy {
 				NewEvent {
 					source: &self.source,
 					r#ref: &r#ref,
-					message: subject,
-					description: Some(body),
+					message: body,
+					description: Some(subject),
 					severity: Some(self.severity.unwrap_or(Severity::Error)),
 					occurred_at: Some(Timestamp::now()),
 					active: Some(true),


### PR DESCRIPTION
Canopy's `/events` API treats `message` as the longer body and `description` as the short subject. We had it the other way around in both the alertd target and the legacy tamanu-alerts target, so canopy issues were showing the alert subject as the body and the body as the title.

Trigger sends now map `body → message` and `subject → description`. Clear sends are unchanged: `"alert cleared"` stays in `message` since there is no body for a clear and `message` is required.