### PR TITLE
repo: exclude dev-only files from packaged crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ members = [
 	"crates/rpi-st7789v2-driver",
 ]
 
+[workspace.package]
+exclude = ["release.toml", "update-usage.sh"]
+
 [workspace.lints.rust]
 unsafe_code = "forbid"
 rust_2018_idioms = { level = "deny", priority = -1 }

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes
 license = "GPL-3.0-or-later"
 description = "(Internal) BES tooling: Alert daemon"
 repository = "https://github.com/beyondessential/bestool/tree/main/crates/alertd"
+exclude.workspace = true
 
 [lints]
 workspace = true

--- a/crates/algae-cli/Cargo.toml
+++ b/crates/algae-cli/Cargo.toml
@@ -10,6 +10,7 @@ description = "Lightweight age profile for user-friendly encryption (CLI tool an
 keywords = ["age", "cryptography", "encryption"]
 categories = ["command-line-utilities"]
 repository = "https://github.com/beyondessential/bestool/tree/main/crates/algae-cli"
+exclude.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -10,6 +10,7 @@ description = "BES Deployment tooling"
 keywords = ["bes", "tamanu", "tupaia"]
 categories = ["command-line-utilities"]
 repository = "https://github.com/beyondessential/bestool"
+exclude.workspace = true
 
 [lints]
 workspace = true

--- a/crates/postgres/Cargo.toml
+++ b/crates/postgres/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes
 license = "GPL-3.0-or-later"
 description = "PostgreSQL connection pool utilities for BES tooling"
 repository = "https://github.com/beyondessential/bestool/tree/main/crates/postgres"
+exclude.workspace = true
 
 [lints]
 workspace = true

--- a/crates/psql/Cargo.toml
+++ b/crates/psql/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes
 license = "GPL-3.0-or-later"
 description = "psql-inspired client for PostgreSQL"
 repository = "https://github.com/beyondessential/bestool/tree/main/crates/psql"
+exclude.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rpi-st7789v2-driver/Cargo.toml
+++ b/crates/rpi-st7789v2-driver/Cargo.toml
@@ -11,6 +11,7 @@ description = "Raspberry-Pi driver for the ST7789V2 TFT display controller (Wave
 keywords = ["embedded-graphics", "waveshare", "st7789v2", "lcd", "raspberry-pi"]
 categories = ["embedded", "hardware-support"]
 repository = "https://github.com/beyondessential/bestool"
+exclude.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Follows from #330 (which deleted three `release.toml` files) and the spurious release PR that came right after (#331): release-plz sees per-crate file changes via Cargo's packaged-files list, so a deletion inside a crate directory counts as a real change even when the file was dev-only config. That produced patch bumps for `algae-cli` and `rpi-st7789v2-driver` whose entire diff-since-tag was the `release.toml` removal.

Treat dev-only files as workspace-wide non-package files via Cargo's `exclude`:

- Add `[workspace.package] exclude = ["release.toml", "update-usage.sh"]` at workspace level.
- Each crate inherits via `exclude.workspace = true` so future crates added to the workspace pick it up.

Files in the exclude list:

- `release.toml` — cargo-release config, never useful to ship.
- `update-usage.sh` — currently only present in `crates/alertd/` as a small shim around the workspace script; dev tooling.