### PR TITLE
fix(ci): match GH release name to bestool tag

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,3 +8,4 @@ git_tag_name = "{{ package }}-v{{ version }}"
 [[package]]
 name = "bestool"
 git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"


### PR DESCRIPTION
The bestool override only set \`git_tag_name = \"v{{ version }}\"\`, so the git tag came out as \`v1.9.0\` (correct), but the GitHub Release fell back to the workspace default name \`{{ package }}-v{{ version }}\` and ended up as \`bestool-v1.9.0\`. Add a matching \`git_release_name\` override so the release page is named to match the tag.

Existing \`bestool-v1.9.0\` release can be renamed in the GH UI as a one-off; this stops the drift from happening again.