### PR TITLE
repo: clean up cargo-release leftovers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The following types are conventional:
 - `tweak` for minor changes that do not fit into any other category
 - `wip` or `draft` for features committed in a half-working state (must be feature-gated)
 
-This list is informational, the authoritative list is in the [git-cliff config](./cliff.toml).
+This list is informational.
 
 Additional change lines can be added to the body of a commit message.
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ See `bestool <subcommand> --help` for extensive help.
 
 ## Download
 
-Current release: 1.8.2
-
 | Platform | Variant | Download |
 | -------- | ------- | -------- |
-| Windows | x86 | [bestool.exe](https://tools.ops.tamanu.io/bestool/1.8.2/x86_64-pc-windows-msvc/bestool.exe) |
-| Linux | x86 | [bestool](https://tools.ops.tamanu.io/bestool/1.8.2/x86_64-unknown-linux-gnu/bestool) |
-| Linux | x86 static | [bestool](https://tools.ops.tamanu.io/bestool/1.8.2/x86_64-unknown-linux-musl/bestool) |
-| Linux | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/1.8.2/aarch64-unknown-linux-musl/bestool) |
-| Mac | Intel | [bestool](https://tools.ops.tamanu.io/bestool/1.8.2/x86_64-apple-darwin/bestool) |
-| Mac | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/1.8.2/aarch64-apple-darwin/bestool) |
+| Windows | x86 | [bestool.exe](https://tools.ops.tamanu.io/bestool/latest/x86_64-pc-windows-msvc/bestool.exe) |
+| Linux | x86 | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-gnu/bestool) |
+| Linux | x86 static | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-musl/bestool) |
+| Linux | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/latest/aarch64-unknown-linux-musl/bestool) |
+| Mac | Intel | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-apple-darwin/bestool) |
+| Mac | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/latest/aarch64-apple-darwin/bestool) |
+
+These URLs always point to the latest release. Pin to a specific version with `https://tools.ops.tamanu.io/bestool/<version>/<target>/bestool`.
 
 ### Self-update
 
@@ -37,19 +37,6 @@ echo "deb [signed-by=/etc/apt/keyrings/bes-tools.gpg] https://tools.ops.tamanu.i
 sudo apt-get update
 sudo apt-get install bestool
 ```
-
-### Always-latest URLs
-
-The above URLs are for the current release. If you want to always get the latest version, you can use the following URLs:
-
-| Platform | Variant | Download |
-| -------- | ------- | -------- |
-| Windows | x86 | [bestool.exe](https://tools.ops.tamanu.io/bestool/latest/x86_64-pc-windows-msvc/bestool.exe) |
-| Linux | x86 | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-gnu/bestool) |
-| Linux | x86 static | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-musl/bestool) |
-| Linux | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/latest/aarch64-unknown-linux-musl/bestool) |
-| Mac | Intel | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-apple-darwin/bestool) |
-| Mac | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/latest/aarch64-apple-darwin/bestool) |
 
 ### In GitHub Actions
 
@@ -114,16 +101,7 @@ $ cargo build --release
 ```
 
 Commits should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
-Types are listed in the [cliff.toml](./cliff.toml#L62-L78) file.
 
 ### Releasing
 
-To make a release, install [cargo-release](https://github.com/crate-ci/cargo-release) and [git-cliff](https://git-cliff.org/), then:
-
-```console
-$ git switch main
-$ git pull
-$ cargo release minor --execute
-```
-
-(or `patch` or `major` instead of `minor`)
+Releases are automated by [release-plz](https://release-plz.dev). Pushing to `main` opens a `repo: release` PR with per-crate version bumps determined from conventional commits and `cargo-semver-checks`; merging that PR (auto-merge is enabled once CI is green) publishes the affected crates to crates.io, pushes per-crate tags, and triggers the binary-build workflows.

--- a/crates/algae-cli/release.toml
+++ b/crates/algae-cli/release.toml
@@ -1,1 +1,0 @@
-publish = true

--- a/crates/bestool/release.toml
+++ b/crates/bestool/release.toml
@@ -1,7 +1,0 @@
-publish = true
-tag-name = "v{{version}}"
-pre-release-hook = ["git", "cliff", "-r", "../..", "-c", "../../cliff.toml", "-o", "../../CHANGELOG.md", "--tag", "{{version}}"]
-pre-release-replacements = [
-  { file = "../../README.md", search = "Current release: [0-9\\.]+", replace = "Current release: {{version}}"},
-  { file = "../../README.md", search = "https://tools.ops.tamanu.io/bestool/[0-9\\.]+/", replace = "https://tools.ops.tamanu.io/bestool/{{version}}/"},
-]

--- a/crates/rpi-st7789v2-driver/release.toml
+++ b/crates/rpi-st7789v2-driver/release.toml
@@ -1,1 +1,0 @@
-publish = true


### PR DESCRIPTION
## Summary

Follow-up to #327: the per-crate \`release.toml\` files and a handful of README/CONTRIBUTING references to the old cargo-release flow were left behind. They're inert under release-plz but caused the README's \`Current release: 1.8.2\` line and versioned download URLs to freeze.

- Delete \`crates/bestool/release.toml\` (the one with the README \`pre-release-replacements\`), \`crates/algae-cli/release.toml\`, and \`crates/rpi-st7789v2-driver/release.toml\` (the latter two only set \`publish = true\`, which is the default).
- Drop the versioned download table from \`README.md\`. The \`/latest/\` URLs already served the same purpose under a separate heading; promote them and add a line about pinning to a specific version manually.
- Rewrite the README's \"Releasing\" section to describe the release-plz auto-flow instead of the \`cargo release minor --execute\` recipe.
- Remove dead links to \`cliff.toml\` from \`README.md\` and \`CONTRIBUTING.md\`.