### PR TITLE
fix(tamanu/doctor): skip fhir_jobs check on facility servers

### DIFF
--- a/crates/alertd/ALERTS.md
+++ b/crates/alertd/ALERTS.md
@@ -90,13 +90,11 @@ event: <event-type>
 ```
 
 Event types:
-- `http`: HTTP POST to `/alert` endpoint
 - `definition-error`: Alert definition file has errors
 - `source-error`: Alert source execution failed
 - `database-down`: The PostgreSQL database is unreachable
 
 Event-specific context variables vary by type:
-- `http`: `message`, `subject`, any other variables sent to the endpoint
 - `definition-error`: `alert_file`, `error_message`
 - `source-error`: `alert_file`, `error_message`
 - `database-down`: `database_url` (password redacted), `error_message`

--- a/crates/alertd/TARGETS.md
+++ b/crates/alertd/TARGETS.md
@@ -73,8 +73,7 @@ targets:
 
 Canopy requires one of two auth paths; alertd probes them at startup and on every reload:
 
-1. **Tailscale** — if `https://tamanu-meta-prod.tail53aef.ts.net/public/events` is reachable
-   from this host (i.e. the host is on the canopy tailnet), events are pushed there without any
+1. **Tailscale** — if the host is on the canopy tailnet, events are pushed there without any
    client cert. This path is preferred when available.
 
 2. **mTLS via Tamanu device key** — falls back to the public endpoint (`url:` above) using a

--- a/crates/alertd/src/canopy.rs
+++ b/crates/alertd/src/canopy.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_CANOPY_URL: &str = "https://meta.tamanu.app";
 ///
 /// On hosts that share the canopy tailnet, posting to this URL works without
 /// mTLS — the tailscale identity is the auth.
-pub const TAILSCALE_URL: &str = "https://tamanu-meta-prod.tail53aef.ts.net";
+pub const TAILSCALE_URL: &str = "https://canopy.tail53aef.ts.net";
 
 /// How long renewed canopy certs are valid for.
 ///

--- a/crates/alertd/src/events.rs
+++ b/crates/alertd/src/events.rs
@@ -43,7 +43,6 @@ fn synthetic_alert(event_type: &EventType, entity_key: Option<&str>) -> AlertDef
 pub enum EventType {
 	SourceError,
 	DefinitionError,
-	Http,
 	DatabaseDown,
 }
 
@@ -52,7 +51,6 @@ impl EventType {
 		match self {
 			Self::SourceError => "source-error",
 			Self::DefinitionError => "definition-error",
-			Self::Http => "http",
 			Self::DatabaseDown => "database-down",
 		}
 	}
@@ -68,11 +66,6 @@ pub enum EventContext {
 	DefinitionError {
 		alert_file: String,
 		error_message: String,
-	},
-	Http {
-		message: String,
-		subject: Option<String>,
-		custom: serde_json::Value,
 	},
 	DatabaseDown {
 		database_url: String,
@@ -97,19 +90,6 @@ impl EventContext {
 			} => {
 				ctx.insert("alert_file", alert_file);
 				ctx.insert("error_message", error_message);
-			}
-			Self::Http {
-				message,
-				subject,
-				custom,
-			} => {
-				ctx.insert("message", message);
-				ctx.insert("subject", subject.as_deref().unwrap_or("Custom alert"));
-				if let serde_json::Value::Object(map) = custom {
-					for (key, value) in map {
-						ctx.insert(key, value);
-					}
-				}
 			}
 			Self::DatabaseDown {
 				database_url,
@@ -345,10 +325,6 @@ fn default_event_template(event_type: &EventType) -> (String, String) {
 				.to_string(),
 			"<pre>{{ error_message }}</pre>".to_string(),
 		),
-		EventType::Http => (
-			"[bestool-alertd] {{ hostname }}: {{ subject }}".to_string(),
-			"{{ message }}".to_string(),
-		),
 		EventType::DatabaseDown => (
 			"[bestool-alertd] {{ hostname }}: Database unreachable".to_string(),
 			"The PostgreSQL database is unreachable.\n\n\
@@ -375,7 +351,6 @@ mod tests {
 	fn test_event_type_as_str() {
 		assert_eq!(EventType::SourceError.as_str(), "source-error");
 		assert_eq!(EventType::DefinitionError.as_str(), "definition-error");
-		assert_eq!(EventType::Http.as_str(), "http");
 		assert_eq!(EventType::DatabaseDown.as_str(), "database-down");
 	}
 
@@ -405,26 +380,6 @@ mod tests {
 	}
 
 	#[test]
-	fn test_event_context_to_tera_http() {
-		let ctx = EventContext::Http {
-			message: "Test message".to_string(),
-			subject: Some("Test subject".to_string()),
-			custom: serde_json::json!({"extra": "data"}),
-		};
-
-		let tera_ctx = ctx.to_tera_context();
-		assert_eq!(
-			tera_ctx.get("message").unwrap().as_str().unwrap(),
-			"Test message"
-		);
-		assert_eq!(
-			tera_ctx.get("subject").unwrap().as_str().unwrap(),
-			"Test subject"
-		);
-		assert_eq!(tera_ctx.get("extra").unwrap().as_str().unwrap(), "data");
-	}
-
-	#[test]
 	fn test_event_type_database_down() {
 		let yaml = "database-down";
 		let event: EventType = serde_yaml::from_str(yaml).unwrap();
@@ -446,21 +401,6 @@ mod tests {
 		assert_eq!(
 			tera_ctx.get("error_message").unwrap().as_str().unwrap(),
 			"connection refused"
-		);
-	}
-
-	#[test]
-	fn test_event_context_http_default_subject() {
-		let ctx = EventContext::Http {
-			message: "Test message".to_string(),
-			subject: None,
-			custom: serde_json::json!({}),
-		};
-
-		let tera_ctx = ctx.to_tera_context();
-		assert_eq!(
-			tera_ctx.get("subject").unwrap().as_str().unwrap(),
-			"Custom alert"
 		);
 	}
 

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -55,7 +55,6 @@ pub async fn start_server(
 	let app = Router::new()
 		.route("/", get(handle_index))
 		.route("/reload", post(handle_reload))
-		.route("/alert", post(handle_alert))
 		.route("/alerts", get(handle_alerts).delete(handle_pause_alert))
 		.route("/targets", get(handle_targets))
 		.route("/validate", post(handle_validate))

--- a/crates/alertd/src/http_server/endpoints.rs
+++ b/crates/alertd/src/http_server/endpoints.rs
@@ -1,4 +1,3 @@
-mod alert;
 mod alerts;
 mod health;
 mod index;
@@ -9,7 +8,6 @@ mod status;
 mod targets;
 mod validate;
 
-pub use alert::handle_alert;
 pub use alerts::handle_alerts;
 pub use health::handle_health;
 pub use index::handle_index;

--- a/crates/alertd/src/http_server/endpoints/alert.rs
+++ b/crates/alertd/src/http_server/endpoints/alert.rs
@@ -28,7 +28,6 @@ pub async fn handle_alert(
 				state.email_config.as_ref(),
 				state.dry_run,
 				event_context,
-				None,
 			)
 			.await
 		{

--- a/crates/alertd/src/http_server/endpoints/index.rs
+++ b/crates/alertd/src/http_server/endpoints/index.rs
@@ -13,11 +13,6 @@ pub async fn handle_index() -> impl IntoResponse {
 			"description": "Trigger a configuration reload (equivalent to SIGHUP)"
 		},
 		{
-			"method": "POST",
-			"path": "/alert",
-			"description": "Trigger a custom HTTP alert with JSON payload"
-		},
-		{
 			"method": "GET",
 			"path": "/alerts",
 			"description": "List currently loaded alert files"

--- a/crates/alertd/src/http_server/endpoints/validate.rs
+++ b/crates/alertd/src/http_server/endpoints/validate.rs
@@ -153,7 +153,7 @@ send:
 	#[tokio::test]
 	async fn test_validate_event_alert() {
 		let yaml = r#"
-event: http
+event: source-error
 send:
   - id: test
     subject: Test

--- a/crates/alertd/src/http_server/types.rs
+++ b/crates/alertd/src/http_server/types.rs
@@ -9,15 +9,6 @@ pub struct StatusResponse {
 }
 
 #[derive(Deserialize)]
-pub struct AlertRequest {
-	pub message: String,
-	#[serde(default)]
-	pub subject: Option<String>,
-	#[serde(flatten)]
-	pub custom: serde_json::Value,
-}
-
-#[derive(Deserialize)]
 pub struct PauseAlertRequest {
 	pub alert: String,
 	pub until: String,

--- a/crates/bestool/src/actions/tamanu/doctor/checks/fhir_jobs.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/checks/fhir_jobs.rs
@@ -18,6 +18,11 @@ const WARN_OLDEST_SECS: i64 = 10 * 60; // 10m
 const FAIL_OLDEST_SECS: i64 = 60 * 60; // 1h
 
 pub async fn run(ctx: CheckContext) -> Check {
+	if ctx.config.is_facility() {
+		return Check::pass("fhir_jobs", "not applicable on facility server")
+			.with_detail("skipped", true);
+	}
+
 	let Some(client) = ctx.db.as_deref() else {
 		return Check::fail("fhir_jobs", "no DB connection", "db_connect failed");
 	};

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -92,7 +92,7 @@ impl DownloadSource {
 			.lookup_ip(match self {
 				Self::Tools => "bestool-proxy-tools",
 				Self::Servers => "bestool-proxy-servers",
-				Self::Meta => "tamanu-meta-prod-disabled",
+				Self::Meta => return Vec::new(),
 			})
 			.await
 			.ok()


### PR DESCRIPTION
Disables the fhir_jobs healthcheck when running on a facility server.