### PR TITLE
feat(tamanu/doctor): compute http error rate over a 10-minute window

### DIFF
--- a/crates/alertd/ALERTS.md
+++ b/crates/alertd/ALERTS.md
@@ -90,13 +90,11 @@ event: <event-type>
 ```
 
 Event types:
-- `http`: HTTP POST to `/alert` endpoint
 - `definition-error`: Alert definition file has errors
 - `source-error`: Alert source execution failed
 - `database-down`: The PostgreSQL database is unreachable
 
 Event-specific context variables vary by type:
-- `http`: `message`, `subject`, any other variables sent to the endpoint
 - `definition-error`: `alert_file`, `error_message`
 - `source-error`: `alert_file`, `error_message`
 - `database-down`: `database_url` (password redacted), `error_message`

--- a/crates/alertd/TARGETS.md
+++ b/crates/alertd/TARGETS.md
@@ -73,8 +73,7 @@ targets:
 
 Canopy requires one of two auth paths; alertd probes them at startup and on every reload:
 
-1. **Tailscale** — if `https://tamanu-meta-prod.tail53aef.ts.net/public/events` is reachable
-   from this host (i.e. the host is on the canopy tailnet), events are pushed there without any
+1. **Tailscale** — if the host is on the canopy tailnet, events are pushed there without any
    client cert. This path is preferred when available.
 
 2. **mTLS via Tamanu device key** — falls back to the public endpoint (`url:` above) using a

--- a/crates/alertd/src/canopy.rs
+++ b/crates/alertd/src/canopy.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_CANOPY_URL: &str = "https://meta.tamanu.app";
 ///
 /// On hosts that share the canopy tailnet, posting to this URL works without
 /// mTLS — the tailscale identity is the auth.
-pub const TAILSCALE_URL: &str = "https://tamanu-meta-prod.tail53aef.ts.net";
+pub const TAILSCALE_URL: &str = "https://canopy.tail53aef.ts.net";
 
 /// How long renewed canopy certs are valid for.
 ///

--- a/crates/alertd/src/events.rs
+++ b/crates/alertd/src/events.rs
@@ -43,7 +43,6 @@ fn synthetic_alert(event_type: &EventType, entity_key: Option<&str>) -> AlertDef
 pub enum EventType {
 	SourceError,
 	DefinitionError,
-	Http,
 	DatabaseDown,
 }
 
@@ -52,7 +51,6 @@ impl EventType {
 		match self {
 			Self::SourceError => "source-error",
 			Self::DefinitionError => "definition-error",
-			Self::Http => "http",
 			Self::DatabaseDown => "database-down",
 		}
 	}
@@ -68,11 +66,6 @@ pub enum EventContext {
 	DefinitionError {
 		alert_file: String,
 		error_message: String,
-	},
-	Http {
-		message: String,
-		subject: Option<String>,
-		custom: serde_json::Value,
 	},
 	DatabaseDown {
 		database_url: String,
@@ -97,19 +90,6 @@ impl EventContext {
 			} => {
 				ctx.insert("alert_file", alert_file);
 				ctx.insert("error_message", error_message);
-			}
-			Self::Http {
-				message,
-				subject,
-				custom,
-			} => {
-				ctx.insert("message", message);
-				ctx.insert("subject", subject.as_deref().unwrap_or("Custom alert"));
-				if let serde_json::Value::Object(map) = custom {
-					for (key, value) in map {
-						ctx.insert(key, value);
-					}
-				}
 			}
 			Self::DatabaseDown {
 				database_url,
@@ -345,10 +325,6 @@ fn default_event_template(event_type: &EventType) -> (String, String) {
 				.to_string(),
 			"<pre>{{ error_message }}</pre>".to_string(),
 		),
-		EventType::Http => (
-			"[bestool-alertd] {{ hostname }}: {{ subject }}".to_string(),
-			"{{ message }}".to_string(),
-		),
 		EventType::DatabaseDown => (
 			"[bestool-alertd] {{ hostname }}: Database unreachable".to_string(),
 			"The PostgreSQL database is unreachable.\n\n\
@@ -375,7 +351,6 @@ mod tests {
 	fn test_event_type_as_str() {
 		assert_eq!(EventType::SourceError.as_str(), "source-error");
 		assert_eq!(EventType::DefinitionError.as_str(), "definition-error");
-		assert_eq!(EventType::Http.as_str(), "http");
 		assert_eq!(EventType::DatabaseDown.as_str(), "database-down");
 	}
 
@@ -405,26 +380,6 @@ mod tests {
 	}
 
 	#[test]
-	fn test_event_context_to_tera_http() {
-		let ctx = EventContext::Http {
-			message: "Test message".to_string(),
-			subject: Some("Test subject".to_string()),
-			custom: serde_json::json!({"extra": "data"}),
-		};
-
-		let tera_ctx = ctx.to_tera_context();
-		assert_eq!(
-			tera_ctx.get("message").unwrap().as_str().unwrap(),
-			"Test message"
-		);
-		assert_eq!(
-			tera_ctx.get("subject").unwrap().as_str().unwrap(),
-			"Test subject"
-		);
-		assert_eq!(tera_ctx.get("extra").unwrap().as_str().unwrap(), "data");
-	}
-
-	#[test]
 	fn test_event_type_database_down() {
 		let yaml = "database-down";
 		let event: EventType = serde_yaml::from_str(yaml).unwrap();
@@ -446,21 +401,6 @@ mod tests {
 		assert_eq!(
 			tera_ctx.get("error_message").unwrap().as_str().unwrap(),
 			"connection refused"
-		);
-	}
-
-	#[test]
-	fn test_event_context_http_default_subject() {
-		let ctx = EventContext::Http {
-			message: "Test message".to_string(),
-			subject: None,
-			custom: serde_json::json!({}),
-		};
-
-		let tera_ctx = ctx.to_tera_context();
-		assert_eq!(
-			tera_ctx.get("subject").unwrap().as_str().unwrap(),
-			"Custom alert"
 		);
 	}
 

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -55,7 +55,6 @@ pub async fn start_server(
 	let app = Router::new()
 		.route("/", get(handle_index))
 		.route("/reload", post(handle_reload))
-		.route("/alert", post(handle_alert))
 		.route("/alerts", get(handle_alerts).delete(handle_pause_alert))
 		.route("/targets", get(handle_targets))
 		.route("/validate", post(handle_validate))

--- a/crates/alertd/src/http_server/endpoints.rs
+++ b/crates/alertd/src/http_server/endpoints.rs
@@ -1,4 +1,3 @@
-mod alert;
 mod alerts;
 mod health;
 mod index;
@@ -9,7 +8,6 @@ mod status;
 mod targets;
 mod validate;
 
-pub use alert::handle_alert;
 pub use alerts::handle_alerts;
 pub use health::handle_health;
 pub use index::handle_index;

--- a/crates/alertd/src/http_server/endpoints/alert.rs
+++ b/crates/alertd/src/http_server/endpoints/alert.rs
@@ -28,7 +28,6 @@ pub async fn handle_alert(
 				state.email_config.as_ref(),
 				state.dry_run,
 				event_context,
-				None,
 			)
 			.await
 		{

--- a/crates/alertd/src/http_server/endpoints/index.rs
+++ b/crates/alertd/src/http_server/endpoints/index.rs
@@ -13,11 +13,6 @@ pub async fn handle_index() -> impl IntoResponse {
 			"description": "Trigger a configuration reload (equivalent to SIGHUP)"
 		},
 		{
-			"method": "POST",
-			"path": "/alert",
-			"description": "Trigger a custom HTTP alert with JSON payload"
-		},
-		{
 			"method": "GET",
 			"path": "/alerts",
 			"description": "List currently loaded alert files"

--- a/crates/alertd/src/http_server/endpoints/validate.rs
+++ b/crates/alertd/src/http_server/endpoints/validate.rs
@@ -153,7 +153,7 @@ send:
 	#[tokio::test]
 	async fn test_validate_event_alert() {
 		let yaml = r#"
-event: http
+event: source-error
 send:
   - id: test
     subject: Test

--- a/crates/alertd/src/http_server/types.rs
+++ b/crates/alertd/src/http_server/types.rs
@@ -9,15 +9,6 @@ pub struct StatusResponse {
 }
 
 #[derive(Deserialize)]
-pub struct AlertRequest {
-	pub message: String,
-	#[serde(default)]
-	pub subject: Option<String>,
-	#[serde(flatten)]
-	pub custom: serde_json::Value,
-}
-
-#[derive(Deserialize)]
 pub struct PauseAlertRequest {
 	pub alert: String,
 	pub until: String,

--- a/crates/bestool/src/actions/tamanu/doctor/checks/http_errors.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/checks/http_errors.rs
@@ -1,15 +1,33 @@
-//! HTTP error rate, sourced from Caddy's Prometheus metrics endpoint.
+//! HTTP error rate over a sliding 10-minute window.
 //!
 //! Caddy's admin API at `localhost:2019` exposes `/metrics` in Prometheus text
-//! format. The relevant series is `caddy_http_requests_total{code="…",…}`,
-//! a cumulative counter labelled with the HTTP status code. We aggregate by
-//! status class and report the cumulative server-error rate. Only 5xx responses
-//! count as errors; 4xx responses are client mistakes (bad URLs, auth, etc.)
-//! and aren't worth alerting on.
+//! format. The relevant series is `caddy_http_request_duration_seconds_count`,
+//! labelled with the HTTP status code. Prometheus counters only grow over
+//! Caddy's lifetime, so cumulative ratios become useless very quickly: a
+//! genuine spike right now barely moves the needle against months of clean
+//! traffic.
+//!
+//! To get a rate that reflects *recent* health we snapshot the counters to
+//! disk on every doctor run, then compare against the oldest snapshot that's
+//! still within the window. With the default 1-minute cron there are normally
+//! ~10 snapshots covering the last 10 minutes; ad-hoc manual runs piggy-back
+//! on whatever the cron just wrote. If no usable historical snapshot exists
+//! (cold start, cache wiped, Caddy restarted) we fall back to a 10-second
+//! in-run sample.
+//!
+//! Only 5xx responses count as errors; 4xx responses are client mistakes
+//! (bad URLs, auth, etc.) and aren't worth alerting on.
 
-use std::time::Duration;
+use std::{
+	collections::BTreeMap,
+	path::{Path, PathBuf},
+	time::Duration,
+};
 
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use tracing::{debug, warn};
 
 use super::CheckContext;
 use crate::actions::tamanu::doctor::check::Check;
@@ -19,6 +37,24 @@ const TIMEOUT: Duration = Duration::from_secs(3);
 
 const WARN_ERROR_PCT: f64 = 5.0;
 const FAIL_ERROR_PCT: f64 = 20.0;
+
+/// How far back we'll compare current counters against. Older snapshots are
+/// pruned.
+const WINDOW: Duration = Duration::from_secs(10 * 60);
+/// Grace beyond `WINDOW` before a snapshot is dropped from the history file.
+const PRUNE_GRACE: Duration = Duration::from_secs(60);
+/// Shortest usable historical window. If the freshest available history is
+/// younger than this, do an in-run sample instead — a 5-second delta isn't a
+/// rate, it's noise.
+const MIN_HISTORY_AGE: Duration = Duration::from_secs(30);
+/// Sleep between the two samples when we can't use history.
+const IN_RUN_SAMPLE: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Snapshot {
+	taken_at: Timestamp,
+	counts: BTreeMap<String, u64>,
+}
 
 pub async fn run(_ctx: CheckContext) -> Check {
 	let client = match reqwest::Client::builder().timeout(TIMEOUT).build() {
@@ -33,46 +69,153 @@ pub async fn run(_ctx: CheckContext) -> Check {
 		}
 	};
 
+	let current_counts = match fetch_counts(&client).await {
+		FetchResult::Counts(c) => c,
+		FetchResult::Skip(check) => return check,
+	};
+	let current = Snapshot {
+		taken_at: Timestamp::now(),
+		counts: current_counts,
+	};
+
+	let state = state_path();
+	let mut history = state
+		.as_deref()
+		.map(load_history)
+		.unwrap_or_default();
+	prune_history(&mut history, current.taken_at);
+
+	let (baseline, source) = match pick_baseline(&history, &current) {
+		Some(b) => (b.clone(), BaselineSource::History),
+		None => {
+			tokio::time::sleep(IN_RUN_SAMPLE).await;
+			let second_counts = match fetch_counts(&client).await {
+				FetchResult::Counts(c) => c,
+				FetchResult::Skip(check) => return check,
+			};
+			let second = Snapshot {
+				taken_at: Timestamp::now(),
+				counts: second_counts,
+			};
+			// `current` was taken first; second was taken IN_RUN_SAMPLE later.
+			// Re-assign so `current` is the newer one for the delta math below.
+			let baseline = current.clone();
+			append_and_save(&state, &mut history, second.clone());
+			return build_check(&baseline, &second, BaselineSource::InRunSample);
+		}
+	};
+
+	append_and_save(&state, &mut history, current.clone());
+	build_check(&baseline, &current, source)
+}
+
+enum FetchResult {
+	Counts(BTreeMap<String, u64>),
+	Skip(Check),
+}
+
+async fn fetch_counts(client: &reqwest::Client) -> FetchResult {
 	let body = match client.get(CADDY_METRICS_URL).send().await {
 		Ok(resp) if resp.status().is_success() => match resp.text().await {
 			Ok(t) => t,
 			Err(err) => {
-				return Check::pass(
-					"http_errors",
-					"caddy /metrics body read failed",
-				)
-				.with_detail("skipped", true)
-				.with_detail("reason", err.to_string());
+				return FetchResult::Skip(
+					Check::pass("http_errors", "caddy /metrics body read failed")
+						.with_detail("skipped", true)
+						.with_detail("reason", err.to_string()),
+				);
 			}
 		},
 		Ok(resp) => {
-			return Check::pass(
-				"http_errors",
-				format!("caddy /metrics returned HTTP {}", resp.status().as_u16()),
-			)
-			.with_detail("skipped", true);
+			return FetchResult::Skip(
+				Check::pass(
+					"http_errors",
+					format!("caddy /metrics returned HTTP {}", resp.status().as_u16()),
+				)
+				.with_detail("skipped", true),
+			);
 		}
 		Err(_) => {
-			return Check::pass("http_errors", "caddy admin unreachable")
-				.with_detail("skipped", true);
+			return FetchResult::Skip(
+				Check::pass("http_errors", "caddy admin unreachable")
+					.with_detail("skipped", true),
+			);
 		}
 	};
 
-	let counts = parse_status_counts(&body);
-	let total: u64 = counts.iter().map(|(_, n)| n).sum();
-	let errored: u64 = counts
+	FetchResult::Counts(parse_status_counts(&body))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BaselineSource {
+	History,
+	InRunSample,
+}
+
+fn pick_baseline<'a>(history: &'a [Snapshot], current: &Snapshot) -> Option<&'a Snapshot> {
+	history
+		.iter()
+		.filter(|s| {
+			let age = duration_between(s.taken_at, current.taken_at);
+			age >= MIN_HISTORY_AGE && age <= WINDOW
+		})
+		// A counter going down means Caddy restarted between the snapshots and
+		// the delta would be meaningless. Skip such baselines.
+		.filter(|s| !counters_reset(&s.counts, &current.counts))
+		// Oldest still-usable snapshot gives the widest window.
+		.min_by_key(|s| s.taken_at)
+}
+
+fn counters_reset(before: &BTreeMap<String, u64>, after: &BTreeMap<String, u64>) -> bool {
+	before
+		.iter()
+		.any(|(code, b)| after.get(code).copied().unwrap_or(0) < *b)
+}
+
+fn delta_counts(
+	before: &BTreeMap<String, u64>,
+	after: &BTreeMap<String, u64>,
+) -> BTreeMap<String, u64> {
+	let mut out = BTreeMap::new();
+	for (code, after_n) in after {
+		let before_n = before.get(code).copied().unwrap_or(0);
+		let d = after_n.saturating_sub(before_n);
+		if d > 0 {
+			out.insert(code.clone(), d);
+		}
+	}
+	out
+}
+
+fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) -> Check {
+	let deltas = delta_counts(&baseline.counts, &current.counts);
+	let total: u64 = deltas.values().sum();
+	let errored: u64 = deltas
 		.iter()
 		.filter(|(code, _)| code.starts_with('5'))
 		.map(|(_, n)| n)
 		.sum();
+	let window = duration_between(baseline.taken_at, current.taken_at);
+	let window_label = humanise_window(window);
+	let source_label = match source {
+		BaselineSource::History => "vs history",
+		BaselineSource::InRunSample => "live sample",
+	};
 
 	if total == 0 {
-		return Check::pass("http_errors", "no requests observed yet")
-			.with_detail("total", 0u64);
+		return Check::pass(
+			"http_errors",
+			format!("no requests in last {window_label} ({source_label})"),
+		)
+		.with_detail("total_requests", 0u64)
+		.with_detail("window_seconds", window.as_secs())
+		.with_detail("baseline_source", source_label);
 	}
 
 	let pct = ((errored as f64 / total as f64) * 100.0).round();
-	let summary = format!("{errored}/{total} server errors ({pct:.0}% cumulative)");
+	let summary = format!(
+		"{errored}/{total} server errors ({pct:.0}%) in last {window_label} ({source_label})"
+	);
 
 	let check = if pct >= FAIL_ERROR_PCT {
 		Check::fail(
@@ -91,14 +234,91 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	};
 
 	let mut by_code: Map<String, Value> = Map::new();
-	for (code, n) in &counts {
+	for (code, n) in &deltas {
 		by_code.insert(code.clone(), Value::from(*n));
 	}
 
 	check.with_detail("total_requests", total)
 		.with_detail("server_error_requests", errored)
 		.with_detail("server_error_rate_pct", pct)
+		.with_detail("window_seconds", window.as_secs())
+		.with_detail("baseline_source", source_label)
 		.with_detail("by_code", Value::Object(by_code))
+}
+
+fn duration_between(earlier: Timestamp, later: Timestamp) -> Duration {
+	let secs = later.as_second().saturating_sub(earlier.as_second());
+	Duration::from_secs(secs.max(0) as u64)
+}
+
+fn humanise_window(d: Duration) -> String {
+	let secs = d.as_secs();
+	if secs < 60 {
+		format!("{secs}s")
+	} else {
+		let m = secs / 60;
+		let s = secs % 60;
+		if s == 0 {
+			format!("{m}m")
+		} else {
+			format!("{m}m {s}s")
+		}
+	}
+}
+
+fn state_path() -> Option<PathBuf> {
+	dirs::cache_dir().map(|d| d.join("bestool").join("doctor-http-errors.json"))
+}
+
+fn load_history(path: &Path) -> Vec<Snapshot> {
+	match std::fs::read(path) {
+		Ok(bytes) => match serde_json::from_slice::<Vec<Snapshot>>(&bytes) {
+			Ok(v) => v,
+			Err(err) => {
+				debug!(%err, ?path, "ignoring unparseable doctor http_errors history");
+				Vec::new()
+			}
+		},
+		Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+		Err(err) => {
+			debug!(%err, ?path, "could not read doctor http_errors history");
+			Vec::new()
+		}
+	}
+}
+
+fn prune_history(history: &mut Vec<Snapshot>, now: Timestamp) {
+	let cutoff = WINDOW + PRUNE_GRACE;
+	history.retain(|s| {
+		let age = duration_between(s.taken_at, now);
+		age <= cutoff
+	});
+}
+
+fn append_and_save(path: &Option<PathBuf>, history: &mut Vec<Snapshot>, snapshot: Snapshot) {
+	history.push(snapshot);
+	let Some(path) = path else { return };
+	if let Some(parent) = path.parent()
+		&& let Err(err) = std::fs::create_dir_all(parent)
+	{
+		warn!(%err, ?parent, "could not create doctor http_errors cache dir");
+		return;
+	}
+	let json = match serde_json::to_vec(history) {
+		Ok(b) => b,
+		Err(err) => {
+			warn!(%err, "could not serialise doctor http_errors history");
+			return;
+		}
+	};
+	let tmp = path.with_extension("json.tmp");
+	if let Err(err) = std::fs::write(&tmp, &json) {
+		warn!(%err, ?tmp, "could not write doctor http_errors history");
+		return;
+	}
+	if let Err(err) = std::fs::rename(&tmp, path) {
+		warn!(%err, ?path, "could not rename doctor http_errors history");
+	}
 }
 
 /// Parse `caddy_http_request_duration_seconds_count{code="NNN",...} <count>` lines.
@@ -111,7 +331,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 /// and take the **max** across handlers: the entry-point handler must have
 /// seen every request matching that label combination, so its count is the
 /// real one. Then we sum across hosts/methods/servers per code.
-fn parse_status_counts(body: &str) -> Vec<(String, u64)> {
+fn parse_status_counts(body: &str) -> BTreeMap<String, u64> {
 	use std::collections::HashMap;
 
 	let mut per_tuple: HashMap<(String, String, String, String), u64> = HashMap::new();
@@ -145,14 +365,11 @@ fn parse_status_counts(body: &str) -> Vec<(String, u64)> {
 		*entry = (*entry).max(value);
 	}
 
-	let mut totals: HashMap<String, u64> = HashMap::new();
+	let mut totals: BTreeMap<String, u64> = BTreeMap::new();
 	for ((_, _, _, code), count) in per_tuple {
 		*totals.entry(code).or_insert(0) += count;
 	}
-
-	let mut entries: Vec<(String, u64)> = totals.into_iter().collect();
-	entries.sort_by(|a, b| a.0.cmp(&b.0));
-	entries
+	totals
 }
 
 fn extract_label(labels: &str, key: &str) -> Option<String> {
@@ -180,13 +397,18 @@ caddy_http_request_duration_seconds_bucket{code=\"200\",handler=\"encode\",host=
 other_metric{foo=\"bar\"} 7
 ";
 
+	fn snap(secs: i64, counts: &[(&str, u64)]) -> Snapshot {
+		Snapshot {
+			taken_at: Timestamp::from_second(secs).unwrap(),
+			counts: counts.iter().map(|(k, v)| ((*k).to_string(), *v)).collect(),
+		}
+	}
+
 	#[test]
 	fn parses_caddy_metric_lines() {
 		let counts = parse_status_counts(SAMPLE);
-		// 200 entries dedupe across handlers (max=9 for the (host,method,server,code)
-		// tuple); 404 and 502 each have a single handler entry.
 		assert_eq!(
-			counts,
+			counts.into_iter().collect::<Vec<_>>(),
 			vec![
 				("200".to_string(), 9),
 				("404".to_string(), 12),
@@ -207,5 +429,86 @@ other_metric{foo=\"bar\"} 7
 			extract_label("{code=\"200\",server=\"srv0\"}", "code"),
 			Some("200".to_string())
 		);
+	}
+
+	#[test]
+	fn delta_only_counts_growth() {
+		let before: BTreeMap<String, u64> =
+			[("200".to_string(), 10), ("500".to_string(), 2)].into();
+		let after: BTreeMap<String, u64> =
+			[("200".to_string(), 15), ("500".to_string(), 4), ("404".to_string(), 1)].into();
+		let d = delta_counts(&before, &after);
+		assert_eq!(d.get("200").copied(), Some(5));
+		assert_eq!(d.get("500").copied(), Some(2));
+		assert_eq!(d.get("404").copied(), Some(1));
+	}
+
+	#[test]
+	fn reset_detected_when_any_counter_drops() {
+		let before: BTreeMap<String, u64> = [("200".to_string(), 10)].into();
+		let after_dropped: BTreeMap<String, u64> = [("200".to_string(), 5)].into();
+		assert!(counters_reset(&before, &after_dropped));
+		let after_grown: BTreeMap<String, u64> = [("200".to_string(), 11)].into();
+		assert!(!counters_reset(&before, &after_grown));
+	}
+
+	#[test]
+	fn pick_baseline_prefers_oldest_within_window() {
+		let now = Timestamp::from_second(10_000).unwrap();
+		let current = Snapshot {
+			taken_at: now,
+			counts: [("200".to_string(), 100)].into(),
+		};
+		let history = vec![
+			snap(10_000 - 700, &[("200", 10)]),  // 11m40s old — too old
+			snap(10_000 - 540, &[("200", 30)]),  // 9m old — usable
+			snap(10_000 - 300, &[("200", 60)]),  // 5m old — usable
+			snap(10_000 - 10, &[("200", 90)]),   // 10s old — too fresh
+		];
+		let baseline = pick_baseline(&history, &current).expect("should pick one");
+		assert_eq!(baseline.taken_at.as_second(), 10_000 - 540);
+	}
+
+	#[test]
+	fn pick_baseline_skips_when_only_fresh_snapshots() {
+		let now = Timestamp::from_second(10_000).unwrap();
+		let current = Snapshot {
+			taken_at: now,
+			counts: [("200".to_string(), 100)].into(),
+		};
+		let history = vec![snap(10_000 - 5, &[("200", 95)])];
+		assert!(pick_baseline(&history, &current).is_none());
+	}
+
+	#[test]
+	fn pick_baseline_skips_resets() {
+		let now = Timestamp::from_second(10_000).unwrap();
+		let current = Snapshot {
+			taken_at: now,
+			counts: [("200".to_string(), 5)].into(),
+		};
+		let history = vec![snap(10_000 - 300, &[("200", 100)])];
+		assert!(pick_baseline(&history, &current).is_none());
+	}
+
+	#[test]
+	fn prune_drops_snapshots_outside_window_plus_grace() {
+		let now = Timestamp::from_second(10_000).unwrap();
+		let mut history = vec![
+			snap(10_000 - (WINDOW + PRUNE_GRACE).as_secs() as i64 - 1, &[("200", 1)]),
+			snap(10_000 - WINDOW.as_secs() as i64, &[("200", 2)]),
+			snap(10_000 - 60, &[("200", 3)]),
+		];
+		prune_history(&mut history, now);
+		assert_eq!(history.len(), 2);
+		assert_eq!(history[0].counts.get("200").copied(), Some(2));
+	}
+
+	#[test]
+	fn humanise_window_formats_seconds_and_minutes() {
+		assert_eq!(humanise_window(Duration::from_secs(10)), "10s");
+		assert_eq!(humanise_window(Duration::from_secs(60)), "1m");
+		assert_eq!(humanise_window(Duration::from_secs(540)), "9m");
+		assert_eq!(humanise_window(Duration::from_secs(545)), "9m 5s");
 	}
 }

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -92,7 +92,7 @@ impl DownloadSource {
 			.lookup_ip(match self {
 				Self::Tools => "bestool-proxy-tools",
 				Self::Servers => "bestool-proxy-servers",
-				Self::Meta => "tamanu-meta-prod-disabled",
+				Self::Meta => return Vec::new(),
 			})
 			.await
 			.ok()


### PR DESCRIPTION
## Summary

- `http_errors` was comparing cumulative Caddy counters from process start, so a real error spike right now barely budged the ratio against months of clean traffic. Switch to a sliding 10-minute window.
- Snapshot the counters to `dirs::cache_dir()/bestool/doctor-http-errors.json` on every run. Compare against the oldest snapshot still within the window — with the default 1-minute cron there are ~10 snapshots in scope, and ad-hoc manual runs piggy-back on whatever the cron just wrote.
- Cold-start / cache-wipe / Caddy-restart cases fall back to a 10s in-run sample (counter-reset detection skips baselines where any code's count went backwards).
- Summary now reads e.g. `0/3421 server errors (0%) in last 9m 40s (vs history)`. Details report deltas, not cumulative.