### PR TITLE
feat(self-update): skip download when already on latest version

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -745,7 +745,7 @@ Alias: self
 * `--temp-dir <TEMP_DIR>` — Temporary directory to download to.
 
    Defaults to the system temp directory.
-* `--force` — Force self-update even if installed via package manager
+* `--force` — Force reinstall, even if already on the latest version or installed via package manager
 
 
 

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -5,11 +5,11 @@ use clap::Parser;
 use binstalk_downloader::download::{Download, PkgFmt};
 use detect_targets::{TARGET, get_desired_targets};
 use miette::{IntoDiagnostic, Result, miette};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{
 	args::Args,
-	download::{DownloadSource, client},
+	download::{DownloadSource, client, fetch_latest_version},
 };
 
 use super::Context;
@@ -84,7 +84,7 @@ pub struct SelfUpdateArgs {
 	#[arg(short = 'P', long)]
 	pub add_to_path: bool,
 
-	/// Force self-update even if installed via package manager.
+	/// Force reinstall, even if already on the latest version or installed via package manager.
 	#[arg(long)]
 	pub force: bool,
 }
@@ -100,10 +100,29 @@ pub async fn run(ctx: Context<Args, SelfUpdateArgs>) -> Result<()> {
 		version,
 		target,
 		temp_dir,
+		force,
 		#[cfg(windows)]
 		add_to_path,
-		..
 	} = ctx.args_sub;
+
+	if version == "latest" && !force {
+		match fetch_latest_version().await {
+			Ok(latest) => {
+				let current = env!("CARGO_PKG_VERSION");
+				if latest == current {
+					info!(
+						version = current,
+						"Already on the latest version. Use --force to reinstall."
+					);
+					return Ok(());
+				}
+				info!(current = current, latest = %latest, "Update available, proceeding");
+			}
+			Err(err) => {
+				debug!("Failed to check latest version, continuing with download: {err}");
+			}
+		}
+	}
 
 	let client = client().await?;
 

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -118,14 +118,12 @@ fn tailscale_resolver() -> Resolver<impl ConnectionProvider> {
 	.expect("tailscale resolver config is hardcoded and cannot fail to build")
 }
 
-pub async fn check_for_update() -> Result<()> {
-	let current_version = env!("CARGO_PKG_VERSION");
-
+pub async fn fetch_latest_version() -> Result<String> {
 	let url = DownloadSource::Tools
 		.host()
 		.join("/bestool/latest-version.txt")
 		.into_diagnostic()?;
-	debug!(?url, "Checking for updates");
+	debug!(?url, "Fetching latest bestool version");
 
 	let response = client()
 		.await?
@@ -134,19 +132,27 @@ pub async fn check_for_update() -> Result<()> {
 		.await
 		.into_diagnostic()?;
 
-	let latest_version = response.bytes().await.into_diagnostic()?;
-	let latest_version = std::str::from_utf8(&latest_version).into_diagnostic()?;
-	let latest_version = latest_version.trim();
+	let body = response.bytes().await.into_diagnostic()?;
+	let latest = std::str::from_utf8(&body)
+		.into_diagnostic()?
+		.trim()
+		.to_owned();
+	Ok(latest)
+}
+
+pub async fn check_for_update() -> Result<()> {
+	let current_version = env!("CARGO_PKG_VERSION");
+	let latest_version = fetch_latest_version().await?;
 	debug!(
 		current = current_version,
-		latest = latest_version,
+		latest = %latest_version,
 		"Version check result"
 	);
 
 	if latest_version != current_version {
 		info!(
 			current = current_version,
-			latest = latest_version,
+			latest = %latest_version,
 			"A new version of bestool is available. Run 'bestool self-update' to update."
 		);
 	} else {


### PR DESCRIPTION
🤖

## Summary

`bestool self-update` already does the work of downloading and self-replacing even when the current binary is already at the latest version. We publish `latest-version.txt` on every release, so we can cheaply check first.

- New `download::fetch_latest_version()` helper, shared with the background check.
- In `self-update`: when `--version` is the default `latest` and `--force` isn't set, fetch `latest-version.txt`; if it equals `CARGO_PKG_VERSION`, log and return without downloading. If the fetch fails, fall through to the existing download path.
- `--force` now also bypasses this check (preserving the existing package-manager-bypass semantics). Help text updated.