### PR TITLE
refactor(actions): make Context a type-keyed extensions map

### DIFF
--- a/crates/bestool/src/actions.rs
+++ b/crates/bestool/src/actions.rs
@@ -5,10 +5,21 @@ use tracing::{debug, trace};
 pub use context::Context;
 pub mod context;
 
+/// Wire up a subcommand level.
+///
+/// Generates an `Action` enum (one variant per subcommand), and a `run(args,
+/// ctx)` dispatcher. The `prep` closure runs before dispatch: it returns the
+/// chosen `Action` along with a `Context` that has been populated with this
+/// level's args (and anything else the level wants to provide). Each variant
+/// then dispatches to `<modname>::run(sub_args, ctx)`.
+///
+/// Every level uses the same `(args, ctx)` signature, so contexts compose
+/// across arbitrary nesting depth and downstream handlers can extract any
+/// ancestor's args by type via `ctx.require::<T>()`.
 #[macro_export]
 macro_rules! subcommands {
 	(
-		[$argtype:ty => $ctxcode:block]($ctxmethod:ident)
+		[$argtype:ty => $prep:expr]
 		$(
 			$(#[cfg($cfg:meta)])*
 			$(#[clap($clap:meta)])*
@@ -29,12 +40,13 @@ macro_rules! subcommands {
 			)*
 		}
 
-		pub async fn run(ctx: $argtype) -> Result<()> {
-			let ctxfn = $ctxcode;
-			match ctxfn(ctx)? {
+		pub async fn run(args: $argtype, ctx: Context) -> Result<()> {
+			let prep = $prep;
+			let (action, ctx) = prep(args, ctx)?;
+			match action {
 				$(
 					$(#[cfg($cfg)])*
-					(Action::$enumname(args), ctx) => $modname::run(ctx.$ctxmethod(args)).await,
+					Action::$enumname(args) => $modname::run(args, ctx).await,
 				)*
 			}
 		}
@@ -46,11 +58,13 @@ pub use subcommands;
 use crate::args::Args;
 
 subcommands! {
-	[Args => {|args: Args| -> Result<(Action, Context<Args>)> {
+	[Args => |args: Args, mut ctx: Context| -> Result<(Action, Context)> {
 		debug!(version=%env!("CARGO_PKG_VERSION"), "starting up");
 		trace!(action=?args.action, "action");
-		Ok((args.action.clone(), Context::new().with_top(args)))
-	}}](with_sub)
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
 
 	#[cfg(feature = "tamanu-psql")]
 	audit_psql => AuditPsql(AuditPsqlArgs),
@@ -90,5 +104,5 @@ pub async fn run_with_update_check(args: Args) -> Result<()> {
 		debug!("Failed to check for updates: {}", err);
 	}
 
-	run(args).await
+	run(args, Context::new()).await
 }

--- a/crates/bestool/src/actions/audit_psql.rs
+++ b/crates/bestool/src/actions/audit_psql.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use miette::Result;
 
 use crate::actions::Context;
-use crate::args::Args;
 
 /// Export audit database entries as JSON.
 #[derive(Debug, Clone, Parser)]
@@ -42,9 +41,7 @@ fn help_audit_path() -> String {
 	)
 }
 
-pub async fn run(ctx: Context<Args, AuditPsqlArgs>) -> Result<()> {
-	let args = ctx.args_sub;
-
+pub async fn run(args: AuditPsqlArgs, _ctx: Context) -> Result<()> {
 	let options = ExportOptions {
 		audit_path: args.audit_path,
 		query_options: QueryOptions {

--- a/crates/bestool/src/actions/caddy.rs
+++ b/crates/bestool/src/actions/caddy.rs
@@ -1,8 +1,6 @@
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-use crate::args::Args;
-
 use super::Context;
 
 pub mod configure_tamanu;
@@ -22,9 +20,11 @@ pub enum CaddyAction {
 	Download(download::DownloadArgs),
 }
 
-pub async fn run(ctx: Context<Args, CaddyArgs>) -> Result<()> {
-	match ctx.args_sub.action.clone() {
-		CaddyAction::ConfigureTamanu(subargs) => configure_tamanu::run(ctx.push(subargs)).await,
-		CaddyAction::Download(subargs) => download::run(ctx.push(subargs)).await,
+pub async fn run(args: CaddyArgs, mut ctx: Context) -> Result<()> {
+	let action = args.action.clone();
+	ctx.provide(args);
+	match action {
+		CaddyAction::ConfigureTamanu(subargs) => configure_tamanu::run(subargs, ctx).await,
+		CaddyAction::Download(subargs) => download::run(subargs, ctx).await,
 	}
 }

--- a/crates/bestool/src/actions/caddy/configure_tamanu.rs
+++ b/crates/bestool/src/actions/caddy/configure_tamanu.rs
@@ -8,8 +8,6 @@ use tracing::info;
 
 use crate::actions::Context;
 
-use super::CaddyArgs;
-
 const CADDYFILE_TEMPLATE: &str = include_str!("tamanu.Caddyfile.tera");
 #[test]
 fn test_caddyfile_template() {
@@ -63,7 +61,7 @@ pub struct ConfigureTamanuArgs {
 	pub zerossl_api_key: Option<String>,
 }
 
-pub async fn run(ctx: Context<CaddyArgs, ConfigureTamanuArgs>) -> Result<()> {
+pub async fn run(args: ConfigureTamanuArgs, _ctx: Context) -> Result<()> {
 	let ConfigureTamanuArgs {
 		path,
 		print,
@@ -73,7 +71,7 @@ pub async fn run(ctx: Context<CaddyArgs, ConfigureTamanuArgs>) -> Result<()> {
 		web_version,
 		email,
 		zerossl_api_key,
-	} = ctx.args_sub;
+	} = args;
 
 	let mut tera = Tera::default();
 	tera.add_raw_template("Caddyfile", CADDYFILE_TEMPLATE)

--- a/crates/bestool/src/actions/caddy/download.rs
+++ b/crates/bestool/src/actions/caddy/download.rs
@@ -11,8 +11,6 @@ use crate::{
 	download::{DownloadSource, client},
 };
 
-use super::CaddyArgs;
-
 /// Download caddy.
 #[derive(Debug, Clone, Parser)]
 pub struct DownloadArgs {
@@ -37,13 +35,13 @@ pub struct DownloadArgs {
 	pub target: Option<String>,
 }
 
-pub async fn run(ctx: Context<CaddyArgs, DownloadArgs>) -> Result<()> {
+pub async fn run(args: DownloadArgs, _ctx: Context) -> Result<()> {
 	let DownloadArgs {
 		version,
 		path,
 		url_only,
 		target,
-	} = ctx.args_sub;
+	} = args;
 
 	let detected_targets = get_desired_targets(target.map(|t| vec![t]));
 	let detected_targets = detected_targets.get().await;

--- a/crates/bestool/src/actions/completions.rs
+++ b/crates/bestool/src/actions/completions.rs
@@ -3,8 +3,6 @@ use clap_complete::{Generator, Shell};
 
 use miette::Result;
 
-use crate::args::Args;
-
 use super::Context;
 
 /// Generate a shell completions script.
@@ -38,7 +36,7 @@ pub enum ShellCompletion {
 	Zsh,
 }
 
-pub async fn run(ctx: Context<Args, CompletionsArgs>) -> Result<()> {
+pub async fn run(args: CompletionsArgs, _ctx: Context) -> Result<()> {
 	fn generate(generator: impl Generator) {
 		let mut cmd = crate::args::Args::command();
 		clap_complete::generate(
@@ -49,7 +47,7 @@ pub async fn run(ctx: Context<Args, CompletionsArgs>) -> Result<()> {
 		);
 	}
 
-	match ctx.args_sub.shell {
+	match args.shell {
 		ShellCompletion::Bash => generate(Shell::Bash),
 		ShellCompletion::Elvish => generate(Shell::Elvish),
 		ShellCompletion::Fish => generate(Shell::Fish),

--- a/crates/bestool/src/actions/context.rs
+++ b/crates/bestool/src/actions/context.rs
@@ -1,55 +1,117 @@
-#[derive(Clone, Debug)]
-pub struct Context<A = (), B = ()> {
-	pub args_top: A,
-	pub args_sub: B,
+//! Subcommand-handler context: a type-keyed extensions map.
+//!
+//! Every subcommand level provides its own args struct into the context, and
+//! leaf handlers extract whichever ancestors they need by type. This mirrors
+//! the provider/consumer pattern used by HTTP frameworks like axum, and frees
+//! us from carrying the parent type around in the handler's signature.
+//!
+//! Example:
+//!
+//! ```ignore
+//! pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
+//!     let tamanu: &TamanuArgs = ctx.require();
+//!     let top: &Args = ctx.require();
+//!     ...
+//! }
+//! ```
+//!
+//! ## Provider contract
+//!
+//! The `subcommands!` macro inserts each level's args struct into the context
+//! before dispatching, so leaf handlers can rely on every ancestor being
+//! present. Inserting the same type twice replaces the earlier value (useful
+//! when a level wants to override something from above).
+//!
+//! `require::<T>()` panics if a type wasn't provided; `get::<T>()` returns
+//! `Option`. Prefer `require` in handler bodies — a missing ancestor is a
+//! bug, not a user error.
+
+use std::{
+	any::{Any, TypeId, type_name},
+	collections::HashMap,
+	sync::Arc,
+};
+
+/// Type-keyed bag of values, threaded through subcommand dispatch.
+#[derive(Clone, Default)]
+pub struct Context {
+	items: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
 }
 
 impl Context {
 	pub fn new() -> Self {
-		Self {
-			args_top: (),
-			args_sub: (),
-		}
+		Self::default()
+	}
+
+	/// Insert a value, replacing any earlier value of the same type.
+	pub fn provide<T: Send + Sync + 'static>(&mut self, value: T) -> &mut Self {
+		self.items.insert(TypeId::of::<T>(), Arc::new(value));
+		self
+	}
+
+	/// Borrow a previously provided value. Returns `None` if absent.
+	pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
+		self.items
+			.get(&TypeId::of::<T>())
+			.and_then(|v| v.downcast_ref::<T>())
+	}
+
+	/// Borrow a previously provided value. Panics if absent — use when the
+	/// macro contract guarantees the type is present.
+	pub fn require<T: Send + Sync + 'static>(&self) -> &T {
+		self.get::<T>().unwrap_or_else(|| {
+			panic!(
+				"Context: required value of type `{}` not provided",
+				type_name::<T>()
+			)
+		})
 	}
 }
 
-#[allow(dead_code)] // due to command features
-impl<A, B> Context<A, B> {
-	pub fn with_top<C>(self, args_top: C) -> Context<C, B> {
-		Context::<C, B> {
-			args_top,
-			args_sub: self.args_sub,
-		}
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[derive(Debug, PartialEq, Eq)]
+	struct A(u32);
+	#[derive(Debug, PartialEq, Eq)]
+	struct B(&'static str);
+
+	#[test]
+	fn provide_and_get() {
+		let mut ctx = Context::new();
+		ctx.provide(A(42));
+		ctx.provide(B("hi"));
+		assert_eq!(ctx.get::<A>(), Some(&A(42)));
+		assert_eq!(ctx.get::<B>(), Some(&B("hi")));
 	}
 
-	pub fn with_sub<C>(self, args_sub: C) -> Context<A, C> {
-		Context::<A, C> {
-			args_top: self.args_top,
-			args_sub,
-		}
+	#[test]
+	fn provide_replaces() {
+		let mut ctx = Context::new();
+		ctx.provide(A(1));
+		ctx.provide(A(2));
+		assert_eq!(ctx.require::<A>(), &A(2));
 	}
 
-	pub fn push<C>(self, new_sub: C) -> Context<B, C> {
-		Context::<B, C> {
-			args_top: self.args_sub,
-			args_sub: new_sub,
-		}
+	#[test]
+	fn missing_returns_none() {
+		let ctx = Context::new();
+		assert!(ctx.get::<A>().is_none());
 	}
 
-	pub fn take_top(self) -> (A, Context<(), B>) {
-		(
-			self.args_top,
-			Context::<(), B> {
-				args_top: (),
-				args_sub: self.args_sub,
-			},
-		)
+	#[test]
+	#[should_panic(expected = "required value of type")]
+	fn require_panics_when_missing() {
+		let ctx = Context::new();
+		let _: &A = ctx.require();
 	}
 
-	pub fn erased(&self) -> Context<(), ()> {
-		Context::<(), ()> {
-			args_top: (),
-			args_sub: (),
-		}
+	#[test]
+	fn clone_shares_arcs() {
+		let mut ctx = Context::new();
+		ctx.provide(A(7));
+		let cloned = ctx.clone();
+		assert_eq!(cloned.require::<A>(), &A(7));
 	}
 }

--- a/crates/bestool/src/actions/crypto.rs
+++ b/crates/bestool/src/actions/crypto.rs
@@ -1,8 +1,6 @@
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-use crate::args::Args;
-
 use super::Context;
 
 /// Cryptographic operations.
@@ -14,9 +12,11 @@ pub struct CryptoArgs {
 }
 
 super::subcommands! {
-	[Context<Args, CryptoArgs> => {|ctx: Context<Args, CryptoArgs>| -> Result<(Action, Context<CryptoArgs>)> {
-		Ok((ctx.args_sub.action.clone(), ctx.push(())))
-	}}](with_sub)
+	[CryptoArgs => |args: CryptoArgs, mut ctx: Context| -> Result<(Action, Context)> {
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
 
 	decrypt => Decrypt(DecryptArgs),
 	encrypt => Encrypt(EncryptArgs),

--- a/crates/bestool/src/actions/crypto/decrypt.rs
+++ b/crates/bestool/src/actions/crypto/decrypt.rs
@@ -1,9 +1,8 @@
 pub use algae_cli::cli::decrypt::{self, DecryptArgs};
 use miette::Result;
 
-use super::CryptoArgs;
 use crate::actions::Context;
 
-pub async fn run(ctx: Context<CryptoArgs, DecryptArgs>) -> Result<()> {
-	decrypt::run(ctx.args_sub).await
+pub async fn run(args: DecryptArgs, _ctx: Context) -> Result<()> {
+	decrypt::run(args).await
 }

--- a/crates/bestool/src/actions/crypto/encrypt.rs
+++ b/crates/bestool/src/actions/crypto/encrypt.rs
@@ -1,9 +1,8 @@
 pub use algae_cli::cli::encrypt::{self, EncryptArgs};
 use miette::Result;
 
-use super::CryptoArgs;
 use crate::actions::Context;
 
-pub async fn run(ctx: Context<CryptoArgs, EncryptArgs>) -> Result<()> {
-	encrypt::run(ctx.args_sub).await
+pub async fn run(args: EncryptArgs, _ctx: Context) -> Result<()> {
+	encrypt::run(args).await
 }

--- a/crates/bestool/src/actions/crypto/hash.rs
+++ b/crates/bestool/src/actions/crypto/hash.rs
@@ -10,7 +10,7 @@ use merkle_hash::{bytes_to_hex, Algorithm, MerkleTree};
 use miette::{bail, miette, Context as _, IntoDiagnostic, Result};
 use tracing::{debug, instrument};
 
-use super::{Context, CryptoArgs};
+use super::Context;
 
 /// Checksum files and folders.
 ///
@@ -34,12 +34,12 @@ pub struct HashArgs {
 	pub no_filenames: bool,
 }
 
-pub async fn run(ctx: Context<CryptoArgs, HashArgs>) -> Result<()> {
+pub async fn run(args: HashArgs, _ctx: Context) -> Result<()> {
 	let HashArgs {
 		paths,
 		checks,
 		no_filenames,
-	} = ctx.args_sub;
+	} = args;
 
 	let mut mismatches = 0;
 

--- a/crates/bestool/src/actions/crypto/keygen.rs
+++ b/crates/bestool/src/actions/crypto/keygen.rs
@@ -1,9 +1,8 @@
 pub use algae_cli::cli::keygen::{self, KeygenArgs};
 use miette::Result;
 
-use super::CryptoArgs;
 use crate::actions::Context;
 
-pub async fn run(ctx: Context<CryptoArgs, KeygenArgs>) -> Result<()> {
-	keygen::run(ctx.args_sub).await
+pub async fn run(args: KeygenArgs, _ctx: Context) -> Result<()> {
+	keygen::run(args).await
 }

--- a/crates/bestool/src/actions/crypto/protect.rs
+++ b/crates/bestool/src/actions/crypto/protect.rs
@@ -1,9 +1,8 @@
 pub use algae_cli::cli::protect::{self, ProtectArgs};
 use miette::Result;
 
-use super::CryptoArgs;
 use crate::actions::Context;
 
-pub async fn run(ctx: Context<CryptoArgs, ProtectArgs>) -> Result<()> {
-	protect::run(ctx.args_sub).await
+pub async fn run(args: ProtectArgs, _ctx: Context) -> Result<()> {
+	protect::run(args).await
 }

--- a/crates/bestool/src/actions/crypto/reveal.rs
+++ b/crates/bestool/src/actions/crypto/reveal.rs
@@ -1,9 +1,8 @@
 pub use algae_cli::cli::reveal::{self, RevealArgs};
 use miette::Result;
 
-use super::CryptoArgs;
 use crate::actions::Context;
 
-pub async fn run(ctx: Context<CryptoArgs, RevealArgs>) -> Result<()> {
-	reveal::run(ctx.args_sub).await
+pub async fn run(args: RevealArgs, _ctx: Context) -> Result<()> {
+	reveal::run(args).await
 }

--- a/crates/bestool/src/actions/docs.rs
+++ b/crates/bestool/src/actions/docs.rs
@@ -9,7 +9,7 @@ use super::Context;
 #[derive(Debug, Clone, Parser)]
 pub struct DocsArgs {}
 
-pub async fn run(_ctx: Context<Args, DocsArgs>) -> Result<()> {
+pub async fn run(_args: DocsArgs, _ctx: Context) -> Result<()> {
 	let markdown = clap_markdown::help_markdown::<Args>();
 	println!("{}", markdown);
 	Ok(())

--- a/crates/bestool/src/actions/file.rs
+++ b/crates/bestool/src/actions/file.rs
@@ -1,8 +1,6 @@
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-use crate::args::Args;
-
 use super::Context;
 
 /// File utilities.
@@ -14,9 +12,11 @@ pub struct FileArgs {
 }
 
 super::subcommands! {
-	[Context<Args, FileArgs> => {|ctx: Context<Args, FileArgs>| -> Result<(Action, Context<FileArgs>)> {
-		Ok((ctx.args_sub.action.clone(), ctx.push(())))
-	}}](with_sub)
+	[FileArgs => |args: FileArgs, mut ctx: Context| -> Result<(Action, Context)> {
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
 
 	join => Join(JoinArgs),
 	split => Split(SplitArgs)

--- a/crates/bestool/src/actions/file/join.rs
+++ b/crates/bestool/src/actions/file/join.rs
@@ -18,7 +18,7 @@ use tokio::{
 use tokio_util::io::{ReaderStream, StreamReader};
 use tracing::{error, info, instrument};
 
-use super::{split::ChunkedMetadata, Context, FileArgs};
+use super::{split::ChunkedMetadata, Context};
 
 /// Join a split file.
 ///
@@ -46,8 +46,8 @@ pub struct JoinArgs {
 	pub output: Option<PathBuf>,
 }
 
-pub async fn run(ctx: Context<FileArgs, JoinArgs>) -> Result<()> {
-	let JoinArgs { input, output } = ctx.args_sub;
+pub async fn run(args: JoinArgs, _ctx: Context) -> Result<()> {
+	let JoinArgs { input, output } = args;
 
 	let meta = parse_metadata(&input).await?;
 

--- a/crates/bestool/src/actions/file/split.rs
+++ b/crates/bestool/src/actions/file/split.rs
@@ -24,7 +24,7 @@ use tokio::{
 use tokio_util::io::InspectReader;
 use tracing::{debug, instrument};
 
-use super::{Context, FileArgs};
+use super::Context;
 
 /// Split a file into fixed-size chunks.
 ///
@@ -65,12 +65,12 @@ pub struct SplitArgs {
 	pub size: Option<NonZero<u16>>,
 }
 
-pub async fn run(ctx: Context<FileArgs, SplitArgs>) -> Result<()> {
+pub async fn run(args: SplitArgs, _ctx: Context) -> Result<()> {
 	let SplitArgs {
 		input,
 		output,
 		size,
-	} = ctx.args_sub;
+	} = args;
 
 	let chunk_size = size.map(ChunkSize::Mib).unwrap_or_default();
 	copy_into_chunks(&input, &output, chunk_size).await

--- a/crates/bestool/src/actions/iti.rs
+++ b/crates/bestool/src/actions/iti.rs
@@ -3,8 +3,6 @@ use std::time::Duration;
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-use crate::args::Args;
-
 use super::Context;
 
 pub(crate) fn parse_friendly_duration(s: &str) -> Result<Duration, String> {
@@ -21,9 +19,11 @@ pub struct ItiArgs {
 }
 
 super::subcommands! {
-	[Context<Args, ItiArgs> => {|ctx: Context<Args, ItiArgs>| -> Result<(Action, Context<ItiArgs>)> {
-		Ok((ctx.args_sub.action.clone(), ctx.push(())))
-	}}](with_sub)
+	[ItiArgs => |args: ItiArgs, mut ctx: Context| -> Result<(Action, Context)> {
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
 
 	#[cfg(feature = "iti-battery")]
 	battery => Battery(BatteryArgs),

--- a/crates/bestool/src/actions/iti/battery.rs
+++ b/crates/bestool/src/actions/iti/battery.rs
@@ -7,7 +7,7 @@ use tokio::time::sleep;
 use tracing::instrument;
 
 use crate::actions::{
-	iti::{ItiArgs, lcd::{
+	iti::{lcd::{
 		json::{Item, Screen},
 		send,
 	}, parse_friendly_duration},
@@ -70,11 +70,11 @@ pub struct BatteryArgs {
 	pub estimate: bool,
 }
 
-pub async fn run(ctx: Context<ItiArgs, BatteryArgs>) -> Result<()> {
-	if let Some(n) = ctx.args_sub.watch {
+pub async fn run(args: BatteryArgs, _ctx: Context) -> Result<()> {
+	if let Some(n) = args.watch {
 		// gather info only for initial round
-		let mut rolling = if ctx.args_sub.estimate {
-			let first = once(ctx.clone(), None).await?;
+		let mut rolling = if args.estimate {
+			let first = once(&args, None).await?;
 			sleep(n).await;
 			Some(VecDeque::from([first]))
 		} else {
@@ -82,17 +82,17 @@ pub async fn run(ctx: Context<ItiArgs, BatteryArgs>) -> Result<()> {
 		};
 
 		loop {
-			once(ctx.clone(), rolling.as_mut()).await?;
+			once(&args, rolling.as_mut()).await?;
 			sleep(n).await;
 		}
 	} else {
-		once(ctx, None).await?;
+		once(&args, None).await?;
 	}
 
 	Ok(())
 }
 
-pub async fn once(ctx: Context<ItiArgs, BatteryArgs>, rolling: Option<&mut VecDeque<f64>>) -> Result<f64> {
+pub async fn once(args: &BatteryArgs, rolling: Option<&mut VecDeque<f64>>) -> Result<f64> {
 	let gpio = Gpio::new().into_diagnostic().wrap_err("gpio: init")?;
 	let powered = gpio
 		.get(6)
@@ -132,7 +132,7 @@ pub async fn once(ctx: Context<ItiArgs, BatteryArgs>, rolling: Option<&mut VecDe
 			.unwrap_or(rolling.len() - 1);
 
 		let mut rate = (capacity - rolling.get(index_to_first_difference).unwrap_or(&capacity))
-			/ ((rolling.len() as u64 * ctx.args_sub.watch.unwrap().as_secs()) as f64);
+			/ ((rolling.len() as u64 * args.watch.unwrap().as_secs()) as f64);
 		let capacity_left = if rate > 0.0 {
 			(100.0 - capacity).abs()
 		} else {
@@ -200,7 +200,7 @@ pub async fn once(ctx: Context<ItiArgs, BatteryArgs>, rolling: Option<&mut VecDe
 		}
 	};
 
-	if ctx.args_sub.json {
+	if args.json {
 		if let Some((rate, ref time_remaining)) = estimates {
 			println!(
 				"{}",
@@ -233,7 +233,7 @@ pub async fn once(ctx: Context<ItiArgs, BatteryArgs>, rolling: Option<&mut VecDe
 	}
 
 	#[cfg(feature = "iti-lcd")]
-	if let Some(y) = ctx.args_sub.update_screen {
+	if let Some(y) = args.update_screen {
 		const GREEN: [u8; 3] = [0, 255, 0];
 		const RED: [u8; 3] = [255, 0, 0];
 		const BLACK: [u8; 3] = [0, 0, 0];
@@ -300,7 +300,7 @@ pub async fn once(ctx: Context<ItiArgs, BatteryArgs>, rolling: Option<&mut VecDe
 			},
 		);
 
-		send(&ctx.args_sub.zmq_socket, Screen::Layout(items))?;
+		send(&args.zmq_socket, Screen::Layout(items))?;
 	}
 
 	Ok(capacity)

--- a/crates/bestool/src/actions/iti/improv_wifi.rs
+++ b/crates/bestool/src/actions/iti/improv_wifi.rs
@@ -13,7 +13,7 @@ use tokio::{
 };
 use tracing::{debug, info, warn};
 
-use crate::actions::{Context, iti::ItiArgs};
+use crate::actions::Context;
 
 /// Run the Improv-Wi-Fi BLE peripheral so a phone or browser can provision the device's Wi-Fi.
 ///
@@ -99,8 +99,7 @@ pub struct ImprovWifiArgs {
 	pub one_shot: bool,
 }
 
-pub async fn run(ctx: Context<ItiArgs, ImprovWifiArgs>) -> Result<()> {
-	let args = ctx.args_sub;
+pub async fn run(args: ImprovWifiArgs, _ctx: Context) -> Result<()> {
 
 	let connection = Connection::system()
 		.await

--- a/crates/bestool/src/actions/iti/lcd.rs
+++ b/crates/bestool/src/actions/iti/lcd.rs
@@ -13,7 +13,6 @@ use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use rpi_st7789v2_driver::{DriverArgs, Driver};
 use tracing::{error, info, instrument, trace};
 
-use super::ItiArgs;
 use crate::actions::Context;
 
 pub mod json;
@@ -141,10 +140,10 @@ pub enum LcdAction {
 	Off,
 }
 
-pub async fn run(ctx: Context<ItiArgs, LcdArgs>) -> Result<()> {
+pub async fn run(args: LcdArgs, _ctx: Context) -> Result<()> {
 	use LcdAction::*;
-	match ctx.args_sub.action.clone() {
-		Serve => serve(ctx),
+	match args.action.clone() {
+		Serve => serve(args),
 		Send { message } => {
 			let screen = serde_json::from_str(&message.unwrap_or_else(|| {
 				let mut buf = String::new();
@@ -153,16 +152,16 @@ pub async fn run(ctx: Context<ItiArgs, LcdArgs>) -> Result<()> {
 			}))
 			.into_diagnostic()
 			.wrap_err("json: from_str")?;
-			send(&ctx.args_sub.zmq_socket, screen)
+			send(&args.zmq_socket, screen)
 		}
-		Clear { red, green, blue } => send(&ctx.args_sub.zmq_socket, json::Screen::Clear([red, green, blue])),
-		On => send(&ctx.args_sub.zmq_socket, json::Screen::Light(true)),
-		Off => send(&ctx.args_sub.zmq_socket, json::Screen::Light(false)),
+		Clear { red, green, blue } => send(&args.zmq_socket, json::Screen::Clear([red, green, blue])),
+		On => send(&args.zmq_socket, json::Screen::Light(true)),
+		Off => send(&args.zmq_socket, json::Screen::Light(false)),
 	}
 }
 
-#[instrument(level = "debug", skip(ctx))]
-pub fn serve(ctx: Context<ItiArgs, LcdArgs>) -> Result<()> {
+#[instrument(level = "debug", skip(args))]
+pub fn serve(args: LcdArgs) -> Result<()> {
 	let running = Arc::new(AtomicBool::new(true));
 	let r = running.clone();
 
@@ -182,15 +181,15 @@ pub fn serve(ctx: Context<ItiArgs, LcdArgs>) -> Result<()> {
 		.into_diagnostic()
 		.wrap_err("zmq: set_ipv6")?;
 	socket
-		.bind(&ctx.args_sub.zmq_socket)
+		.bind(&args.zmq_socket)
 		.into_diagnostic()
-		.wrap_err(format!("zmq: bind({})", ctx.args_sub.zmq_socket))?;
+		.wrap_err(format!("zmq: bind({})", args.zmq_socket))?;
 	info!(
 		"ZMQ REP listening on {} for JSON messages",
-		ctx.args_sub.zmq_socket
+		args.zmq_socket
 	);
 
-	let mut lcd = Driver::new(ctx.args_sub.into())?;
+	let mut lcd = Driver::new(args.into())?;
 	lcd.init()?;
 	lcd.probe_buffer_length()?;
 

--- a/crates/bestool/src/actions/iti/sparks.rs
+++ b/crates/bestool/src/actions/iti/sparks.rs
@@ -5,10 +5,10 @@ use miette::Result;
 use sysinfo::System;
 
 use crate::actions::{
-	iti::{ItiArgs, lcd::{
+	iti::lcd::{
 		json::{Item, Screen},
 		send,
-	}},
+	},
 	Context,
 };
 
@@ -42,7 +42,7 @@ const GAP: i32 = 10;
 const OUTER_WIDTH: u32 = ((MAX_X - MIN_X - GAP) as u32) / 2;
 const INNER_WIDTH: u32 = OUTER_WIDTH - 2;
 
-pub async fn run(ctx: Context<ItiArgs, SparksArgs>) -> Result<()> {
+pub async fn run(args: SparksArgs, _ctx: Context) -> Result<()> {
 	let mut sys = System::new();
 	sys.refresh_cpu_usage();
 	sys.refresh_memory();
@@ -50,7 +50,7 @@ pub async fn run(ctx: Context<ItiArgs, SparksArgs>) -> Result<()> {
 	let mut cpu = VecDeque::new();
 	let mut mem = VecDeque::new();
 
-	let mut interval: Duration = ctx.args_sub.interval;
+	let mut interval: Duration = args.interval;
 	if interval < sysinfo::MINIMUM_CPU_UPDATE_INTERVAL {
 		interval = sysinfo::MINIMUM_CPU_UPDATE_INTERVAL;
 	}
@@ -73,7 +73,7 @@ pub async fn run(ctx: Context<ItiArgs, SparksArgs>) -> Result<()> {
 		mem.truncate(INNER_WIDTH as _);
 
 		render(
-			&ctx.args_sub,
+			&args,
 			cpu.iter().rev().copied(),
 			mem.iter().rev().copied(),
 		)?;

--- a/crates/bestool/src/actions/iti/temperature.rs
+++ b/crates/bestool/src/actions/iti/temperature.rs
@@ -5,7 +5,7 @@ use miette::{IntoDiagnostic, Result};
 use tokio::time::sleep;
 
 use crate::actions::{
-	iti::{ItiArgs, lcd::{
+	iti::{lcd::{
 		json::{Item, Screen},
 		send,
 	}, parse_friendly_duration},
@@ -38,18 +38,18 @@ pub struct TemperatureArgs {
 	pub watch: Option<Duration>,
 }
 
-pub async fn run(ctx: Context<ItiArgs, TemperatureArgs>) -> Result<()> {
-	if let Some(n) = ctx.args_sub.watch {
+pub async fn run(args: TemperatureArgs, _ctx: Context) -> Result<()> {
+	if let Some(n) = args.watch {
 		loop {
-			once(ctx.clone()).await?;
+			once(&args).await?;
 			sleep(n).await;
 		}
 	} else {
-		once(ctx).await
+		once(&args).await
 	}
 }
 
-pub async fn once(ctx: Context<ItiArgs, TemperatureArgs>) -> Result<()> {
+pub async fn once(args: &TemperatureArgs) -> Result<()> {
 	let temperature = duct::cmd!("vcgencmd", "measure_temp")
 		.read()
 		.into_diagnostic()?
@@ -58,7 +58,7 @@ pub async fn once(ctx: Context<ItiArgs, TemperatureArgs>) -> Result<()> {
 		.parse::<f32>()
 		.into_diagnostic()?;
 
-	if ctx.args_sub.json {
+	if args.json {
 		println!(
 			"{}",
 			serde_json::json!({
@@ -70,14 +70,14 @@ pub async fn once(ctx: Context<ItiArgs, TemperatureArgs>) -> Result<()> {
 	}
 
 	#[cfg(feature = "iti-lcd")]
-	if let Some(y) = ctx.args_sub.update_screen {
+	if let Some(y) = args.update_screen {
 		const GREEN: [u8; 3] = [0, 255, 0];
 		const RED: [u8; 3] = [255, 0, 0];
 		const BLACK: [u8; 3] = [0, 0, 0];
 		const YELLOW: [u8; 3] = [255, 255, 0];
 
 		send(
-			&ctx.args_sub.zmq_socket,
+			&args.zmq_socket,
 			Screen::Layout(vec![
 				Item {
 					x: 218,

--- a/crates/bestool/src/actions/rdp.rs
+++ b/crates/bestool/src/actions/rdp.rs
@@ -1,8 +1,6 @@
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-use crate::args::Args;
-
 use super::Context;
 
 pub mod audit;
@@ -22,9 +20,11 @@ pub struct RdpArgs {
 }
 
 super::subcommands! {
-	[Context<Args, RdpArgs> => {|ctx: Context<Args, RdpArgs>| -> Result<(Action, Context<RdpArgs>)> {
-		Ok((ctx.args_sub.action.clone(), ctx.push(())))
-	}}](with_sub)
+	[RdpArgs => |args: RdpArgs, mut ctx: Context| -> Result<(Action, Context)> {
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
 
 	monitor => Monitor(MonitorArgs),
 	service => Service(ServiceArgs)

--- a/crates/bestool/src/actions/rdp/monitor.rs
+++ b/crates/bestool/src/actions/rdp/monitor.rs
@@ -8,7 +8,6 @@ use miette::IntoDiagnostic;
 use tracing::{debug, info, warn};
 
 use super::{
-	RdpArgs,
 	audit::AuditLog,
 	events::{Event, EventKind, poll_events},
 	state::{KickDetection, Tracker},
@@ -48,9 +47,7 @@ pub struct MonitorArgs {
 	pub service: bool,
 }
 
-pub async fn run(ctx: Context<RdpArgs, MonitorArgs>) -> Result<()> {
-	let args = ctx.args_sub;
-
+pub async fn run(args: MonitorArgs, _ctx: Context) -> Result<()> {
 	if args.service {
 		#[cfg(windows)]
 		return tokio::task::spawn_blocking(move || super::service::dispatch_service_mode(args))

--- a/crates/bestool/src/actions/rdp/service.rs
+++ b/crates/bestool/src/actions/rdp/service.rs
@@ -5,8 +5,6 @@ use miette::miette;
 
 use crate::actions::Context;
 
-use super::RdpArgs;
-
 #[cfg(windows)]
 pub(crate) const SERVICE_NAME: &str = "bestool-rdp-monitor";
 #[cfg(windows)]
@@ -53,10 +51,10 @@ pub struct InstallArgs {
 	pub kick_window: Option<u64>,
 }
 
-pub async fn run(ctx: Context<RdpArgs, ServiceArgs>) -> Result<()> {
+pub async fn run(args: ServiceArgs, _ctx: Context) -> Result<()> {
 	#[cfg(windows)]
 	{
-		match ctx.args_sub.action {
+		match args.action {
 			Action::Install(args) => imp::install(args),
 			Action::Uninstall => imp::uninstall(),
 			Action::Start => imp::start(),
@@ -67,7 +65,7 @@ pub async fn run(ctx: Context<RdpArgs, ServiceArgs>) -> Result<()> {
 
 	#[cfg(not(windows))]
 	{
-		let _ = ctx;
+		let _ = args;
 		Err(miette!(
 			"rdp service management is only available on Windows"
 		))

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -7,10 +7,7 @@ use detect_targets::{TARGET, get_desired_targets};
 use miette::{IntoDiagnostic, Result, miette};
 use tracing::{debug, info};
 
-use crate::{
-	args::Args,
-	download::{DownloadSource, client, fetch_latest_version},
-};
+use crate::download::{DownloadSource, client, fetch_latest_version};
 
 use super::Context;
 
@@ -89,11 +86,11 @@ pub struct SelfUpdateArgs {
 	pub force: bool,
 }
 
-pub async fn run(ctx: Context<Args, SelfUpdateArgs>) -> Result<()> {
+pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
 	#[cfg(unix)]
 	{
 		check_exe_writable()?;
-		check_package_manager_install(ctx.args_sub.force)?;
+		check_package_manager_install(args.force)?;
 	}
 
 	let SelfUpdateArgs {
@@ -103,7 +100,7 @@ pub async fn run(ctx: Context<Args, SelfUpdateArgs>) -> Result<()> {
 		force,
 		#[cfg(windows)]
 		add_to_path,
-	} = ctx.args_sub;
+	} = args;
 
 	if version == "latest" && !force {
 		match fetch_latest_version().await {

--- a/crates/bestool/src/actions/ssh.rs
+++ b/crates/bestool/src/actions/ssh.rs
@@ -10,8 +10,6 @@ use tokio::{
 };
 use tracing::{debug, info, warn};
 
-use crate::args::Args;
-
 use super::Context;
 
 /// SSH helpers.
@@ -27,9 +25,11 @@ pub enum SshAction {
 	AddKey(AddKeyArgs),
 }
 
-pub async fn run(ctx: Context<Args, SshArgs>) -> Result<()> {
-	match ctx.args_sub.action.clone() {
-		SshAction::AddKey(subargs) => add_key(ctx.push(subargs)).await,
+pub async fn run(args: SshArgs, mut ctx: Context) -> Result<()> {
+	let action = args.action.clone();
+	ctx.provide(args);
+	match action {
+		SshAction::AddKey(subargs) => add_key(subargs, ctx).await,
 	}
 }
 
@@ -56,8 +56,8 @@ pub struct AddKeyArgs {
 	pub keys: Vec<String>,
 }
 
-pub async fn add_key(ctx: Context<SshArgs, AddKeyArgs>) -> Result<()> {
-	let AddKeyArgs { keys } = ctx.args_sub;
+pub async fn add_key(args: AddKeyArgs, _ctx: Context) -> Result<()> {
+	let AddKeyArgs { keys } = args;
 
 	info!("checking public keys are well-formed");
 	let mut valid_keys = keys

--- a/crates/bestool/src/actions/tamanu.rs
+++ b/crates/bestool/src/actions/tamanu.rs
@@ -14,6 +14,7 @@ use crate::args::Args;
 
 use super::Context;
 
+
 mod connection_url;
 mod roots;
 
@@ -49,11 +50,13 @@ pub struct TamanuArgs {
 }
 
 super::subcommands! {
-	[Context<Args, TamanuArgs> => {|ctx: Context<Args, TamanuArgs>| -> Result<(Action, Context<TamanuArgs>)> {
-		let (top, mut ctx) = ctx.take_top();
-		ctx.args_sub.use_colours = top.logging.color.enabled();
-		Ok((ctx.args_sub.action.clone(), ctx.push(())))
-	}}](with_sub)
+	[TamanuArgs => |mut args: TamanuArgs, mut ctx: Context| -> Result<(Action, Context)> {
+		let top: &Args = ctx.require();
+		args.use_colours = top.logging.color.enabled();
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
 
 	#[cfg(feature = "tamanu-alerts")]
 	alerts => Alerts(AlertsArgs),

--- a/crates/bestool/src/actions/tamanu/alertd.rs
+++ b/crates/bestool/src/actions/tamanu/alertd.rs
@@ -195,8 +195,8 @@ enum Command {
 	},
 }
 
-pub async fn run(ctx: Context<TamanuArgs, AlertdArgs>) -> Result<()> {
-	match ctx.args_sub.command {
+pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
+	match args.command {
 		Command::Status { server_addr } => {
 			let addrs = resolve_addrs(server_addr);
 			bestool_alertd::commands::get_status(&addrs).await
@@ -225,7 +225,7 @@ pub async fn run(ctx: Context<TamanuArgs, AlertdArgs>) -> Result<()> {
 			bestool_alertd::commands::pause_alert(&alert, until.as_deref(), &addrs).await
 		}
 		Command::Run { daemon } => {
-			let (version, root) = find_tamanu(&ctx.args_top)?;
+			let (version, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 			let config = load_config(&root, None)?;
 			debug!(?config, "parsed Tamanu config");
 
@@ -247,7 +247,7 @@ pub async fn run(ctx: Context<TamanuArgs, AlertdArgs>) -> Result<()> {
 		Command::ConfigureRecovery => bestool_alertd::windows_service::configure_recovery(),
 		#[cfg(windows)]
 		Command::Service { daemon } => {
-			let (version, root) = find_tamanu(&ctx.args_top)?;
+			let (version, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 			let config = load_config(&root, None)?;
 			debug!(?config, "parsed Tamanu config");
 

--- a/crates/bestool/src/actions/tamanu/alerts/command.rs
+++ b/crates/bestool/src/actions/tamanu/alerts/command.rs
@@ -104,15 +104,15 @@ async fn default_dirs(root: &Path) -> Vec<PathBuf> {
 	.collect()
 }
 
-pub async fn run(ctx: Context<TamanuArgs, AlertsArgs>) -> Result<()> {
-	let (version, root) = find_tamanu(&ctx.args_top)?;
+pub async fn run(args: AlertsArgs, ctx: Context) -> Result<()> {
+	let (version, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let config = load_config(&root, None)?;
 	debug!(?config, "parsed Tamanu config");
 
-	let dirs = if ctx.args_sub.dir.is_empty() {
+	let dirs = if args.dir.is_empty() {
 		default_dirs(&root).await
 	} else {
-		ctx.args_sub.dir
+		args.dir
 	};
 	debug!(?dirs, "searching for alerts");
 
@@ -163,7 +163,7 @@ pub async fn run(ctx: Context<TamanuArgs, AlertsArgs>) -> Result<()> {
 						.wrap_err(format!("{file:?}"))?;
 
 					alert.file = file.to_path_buf();
-					alert.interval = ctx.args_sub.interval;
+					alert.interval = args.interval;
 					debug!(?alert, "parsed alert file");
 					Ok(if alert.enabled { Some(alert) } else { None })
 				})
@@ -252,8 +252,8 @@ pub async fn run(ctx: Context<TamanuArgs, AlertsArgs>) -> Result<()> {
 	let mut set = JoinSet::new();
 	for alert in alerts {
 		let internal_ctx = internal_ctx.clone();
-		let dry_run = ctx.args_sub.dry_run;
-		let timeout_d = ctx.args_sub.timeout;
+		let dry_run = args.dry_run;
+		let timeout_d = args.timeout;
 		let name = alert.file.clone();
 		let config = config.clone();
 		set.spawn(

--- a/crates/bestool/src/actions/tamanu/artifacts.rs
+++ b/crates/bestool/src/actions/tamanu/artifacts.rs
@@ -12,8 +12,6 @@ use target_tuples::{
 
 use crate::actions::Context;
 
-use super::TamanuArgs;
-
 /// List available artifacts for a Tamanu version.
 ///
 /// Fetches and displays the available artifacts (downloads) for a specific Tamanu version.
@@ -129,8 +127,8 @@ pub async fn get_artifacts(version: &str, for_platform: &Platform) -> Result<Vec
 	Ok(artifacts)
 }
 
-pub async fn run(ctx: Context<TamanuArgs, ArtifactsArgs>) -> Result<()> {
-	let ArtifactsArgs { version, platform } = ctx.args_sub;
+pub async fn run(args: ArtifactsArgs, _ctx: Context) -> Result<()> {
+	let ArtifactsArgs { version, platform } = args;
 	let artifacts = get_artifacts(&version, &platform).await?;
 
 	if artifacts.is_empty() {

--- a/crates/bestool/src/actions/tamanu/backup.rs
+++ b/crates/bestool/src/actions/tamanu/backup.rs
@@ -110,29 +110,28 @@ pub struct BackupArgs {
 	pub key: KeyArgs,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, BackupArgs>) -> Result<()> {
-	create_dir_all(&ctx.args_sub.write_to)
+pub async fn run(args: BackupArgs, ctx: Context) -> Result<()> {
+	create_dir_all(&args.write_to)
 		.await
 		.into_diagnostic()
 		.wrap_err("creating dest dir")?;
 
-	let (_, root) = find_tamanu(&ctx.args_top)?;
+	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let config = load_config(&root, None)?;
 	debug!(?config, "parsed Tamanu config");
 
 	let pg_dump = crate::find_postgres::find_postgres_bin("pg_dump")?;
 
 	// check key
-	ctx.args_sub.key.get_public_key().await?;
+	args.key.get_public_key().await?;
 
-	let output = ctx
-		.args_sub
+	let output = args
 		.write_to
 		.join(make_backup_filename(&config, "dump"));
 
 	// Use the default host, which is the localhost via Unix-domain socket on Unix or TCP/IP on Windows
 	#[rustfmt::skip]
-	let (backup_type, excluded_tables) = if ctx.args_sub.lean {
+	let (backup_type, excluded_tables) = if args.lean {
 		(
 			"lean",
 			vec![
@@ -159,7 +158,7 @@ pub async fn run(ctx: Context<TamanuArgs, BackupArgs>) -> Result<()> {
 	};
 	info!(?output, "writing {backup_type} backup");
 
-	if !ctx.args_sub.debug_skip_pgdump {
+	if !args.debug_skip_pgdump {
 		#[rustfmt::skip]
 	duct::cmd(
 		pg_dump,
@@ -167,13 +166,13 @@ pub async fn run(ctx: Context<TamanuArgs, BackupArgs>) -> Result<()> {
 			"--username".into(), config.db.username.into(),
 			"--verbose".into(),
 			"--format".into(), "c".into(),
-			"--compress".into(), ctx.args_sub.compression_level.to_string().into(),
+			"--compress".into(), args.compression_level.to_string().into(),
 			"--file".into(), output.clone().into(),
 			"--dbname".into(), config.db.name.into(),
 		]
 		.into_iter()
 		.chain(excluded_tables)
-		.chain(ctx.args_sub.args),
+		.chain(args.args),
 	)
 	.env("PGPASSWORD", config.db.password)
 	.run()
@@ -185,17 +184,16 @@ pub async fn run(ctx: Context<TamanuArgs, BackupArgs>) -> Result<()> {
 
 	process_backup(
 		output,
-		&ctx.args_sub.write_to,
-		ctx.args_sub.then_copy_to.as_deref().map(|path| Then {
+		&args.write_to,
+		args.then_copy_to.as_deref().map(|path| Then {
 			copy_to: path,
-			split: ctx
-				.args_sub
+			split: args
 				.then_split
 				.map(|n| NonZero::new(n).map(ChunkSize::Mib).unwrap_or_default()),
 		}),
-		ctx.args_sub.keep_days,
+		args.keep_days,
 		".dump",
-		ctx.args_sub.key,
+		args.key,
 	)
 	.await?;
 

--- a/crates/bestool/src/actions/tamanu/backup_configs.rs
+++ b/crates/bestool/src/actions/tamanu/backup_configs.rs
@@ -164,16 +164,16 @@ fn make_backup_filename(config: &TamanuConfig) -> PathBuf {
 	format!("{output_date}-{output_name}.config.zip").into()
 }
 
-pub async fn run(ctx: Context<TamanuArgs, BackupConfigsArgs>) -> Result<()> {
-	create_dir_all(&ctx.args_sub.write_to)
+pub async fn run(args: BackupConfigsArgs, ctx: Context) -> Result<()> {
+	create_dir_all(&args.write_to)
 		.into_diagnostic()
 		.wrap_err("creating dest dir")?;
 
-	let (_, root) = find_tamanu(&ctx.args_top)?;
+	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let kind = find_package(&root);
 	let config = load_config(&root, Some(kind.package_name()))?;
 
-	let output = Path::new(&ctx.args_sub.write_to).join(make_backup_filename(&config));
+	let output = Path::new(&args.write_to).join(make_backup_filename(&config));
 
 	let mut file = std::fs::File::create_new(&output)
 		.into_diagnostic()
@@ -181,7 +181,7 @@ pub async fn run(ctx: Context<TamanuArgs, BackupConfigsArgs>) -> Result<()> {
 
 	let mut zip = ZipWriter::new(&mut file);
 
-	if !ctx.args_sub.test_skip_caddy {
+	if !args.test_skip_caddy {
 		let mut got_caddy = add_dir(&mut zip, "/etc/caddy", "caddy")?;
 		if !got_caddy {
 			got_caddy = add_file(&mut zip, r"C:\Caddy\Caddyfile", "caddy/Caddyfile");
@@ -213,14 +213,14 @@ pub async fn run(ctx: Context<TamanuArgs, BackupConfigsArgs>) -> Result<()> {
 
 	process_backup(
 		output,
-		&ctx.args_sub.write_to,
-		ctx.args_sub.then_copy_to.as_deref().map(|path| Then {
+		&args.write_to,
+		args.then_copy_to.as_deref().map(|path| Then {
 			copy_to: path,
 			split: None,
 		}),
-		ctx.args_sub.keep_days,
+		args.keep_days,
 		".config.zip",
-		ctx.args_sub.key,
+		args.key,
 	)
 	.await?;
 

--- a/crates/bestool/src/actions/tamanu/config/command.rs
+++ b/crates/bestool/src/actions/tamanu/config/command.rs
@@ -34,17 +34,17 @@ pub struct ConfigArgs {
 	pub raw: bool,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, ConfigArgs>) -> Result<()> {
-	let (_, root) = find_tamanu(&ctx.args_top)?;
+pub async fn run(args: ConfigArgs, ctx: Context) -> Result<()> {
+	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 
-	let config = super::loader::load_config_as_object(&root, ctx.args_sub.package.as_deref())?;
+	let config = super::loader::load_config_as_object(&root, args.package.as_deref())?;
 
-	let value = if let Some(key) = &ctx.args_sub.key {
+	let value = if let Some(key) = &args.key {
 		let mut value = &config;
 		for part in key.split('.') {
 			value = match value.get(part) {
 				Some(value) => value,
-				None if ctx.args_sub.or_null => &serde_json::Value::Null,
+				None if args.or_null => &serde_json::Value::Null,
 				None => bail!("key not found: {:?}", key),
 			};
 		}
@@ -55,7 +55,7 @@ pub async fn run(ctx: Context<TamanuArgs, ConfigArgs>) -> Result<()> {
 
 	println!(
 		"{}",
-		match (ctx.args_sub, value.as_str()) {
+		match (args, value.as_str()) {
 			(ConfigArgs { raw: true, .. }, Some(string)) => {
 				string.into()
 			}

--- a/crates/bestool/src/actions/tamanu/db_url.rs
+++ b/crates/bestool/src/actions/tamanu/db_url.rs
@@ -22,11 +22,11 @@ pub struct DbUrlArgs {
 	pub username: Option<String>,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, DbUrlArgs>) -> Result<()> {
-	let (_, root) = find_tamanu(&ctx.args_top)?;
+pub async fn run(args: DbUrlArgs, ctx: Context) -> Result<()> {
+	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let config = load_config(&root, None)?;
 
-	let (username, password) = if let Some(ref user) = ctx.args_sub.username {
+	let (username, password) = if let Some(ref user) = args.username {
 		if let Some(ref report_schemas) = config.db.report_schemas {
 			if let Some(connection) = report_schemas.connections.get(user)
 				&& !connection.username.is_empty()

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -54,11 +54,11 @@ pub struct DoctorArgs {
 	pub only: Vec<String>,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, DoctorArgs>) -> Result<()> {
-	let use_colours = ctx.args_top.use_colours;
-	let args = ctx.args_sub.clone();
+pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
+	let tamanu = ctx.require::<TamanuArgs>();
+	let use_colours = tamanu.use_colours;
 
-	let (version, root) = find_tamanu(&ctx.args_top)?;
+	let (version, root) = find_tamanu(tamanu)?;
 	let config = load_config(&root, None)?;
 
 	let builder = ConnectionUrlBuilder {

--- a/crates/bestool/src/actions/tamanu/download.rs
+++ b/crates/bestool/src/actions/tamanu/download.rs
@@ -12,8 +12,6 @@ use crate::{
 	download::client,
 };
 
-use super::TamanuArgs;
-
 /// Download Tamanu artifacts.
 ///
 /// Use the `tamanu artifacts` subcommand to list of the artifacts available for a version.
@@ -60,7 +58,7 @@ pub struct DownloadArgs {
 	pub platform: Platform,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, DownloadArgs>) -> Result<()> {
+pub async fn run(args: DownloadArgs, _ctx: Context) -> Result<()> {
 	let DownloadArgs {
 		kind,
 		version,
@@ -68,7 +66,7 @@ pub async fn run(ctx: Context<TamanuArgs, DownloadArgs>) -> Result<()> {
 		url_only,
 		no_extract,
 		platform,
-	} = ctx.args_sub;
+	} = args;
 
 	if platform == Platform::Match("container".into()) {
 		bail!("Cannot download container artifacts");

--- a/crates/bestool/src/actions/tamanu/find.rs
+++ b/crates/bestool/src/actions/tamanu/find.rs
@@ -5,6 +5,7 @@ use crate::actions::Context;
 
 use super::TamanuArgs;
 
+
 /// Find Tamanu installations.
 #[derive(Debug, Clone, Parser)]
 pub struct FindArgs {
@@ -23,9 +24,10 @@ pub struct FindArgs {
 	pub with_version: bool,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, FindArgs>) -> Result<()> {
-	let mut versions = if let Some(root) = ctx.args_top.root {
-		if let Some(version) = super::roots::version_of_root(&root)? {
+pub async fn run(args: FindArgs, ctx: Context) -> Result<()> {
+	let tamanu = ctx.require::<TamanuArgs>();
+	let mut versions = if let Some(root) = tamanu.root.as_ref() {
+		if let Some(version) = super::roots::version_of_root(root)? {
 			vec![(version, root.canonicalize().into_diagnostic()?)]
 		} else {
 			bail!("no version found in explicit root {root:?}");
@@ -34,16 +36,16 @@ pub async fn run(ctx: Context<TamanuArgs, FindArgs>) -> Result<()> {
 		super::roots::find_versions()?
 	};
 
-	if ctx.args_sub.asc {
+	if args.asc {
 		versions.reverse();
 	}
 
-	if let Some(count) = ctx.args_sub.count {
+	if let Some(count) = args.count {
 		versions.truncate(count);
 	}
 
 	for (version, root) in versions {
-		if ctx.args_sub.with_version {
+		if args.with_version {
 			println!("[{version}] {}", root.display());
 		} else {
 			println!("{}", root.display());

--- a/crates/bestool/src/actions/tamanu/greenmask_config.rs
+++ b/crates/bestool/src/actions/tamanu/greenmask_config.rs
@@ -103,8 +103,8 @@ struct GreenmaskTransformation {
 	rest: Value,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, GreenmaskConfigArgs>) -> Result<()> {
-	let (_, tamanu_folder) = find_tamanu(&ctx.args_top)?;
+pub async fn run(args: GreenmaskConfigArgs, ctx: Context) -> Result<()> {
+	let (_, tamanu_folder) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let root = tamanu_folder.parent().unwrap();
 
 	let config = load_config(&tamanu_folder, None)?;
@@ -113,7 +113,7 @@ pub async fn run(ctx: Context<TamanuArgs, GreenmaskConfigArgs>) -> Result<()> {
 		.wrap_err("failed to find psql executable")?;
 	let tmp_dir = temp_dir();
 
-	let mut transforms_dirs = ctx.args_sub.folders;
+	let mut transforms_dirs = args.folders;
 	if transforms_dirs.is_empty() {
 		transforms_dirs.push(root.join("greenmask").join("config"));
 		transforms_dirs.push(tamanu_folder.join("greenmask"));
@@ -163,8 +163,7 @@ pub async fn run(ctx: Context<TamanuArgs, GreenmaskConfigArgs>) -> Result<()> {
 	}
 
 	let storage_dir = {
-		let dir = ctx
-			.args_sub
+		let dir = args
 			.storage_dir
 			.unwrap_or_else(|| root.join("greenmask").join("dumps"));
 		fs::create_dir_all(&dir).into_diagnostic()?;

--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -72,17 +72,19 @@ pub struct LogsArgs {
 	pub grep: Option<Regex>,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, LogsArgs>) -> Result<()> {
-	if ctx.args_sub.name == "caddy" {
+pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
+	let tamanu = ctx.require::<TamanuArgs>();
+
+	if args.name == "caddy" {
 		return run_caddy_logs(
-			ctx.args_sub.lines,
-			ctx.args_sub.follow,
-			ctx.args_sub.grep.as_ref(),
-			ctx.args_top.use_colours,
+			args.lines,
+			args.follow,
+			args.grep.as_ref(),
+			tamanu.use_colours,
 		);
 	}
 
-	let (_, root) = find_tamanu(&ctx.args_top)?;
+	let (_, root) = find_tamanu(tamanu)?;
 	let config = load_config(&root, None)?;
 	let kind = if config.is_facility() {
 		ApiServerKind::Facility
@@ -99,13 +101,13 @@ pub async fn run(ctx: Context<TamanuArgs, LogsArgs>) -> Result<()> {
 	};
 
 	let expectations = services::expected(supervisor, kind, &config);
-	let matches: Vec<&Expectation> = match_name(&expectations, &ctx.args_sub.name).collect();
+	let matches: Vec<&Expectation> = match_name(&expectations, &args.name).collect();
 
 	if matches.is_empty() {
 		let candidates: Vec<&str> = up_names(&expectations).collect();
 		bail!(
 			"no service matches {:?}; expected services are: {}",
-			ctx.args_sub.name,
+			args.name,
 			candidates.join(", ")
 		);
 	}
@@ -113,22 +115,12 @@ pub async fn run(ctx: Context<TamanuArgs, LogsArgs>) -> Result<()> {
 	debug!(
 		?matches,
 		"matched expectations for `tamanu logs {}`",
-		ctx.args_sub.name
+		args.name
 	);
 
 	match supervisor {
-		Supervisor::Systemd => run_journalctl(
-			&matches,
-			ctx.args_sub.lines,
-			ctx.args_sub.follow,
-			ctx.args_sub.grep.as_ref(),
-		),
-		Supervisor::Pm2 => run_pm2_logs(
-			&matches,
-			ctx.args_sub.lines,
-			ctx.args_sub.follow,
-			ctx.args_sub.grep,
-		),
+		Supervisor::Systemd => run_journalctl(&matches, args.lines, args.follow, args.grep.as_ref()),
+		Supervisor::Pm2 => run_pm2_logs(&matches, args.lines, args.follow, args.grep),
 	}
 }
 

--- a/crates/bestool/src/actions/tamanu/meta_ticket.rs
+++ b/crates/bestool/src/actions/tamanu/meta_ticket.rs
@@ -45,8 +45,8 @@ struct Ticket {
 	hosting: Option<String>,
 }
 
-pub async fn run(ctx: Context<TamanuArgs, MetaTicketArgs>) -> Result<()> {
-	let (_, root) = find_tamanu(&ctx.args_top)?;
+pub async fn run(_args: MetaTicketArgs, ctx: Context) -> Result<()> {
+	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let config = load_config(&root, None)?;
 
 	let builder = ConnectionUrlBuilder {

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -275,7 +275,7 @@ fn help_audit_path() -> String {
 	)
 }
 
-pub async fn run(ctx: Context<TamanuArgs, PsqlArgs>) -> Result<()> {
+pub async fn run(args: PsqlArgs, ctx: Context) -> Result<()> {
 	let PsqlArgs {
 		username,
 		ssl,
@@ -284,7 +284,7 @@ pub async fn run(ctx: Context<TamanuArgs, PsqlArgs>) -> Result<()> {
 		theme,
 		audit_path,
 		no_redact,
-	} = ctx.args_sub;
+	} = args;
 
 	let url = if let Some(url) = url {
 		let mut url = reqwest::Url::parse(&url).into_diagnostic()?;
@@ -293,7 +293,7 @@ pub async fn run(ctx: Context<TamanuArgs, PsqlArgs>) -> Result<()> {
 		}
 		url.to_string()
 	} else {
-		let (_, root) = find_tamanu(&ctx.args_top)?;
+		let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 		let config = load_config(&root, None)?;
 
 		let (username, password) = if let Some(ref user) = username {
@@ -385,7 +385,7 @@ pub async fn run(ctx: Context<TamanuArgs, PsqlArgs>) -> Result<()> {
 			theme: theme.resolve(),
 			audit_path,
 			write,
-			use_colours: ctx.args_top.use_colours,
+			use_colours: ctx.require::<TamanuArgs>().use_colours,
 			redact_mode,
 			redactions,
 			snippet_lookup: Some(snippet_provider),


### PR DESCRIPTION
## Summary

Replaces the two-slot \`Context<TopArgs, SubArgs>\` with a type-keyed extensions map, axum/React-style. Each subcommand level provides its own args struct into the context; leaf handlers extract whichever ancestors they need via \`ctx.require::<T>()\`.

## Motivation

The old \`Context<A, B>\` could only carry two args shapes (immediate parent + self), so a handler nested more than two deep would lose access to its grandparent's args (e.g. \`Args\` from inside a tamanu leaf). Deep features like the WIP \`tamanu logs\` and \`reload\` would either have to thread args through manually or duplicate state.

## What changed

- \`context.rs\`: \`Context\` is now a \`HashMap<TypeId, Arc<dyn Any + Send + Sync>>\` with \`provide<T>\` / \`get<T>\` / \`require<T>\` methods. It's \`Clone\` (cheap — only Arc clones).
- \`subcommands!\` macro: takes a \`(args, ctx) -> (Action, Context)\` prep closure; emits a uniform \`async fn run(args, ctx)\` dispatcher. Each level inserts its own args into ctx before dispatching to children.
- All 25+ leaf and branch handlers migrated to the new \`async fn run(args: Self, ctx: Context)\` signature. Handlers access ancestor args via \`ctx.require::<ParentArgs>()\`.

## Tradeoff

Compile-time "you definitely have these two levels" guarantee → runtime "panic if you forgot to provide". Mitigated by the macro inserting symmetrically and 5 unit tests on the Context primitives. Worst case is \`bestool foo bar\` panicking with a clear \`required value of type \`X\` not provided\` if I missed a provide() somewhere — which we'd catch on the first dev run.