### PR TITLE
feat(psql): time out write mode after 10 minutes idle

### DIFF
--- a/crates/psql/src/audit/library.rs
+++ b/crates/psql/src/audit/library.rs
@@ -123,6 +123,7 @@ impl Audit {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			write_mode_active_at: None,
 		};
 
 		let audit = Self {

--- a/crates/psql/src/completer/snippets.rs
+++ b/crates/psql/src/completer/snippets.rs
@@ -159,6 +159,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			write_mode_active_at: None,
 		}));
 
 		let mut completer = SqlCompleter::new(Theme::Dark);
@@ -201,6 +202,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			write_mode_active_at: None,
 		}));
 
 		let mut completer = SqlCompleter::new(Theme::Dark);
@@ -241,6 +243,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			write_mode_active_at: None,
 		}));
 
 		let mut completer = SqlCompleter::new(Theme::Dark);
@@ -284,6 +287,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			write_mode_active_at: None,
 		}));
 
 		let mut completer = SqlCompleter::new(Theme::Dark);

--- a/crates/psql/src/repl.rs
+++ b/crates/psql/src/repl.rs
@@ -108,7 +108,7 @@ impl ReplAction {
 
 pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 	debug!("getting connection from pool");
-	let client = pool.get().await.into_diagnostic()?;
+	let client = Arc::new(pool.get().await.into_diagnostic()?);
 
 	if config.write {
 		debug!("setting session to read-write mode");
@@ -160,7 +160,7 @@ pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 	debug!(pid=%backend_pid, "main connection backend PID");
 
 	debug!("getting monitor connection from pool");
-	let monitor_client = pool.get().await.into_diagnostic()?;
+	let monitor_client = Arc::new(pool.get().await.into_diagnostic()?);
 	debug!("monitor connection established");
 
 	let sys_user = std::env::var("USER")
@@ -182,6 +182,7 @@ pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 		transaction_state: TransactionState::None,
 		result_store: ResultStore::new(),
 		initial_content: None,
+		write_mode_active_at: None,
 	};
 
 	let repl_state = Arc::new(Mutex::new(repl_state));
@@ -216,6 +217,20 @@ pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 
 	// Bind Alt+Enter to insert a literal newline
 	rl.bind_sequence(KeyEvent::alt('\r'), EventHandler::Simple(Cmd::Newline));
+
+	let timeout_watcher = match rl.create_external_printer() {
+		Ok(printer) => Some(tokio::spawn(write_mode::watch_write_mode_idle_timeout(
+			Arc::clone(&client),
+			Arc::clone(&monitor_client),
+			backend_pid,
+			Arc::clone(&repl_state),
+			printer,
+		))),
+		Err(e) => {
+			warn!("could not create external printer for write-mode timeout watcher: {e}");
+			None
+		}
+	};
 
 	if config.write {
 		let mut ctx = ReplContext {
@@ -335,6 +350,10 @@ pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 				break;
 			}
 		}
+	}
+
+	if let Some(handle) = timeout_watcher {
+		handle.abort();
 	}
 
 	rl.history_mut().compact()?;

--- a/crates/psql/src/repl/execute.rs
+++ b/crates/psql/src/repl/execute.rs
@@ -4,7 +4,9 @@ use bestool_postgres::error::format_miette_error;
 use tokio::{fs::File, io};
 use tracing::{error, warn};
 
-use super::{state::ReplContext, transaction::TransactionState};
+use super::{
+	state::ReplContext, transaction::TransactionState, write_mode::mark_write_mode_active,
+};
 use crate::{parser::QueryModifier, query::execute_query};
 
 pub async fn handle_execute(
@@ -113,6 +115,7 @@ pub async fn handle_execute(
 
 	match result {
 		Ok(()) => {
+			mark_write_mode_active(ctx.repl_state);
 			let tx_state = TransactionState::check(ctx.monitor_client, ctx.backend_pid).await;
 			if ctx.repl_state.lock().unwrap().write_mode
 				&& matches!(tx_state, TransactionState::None)

--- a/crates/psql/src/repl/state.rs
+++ b/crates/psql/src/repl/state.rs
@@ -1,6 +1,7 @@
 use std::{
 	collections::BTreeMap,
 	sync::{Arc, Mutex},
+	time::Instant,
 };
 
 use bestool_postgres::pool::PgPool;
@@ -30,6 +31,11 @@ pub struct ReplState {
 	pub result_store: ResultStore,
 	pub from_snippet_or_include: bool,
 	pub initial_content: Option<String>,
+	/// When write mode was last considered "active" — either toggled on, or
+	/// just after a successful query while in write mode. Used by the idle
+	/// timeout watcher to decide when to revert write mode to read-only.
+	/// `None` whenever write mode is off.
+	pub write_mode_active_at: Option<Instant>,
 }
 
 impl Default for ReplState {
@@ -55,6 +61,7 @@ impl ReplState {
 			result_store: ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			write_mode_active_at: None,
 		}
 	}
 }

--- a/crates/psql/src/repl/tests.rs
+++ b/crates/psql/src/repl/tests.rs
@@ -1473,6 +1473,7 @@ async fn test_exit_blocked_with_active_transaction() {
 		transaction_state: TransactionState::Active,
 		result_store: crate::result_store::ResultStore::new(),
 		initial_content: None,
+		write_mode_active_at: None,
 	}));
 
 	// Create a dummy audit and readline editor
@@ -1563,6 +1564,7 @@ async fn test_exit_allowed_after_commit() {
 		result_store: crate::result_store::ResultStore::new(),
 		from_snippet_or_include: false,
 		initial_content: None,
+		write_mode_active_at: None,
 	}));
 
 	// Create a dummy audit and readline editor
@@ -1634,6 +1636,7 @@ async fn test_exit_allowed_in_readonly_mode() {
 		result_store: crate::result_store::ResultStore::new(),
 		from_snippet_or_include: false,
 		initial_content: None,
+		write_mode_active_at: None,
 	}));
 
 	// Create a dummy audit and readline editor

--- a/crates/psql/src/repl/write_mode.rs
+++ b/crates/psql/src/repl/write_mode.rs
@@ -1,9 +1,51 @@
-use std::ops::ControlFlow;
+use std::{
+	ops::ControlFlow,
+	sync::{Arc, Mutex},
+	time::{Duration, Instant},
+};
 
-use tracing::{debug, error};
+use bestool_postgres::pool::PgConnection;
+use rustyline::ExternalPrinter;
+use tracing::{debug, error, warn};
 
-use super::{state::ReplContext, transaction::TransactionState};
+use super::{ReplState, state::ReplContext, transaction::TransactionState};
 use crate::ots;
+
+/// How long write mode can stay enabled without activity before it is
+/// automatically reverted to read-only.
+pub const WRITE_MODE_IDLE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// How often the watcher wakes up to check whether write mode should expire.
+pub const WRITE_MODE_TIMEOUT_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Bump the "active in write mode" timestamp so the idle-timeout clock resets.
+pub fn mark_write_mode_active(repl_state: &Arc<Mutex<ReplState>>) {
+	let mut state = repl_state.lock().unwrap();
+	if state.write_mode {
+		state.write_mode_active_at = Some(Instant::now());
+	}
+}
+
+/// Pure decision used by the watcher: should write mode be timed out, given
+/// the current state and observed transaction state?
+fn should_time_out_write_mode(
+	in_write_mode: bool,
+	active_at: Option<Instant>,
+	now: Instant,
+	tx_state: TransactionState,
+	idle_threshold: Duration,
+) -> bool {
+	if !in_write_mode {
+		return false;
+	}
+	let Some(active_at) = active_at else {
+		return false;
+	};
+	if now.duration_since(active_at) < idle_threshold {
+		return false;
+	}
+	matches!(tx_state, TransactionState::Idle | TransactionState::None)
+}
 
 pub async fn handle_write_mode_toggle(ctx: &mut ReplContext<'_>) -> ControlFlow<()> {
 	let state = { ctx.repl_state.lock().unwrap().clone() };
@@ -20,6 +62,7 @@ pub async fn handle_write_mode_toggle(ctx: &mut ReplContext<'_>) -> ControlFlow<
 		let mut new_state = state.clone();
 		new_state.write_mode = false;
 		new_state.ots = None;
+		new_state.write_mode_active_at = None;
 
 		match ctx
 			.client
@@ -41,6 +84,7 @@ pub async fn handle_write_mode_toggle(ctx: &mut ReplContext<'_>) -> ControlFlow<
 				let mut new_state = state.clone();
 				new_state.write_mode = true;
 				new_state.ots = Some(new_ots.clone());
+				new_state.write_mode_active_at = Some(Instant::now());
 
 				match ctx
 					.client
@@ -66,4 +110,183 @@ pub async fn handle_write_mode_toggle(ctx: &mut ReplContext<'_>) -> ControlFlow<
 	}
 
 	ControlFlow::Continue(())
+}
+
+/// Background watcher that reverts write mode to read-only after
+/// `WRITE_MODE_IDLE_TIMEOUT` of inactivity, provided the session isn't
+/// holding an uncommitted transaction.
+///
+/// Designed to be `tokio::spawn`ed for the lifetime of the REPL; aborting the
+/// returned task on shutdown is fine — there is no shared state to flush.
+pub async fn watch_write_mode_idle_timeout<P: ExternalPrinter + Send + 'static>(
+	client: Arc<PgConnection>,
+	monitor_client: Arc<PgConnection>,
+	backend_pid: i32,
+	repl_state: Arc<Mutex<ReplState>>,
+	mut printer: P,
+) {
+	loop {
+		tokio::time::sleep(WRITE_MODE_TIMEOUT_CHECK_INTERVAL).await;
+
+		let (in_write_mode, active_at) = {
+			let state = repl_state.lock().unwrap();
+			(state.write_mode, state.write_mode_active_at)
+		};
+
+		if !in_write_mode {
+			continue;
+		}
+		let Some(active_at) = active_at else { continue };
+		if active_at.elapsed() < WRITE_MODE_IDLE_TIMEOUT {
+			continue;
+		}
+
+		// Don't yank write mode out from under work that's mid-flight or has
+		// uncommitted changes. The watcher will try again on its next tick.
+		let tx_state = TransactionState::check(&monitor_client, backend_pid).await;
+		if !should_time_out_write_mode(
+			in_write_mode,
+			Some(active_at),
+			Instant::now(),
+			tx_state,
+			WRITE_MODE_IDLE_TIMEOUT,
+		) {
+			continue;
+		}
+
+		match client
+			.batch_execute("ROLLBACK; SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY")
+			.await
+		{
+			Ok(_) => {
+				{
+					let mut state = repl_state.lock().unwrap();
+					// Recheck under the lock: an interactive toggle may have raced us.
+					if !state.write_mode {
+						continue;
+					}
+					state.write_mode = false;
+					state.ots = None;
+					state.write_mode_active_at = None;
+				}
+				let minutes = WRITE_MODE_IDLE_TIMEOUT.as_secs() / 60;
+				let msg = format!(
+					"\nWrite mode idle for {minutes} minutes — session reverted to read-only."
+				);
+				if let Err(e) = printer.print(msg) {
+					warn!("failed to print write-mode timeout notice: {e}");
+				}
+				debug!("write mode timed out due to inactivity");
+			}
+			Err(e) => {
+				warn!("failed to revert write mode on timeout: {e}");
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// `Instant - Duration` panics on Windows when the system has been up
+	// for less than the duration (e.g. fresh CI runners); construct the
+	// "later" instant by adding instead.
+	fn baseline() -> (Instant, Instant) {
+		let earlier = Instant::now();
+		let later = earlier + Duration::from_secs(3600);
+		(earlier, later)
+	}
+
+	#[test]
+	fn does_not_time_out_when_write_mode_off() {
+		let (earlier, later) = baseline();
+		assert!(!should_time_out_write_mode(
+			false,
+			Some(earlier),
+			later,
+			TransactionState::None,
+			Duration::from_secs(600),
+		));
+	}
+
+	#[test]
+	fn does_not_time_out_when_no_activity_recorded() {
+		let (_, later) = baseline();
+		assert!(!should_time_out_write_mode(
+			true,
+			None,
+			later,
+			TransactionState::None,
+			Duration::from_secs(600),
+		));
+	}
+
+	#[test]
+	fn does_not_time_out_before_threshold() {
+		let earlier = Instant::now();
+		let later = earlier + Duration::from_secs(60);
+		assert!(!should_time_out_write_mode(
+			true,
+			Some(earlier),
+			later,
+			TransactionState::None,
+			Duration::from_secs(600),
+		));
+	}
+
+	#[test]
+	fn does_not_time_out_with_uncommitted_writes() {
+		let (earlier, later) = baseline();
+		// An open transaction with pending xid (Active) blocks the timeout
+		// so the watcher doesn't rollback work in progress.
+		assert!(!should_time_out_write_mode(
+			true,
+			Some(earlier),
+			later,
+			TransactionState::Active,
+			Duration::from_secs(600),
+		));
+		assert!(!should_time_out_write_mode(
+			true,
+			Some(earlier),
+			later,
+			TransactionState::Error,
+			Duration::from_secs(600),
+		));
+	}
+
+	#[test]
+	fn times_out_when_idle_and_past_threshold() {
+		let earlier = Instant::now();
+		let later = earlier + Duration::from_secs(601);
+		assert!(should_time_out_write_mode(
+			true,
+			Some(earlier),
+			later,
+			TransactionState::Idle,
+			Duration::from_secs(600),
+		));
+		assert!(should_time_out_write_mode(
+			true,
+			Some(earlier),
+			later,
+			TransactionState::None,
+			Duration::from_secs(600),
+		));
+	}
+
+	#[test]
+	fn mark_write_mode_active_only_runs_when_in_write_mode() {
+		let state = Arc::new(Mutex::new(ReplState::new()));
+
+		// Not in write mode: timestamp stays None.
+		mark_write_mode_active(&state);
+		assert!(state.lock().unwrap().write_mode_active_at.is_none());
+
+		// Now in write mode: timestamp gets populated.
+		state.lock().unwrap().write_mode = true;
+		mark_write_mode_active(&state);
+		assert!(state.lock().unwrap().write_mode_active_at.is_some());
+	}
 }


### PR DESCRIPTION
## Summary

Write mode is meant to be a short-lived elevated privilege. Letting it sit open indefinitely is dangerous (especially with our shared admin sessions): an operator who walks away leaves a foothold for whoever walks up, and the long-held BEGIN keeps locks around on the server.

A background watcher ticks every 30 s and reverts write mode to read-only after 10 minutes without activity. "Activity" is being toggled into write mode, plus every successful query in write mode. The watcher only fires when the transaction has no pending xid, so it never rolls back work in progress; the next tick retries.

The user gets a notice printed above the prompt when the timeout fires, and the prompt redraws read-only on the next iteration.

Implementation notes:
- The main and monitor clients are wrapped in `Arc<PgConnection>` so the watcher can share them.
- ROLLBACK + SET READ ONLY are issued on the main client; tokio-postgres serialises requests on the connection.
- An `ExternalPrinter` from rustyline handles the cross-thread print without garbling the prompt.