### PR TITLE
fix(tamanu/doctor): only treat 5xx as HTTP errors

### DIFF
--- a/crates/bestool/src/actions/tamanu/doctor/checks/disk_free.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/checks/disk_free.rs
@@ -48,7 +48,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 		let free = disk.available_space();
 		let used = total.saturating_sub(free);
 		let pct = if total > 0 {
-			(used as f64 / total as f64) * 100.0
+			((used as f64 / total as f64) * 100.0).round()
 		} else {
 			0.0
 		};

--- a/crates/bestool/src/actions/tamanu/doctor/checks/http_errors.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/checks/http_errors.rs
@@ -71,8 +71,8 @@ pub async fn run(_ctx: CheckContext) -> Check {
 			.with_detail("total", 0u64);
 	}
 
-	let pct = (errored as f64 / total as f64) * 100.0;
-	let summary = format!("{errored}/{total} server errors ({pct:.1}% cumulative)");
+	let pct = ((errored as f64 / total as f64) * 100.0).round();
+	let summary = format!("{errored}/{total} server errors ({pct:.0}% cumulative)");
 
 	let check = if pct >= FAIL_ERROR_PCT {
 		Check::fail(

--- a/crates/bestool/src/actions/tamanu/doctor/checks/http_errors.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/checks/http_errors.rs
@@ -3,7 +3,9 @@
 //! Caddy's admin API at `localhost:2019` exposes `/metrics` in Prometheus text
 //! format. The relevant series is `caddy_http_requests_total{code="…",…}`,
 //! a cumulative counter labelled with the HTTP status code. We aggregate by
-//! status class and report the cumulative error rate.
+//! status class and report the cumulative server-error rate. Only 5xx responses
+//! count as errors; 4xx responses are client mistakes (bad URLs, auth, etc.)
+//! and aren't worth alerting on.
 
 use std::time::Duration;
 
@@ -60,10 +62,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	let total: u64 = counts.iter().map(|(_, n)| n).sum();
 	let errored: u64 = counts
 		.iter()
-		.filter(|(code, _)| {
-			let first = code.chars().next();
-			matches!(first, Some('4') | Some('5'))
-		})
+		.filter(|(code, _)| code.starts_with('5'))
 		.map(|(_, n)| n)
 		.sum();
 
@@ -73,7 +72,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	}
 
 	let pct = (errored as f64 / total as f64) * 100.0;
-	let summary = format!("{errored}/{total} errored ({pct:.1}% cumulative)");
+	let summary = format!("{errored}/{total} server errors ({pct:.1}% cumulative)");
 
 	let check = if pct >= FAIL_ERROR_PCT {
 		Check::fail(
@@ -97,8 +96,8 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	}
 
 	check.with_detail("total_requests", total)
-		.with_detail("error_requests", errored)
-		.with_detail("error_rate_pct", pct)
+		.with_detail("server_error_requests", errored)
+		.with_detail("server_error_rate_pct", pct)
 		.with_detail("by_code", Value::Object(by_code))
 }
 

--- a/crates/bestool/src/actions/tamanu/doctor/checks/memory.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/checks/memory.rs
@@ -13,7 +13,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	let total = sys.total_memory();
 	let used = sys.used_memory();
 	let pct = if total > 0 {
-		(used as f64 / total as f64) * 100.0
+		((used as f64 / total as f64) * 100.0).round()
 	} else {
 		0.0
 	};


### PR DESCRIPTION
## Summary

- The `http_errors` check was counting both 4xx and 5xx responses against the warn/fail thresholds. 4xx are client-side mistakes (bad URLs, auth failures, etc.) and shouldn't trigger server-health alerts — narrow the filter to 5xx only. Detail keys renamed to `server_error_*` to match.
- Round the percentages stored in check details (`http_errors`, `memory`, `disk_free`) to whole numbers, matching what the summary line already displays.