### PR TITLE
fix(ci): stop release-plz filtering all commits out

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,4 @@
 [workspace]
-release_always = false
-release_commits = "^repo: release"
 pr_name = "repo: release"
 pr_branch_prefix = "release-plz/"
 pr_labels = ["autorelease"]


### PR DESCRIPTION
## Summary

The config in #327 set \`release_commits = \"^repo: release\"\`, which I mistakenly thought gated *when* release-plz publishes. It actually filters *which commits* release-plz considers at all — for both \`release\` and \`release-pr\`. With it set to that regex, no real commits ever match (only release-plz's own bump commits would), so \`release-pr\` walks the history, finds zero relevant commits per crate, and opens no PRs. Observed output: \`release_pr_output: {\"prs\":[]}\`.

Fix: drop \`release_commits\` and \`release_always\`. With both unset, release-plz considers every commit and tries to release on every push to \`main\`. The publish step is naturally idempotent — it only publishes Cargo.toml versions that aren't already on crates.io — so the \"only publish after the bump-PR merges\" behaviour comes from the version diff, not from commit-message gating.