### PR TITLE
feat(self-update): prefer zstd-compressed download

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -148,6 +148,29 @@ jobs:
 
           dpkg-deb --build --root-owner-group "$deb_dir" "bestool-${target}-${version}.deb"
 
+      - name: Ensure zstd is available
+        shell: bash
+        run: |
+          if command -v zstd >/dev/null 2>&1; then
+            zstd --version
+            exit 0
+          fi
+          case "${{ runner.os }}" in
+            Linux)   sudo apt-get update && sudo apt-get install -y zstd ;;
+            macOS)   brew install zstd ;;
+            Windows) choco install zstandard -y --no-progress ;;
+          esac
+
+      - name: Compress binary with zstd
+        shell: bash
+        run: |
+          src_dir="target/${{ matrix.target }}/dist"
+          name="bestool"
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            name="bestool.exe"
+          fi
+          tar -C "$src_dir" -cf - "$name" | zstd -19 -f -o "$src_dir/$name.tar.zst"
+
       - uses: actions/upload-artifact@v7
         with:
           name: bestool-${{ matrix.target }}-${{ github.sha }}
@@ -156,6 +179,8 @@ jobs:
           path: |
             target/*/dist/bestool
             target/*/dist/bestool.exe
+            target/*/dist/bestool.tar.zst
+            target/*/dist/bestool.exe.tar.zst
             *.deb
 
       - name: Configure AWS Credentials
@@ -172,10 +197,10 @@ jobs:
           src="target/${{ matrix.target }}/dist/bestool"
           dest="s3://bes-ops-tools/bestool/${version}/${{ matrix.target }}/"
           if [[ ${{ runner.os }} == "Windows" ]]; then
-            aws s3 cp "$src".exe "$dest" --no-progress
-          else
-            aws s3 cp "$src" "$dest" --no-progress
+            src="$src.exe"
           fi
+          aws s3 cp "$src" "$dest" --no-progress
+          aws s3 cp "$src.tar.zst" "$dest" --no-progress
 
           for deb in bestool-*.deb; do
             [[ -f "$deb" ]] || continue
@@ -190,10 +215,10 @@ jobs:
           src="target/${{ matrix.target }}/dist/bestool"
           dest="s3://bes-ops-tools/bestool/latest/${{ matrix.target }}/"
           if [[ ${{ runner.os }} == "Windows" ]]; then
-            aws s3 cp "$src".exe "$dest" --no-progress
-          else
-            aws s3 cp "$src" "$dest" --no-progress
+            src="$src.exe"
           fi
+          aws s3 cp "$src" "$dest" --no-progress
+          aws s3 cp "$src.tar.zst" "$dest" --no-progress
 
           aws cloudfront create-invalidation --distribution-id=EDAG0UBS1MN74 --paths '/bestool/latest/*'
 

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -135,21 +135,34 @@ pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
 	let _ = tokio::fs::remove_file(&dest).await;
 
 	let host = DownloadSource::Tools.host();
-	let url = host
-		.join(&format!(
-			"/bestool/{version}/{target}/{filename}",
-			target = detected_targets
-				.first()
-				.cloned()
-				.unwrap_or_else(|| TARGET.into()),
-		))
+	let target = detected_targets
+		.first()
+		.cloned()
+		.unwrap_or_else(|| TARGET.into());
+	let bin_path = format!("/bestool/{version}/{target}/{filename}");
+	let bin_url = host.join(&bin_path).into_diagnostic()?;
+	let tzst_url = host
+		.join(&format!("{bin_path}.tar.zst"))
 		.into_diagnostic()?;
-	info!(url = %url, "downloading");
 
-	Download::new(client, url)
-		.and_extract(PkgFmt::Bin, &dest)
+	let tzst_available = client
+		.remote_gettable(tzst_url.clone())
 		.await
-		.into_diagnostic()?;
+		.unwrap_or(false);
+
+	if tzst_available {
+		info!(url = %tzst_url, "downloading compressed");
+		Download::new(client, tzst_url)
+			.and_extract(PkgFmt::Tzstd, &dir)
+			.await
+			.into_diagnostic()?;
+	} else {
+		info!(url = %bin_url, "downloading");
+		Download::new(client, bin_url)
+			.and_extract(PkgFmt::Bin, &dest)
+			.await
+			.into_diagnostic()?;
+	}
 
 	#[cfg(windows)]
 	if add_to_path && let Err(err) = add_self_to_path() {


### PR DESCRIPTION
🤖

Stacked on #341.

## Summary

The bestool binary has grown to ~50 MiB uncompressed and CloudFront doesn't compress on the fly. zstd shrinks it to ~36% of that (around 18 MiB).

- CI now produces `bestool[.exe].tar.zst` alongside the uncompressed binary and uploads both to the versioned and `latest/` S3 paths. The tarball wraps the single binary so we can reuse binstalk-downloader's existing `Tzstd` extractor on the client side without adding a new direct dep.
- `self-update` probes for `bestool[.exe].tar.zst`; if present, downloads and extracts via `PkgFmt::Tzstd`. Falls back to the uncompressed URL when the `.tar.zst` isn't there — covers older releases still on S3, and old clients keep hitting the existing path unchanged.