### PR TITLE
feat: hardcoded tailscale IP fallback for canopy and proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
+ "hickory-resolver",
  "jiff",
  "lloggs",
  "mailgun-rs",

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -26,6 +26,7 @@ dirs = "6.0.0"
 flate2 = "1.0.34"
 futures = { workspace = true }
 glob = "0.3.3"
+hickory-resolver = "0.26.1"
 jiff = { version = "0.2.24", features = ["serde"] }
 lloggs = { workspace = true, optional = true }
 mailgun-rs = "2.0.2"

--- a/crates/alertd/src/canopy.rs
+++ b/crates/alertd/src/canopy.rs
@@ -1,6 +1,16 @@
-use std::{fmt, io::Write, time::Duration};
+use std::{
+	fmt,
+	io::Write,
+	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+	time::Duration,
+};
 
 use flate2::{Compression, write::GzEncoder};
+use hickory_resolver::{
+	ConnectionProvider, Resolver,
+	config::{ConnectionConfig, NameServerConfig, ResolverConfig},
+	net::runtime::TokioRuntimeProvider,
+};
 use jiff::Timestamp;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
@@ -19,6 +29,15 @@ pub const DEFAULT_CANOPY_URL: &str = "https://meta.tamanu.app";
 /// On hosts that share the canopy tailnet, posting to this URL works without
 /// mTLS — the tailscale identity is the auth.
 pub const TAILSCALE_URL: &str = "https://canopy.tail53aef.ts.net";
+
+/// Bare hostname used for `resolve_to_addrs` overrides.
+const TAILSCALE_HOST: &str = "canopy.tail53aef.ts.net";
+
+/// Hardcoded tailscale IPs for canopy, used when tailscale DNS
+/// (100.100.100.100) is unreachable but the tailnet otherwise is.
+const CANOPY_HARDCODED_V4: Ipv4Addr = Ipv4Addr::new(100, 99, 98, 97);
+const CANOPY_HARDCODED_V6: Ipv6Addr =
+	Ipv6Addr::new(0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0x9337, 0xfb52);
 
 /// How long renewed canopy certs are valid for.
 ///
@@ -312,30 +331,76 @@ impl CanopyClient {
 /// 2xx — anything else (timeout, non-2xx, transport error) returns `None` so
 /// the caller can fall back to mTLS.
 ///
+/// Tries two paths in order:
+/// 1. Resolve `canopy` via the tailscale DNS server (100.100.100.100) and
+///    probe with those addresses.
+/// 2. Use hardcoded tailscale IPs for canopy and probe with those.
+///
 /// `/public/servers` is used because:
 /// - it lives under `/public/...`, the only mount that accepts tagged-device
 ///   tailscale callers (everything else 403s with `tagged-device-not-allowed`);
 /// - it's a `GET` with no body, no `VersionHeader` requirement, and no auth;
 /// - it's read-only, so probing it has no side effects.
 async fn probe_tailscale() -> Option<reqwest::Client> {
-	let url = format!("{TAILSCALE_URL}/public/servers");
+	let dns_addrs: Vec<SocketAddr> = tailscale_resolver()
+		.lookup_ip("canopy")
+		.await
+		.ok()
+		.map(|addrs| addrs.iter().map(|ip| SocketAddr::new(ip, 443)).collect())
+		.unwrap_or_default();
+	if !dns_addrs.is_empty()
+		&& let Some(client) = try_probe(&dns_addrs).await
+	{
+		return Some(client);
+	}
 
+	let hardcoded = [
+		SocketAddr::new(IpAddr::V4(CANOPY_HARDCODED_V4), 443),
+		SocketAddr::new(IpAddr::V6(CANOPY_HARDCODED_V6), 443),
+	];
+	debug!(
+		?hardcoded,
+		"canopy tailscale DNS lookup empty or probe failed, trying hardcoded IPs"
+	);
+	try_probe(&hardcoded).await
+}
+
+async fn try_probe(addrs: &[SocketAddr]) -> Option<reqwest::Client> {
 	let client = reqwest::Client::builder()
 		.timeout(TAILSCALE_PROBE_TIMEOUT)
+		.resolve_to_addrs(TAILSCALE_HOST, addrs)
 		.build()
 		.ok()?;
 
+	let url = format!("{TAILSCALE_URL}/public/servers");
 	match client.get(&url).send().await {
 		Ok(resp) if resp.status().is_success() => Some(client),
 		Ok(resp) => {
-			debug!(status = %resp.status(), "canopy tailscale probe: unexpected status");
+			debug!(status = %resp.status(), ?addrs, "canopy tailscale probe: unexpected status");
 			None
 		}
 		Err(err) => {
-			debug!("canopy tailscale probe failed: {err}");
+			debug!(?addrs, "canopy tailscale probe failed: {err}");
 			None
 		}
 	}
+}
+
+fn tailscale_resolver() -> Resolver<impl ConnectionProvider> {
+	Resolver::builder_with_config(
+		ResolverConfig::from_parts(
+			None,
+			vec!["tail53aef.ts.net.".parse().unwrap()],
+			vec![NameServerConfig::new(
+				"100.100.100.100".parse().unwrap(),
+				true,
+				vec![ConnectionConfig::udp()],
+			)],
+		),
+		TokioRuntimeProvider::default(),
+	)
+	.build()
+	.expect("tailscale resolver config is hardcoded and cannot fail to build")
 }
 
 fn gzip_bytes(bytes: &[u8]) -> std::io::Result<Vec<u8>> {

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -1,7 +1,8 @@
 use std::{
 	iter,
-	net::SocketAddr,
+	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 	num::{NonZeroU16, NonZeroU64},
+	time::Duration,
 };
 
 use binstalk_downloader::remote::{Client, Url};
@@ -11,7 +12,10 @@ use hickory_resolver::{
 	net::runtime::TokioRuntimeProvider,
 };
 use miette::{IntoDiagnostic, Result};
+use tokio::{net::TcpStream, time::timeout};
 use tracing::{debug, info, instrument};
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 pub async fn reqwest_client() -> Result<reqwest::Client> {
 	let mut builder = reqwest::Client::builder();
@@ -88,17 +92,73 @@ impl DownloadSource {
 		// - we're querying tailscale DNS server directly
 		// - we don't really want to have this be easily hijacked by another tailnet
 		// this does have the effect of exposing our tailnet suffix here, but that should be safe
-		tailscale_resolver()
-			.lookup_ip(match self {
-				Self::Tools => "bestool-proxy-tools",
-				Self::Servers => "bestool-proxy-servers",
-				Self::Meta => return Vec::new(),
-			})
+		let hostname = match self {
+			Self::Tools => "bestool-proxy-tools",
+			Self::Servers => "bestool-proxy-servers",
+			Self::Meta => return Vec::new(),
+		};
+
+		let dns_addrs: Vec<SocketAddr> = tailscale_resolver()
+			.lookup_ip(hostname)
 			.await
 			.ok()
 			.map(|addrs| addrs.iter().map(|ip| SocketAddr::new(ip, 443)).collect())
-			.unwrap_or_default()
+			.unwrap_or_default();
+		if !dns_addrs.is_empty() {
+			return dns_addrs;
+		}
+
+		let hardcoded = self.hardcoded_proxy_addrs();
+		debug!(
+			?self,
+			?hardcoded,
+			"tailscale DNS lookup empty, probing hardcoded proxy IPs"
+		);
+		if probe_tcp_reachable(&hardcoded).await {
+			return hardcoded;
+		}
+
+		Vec::new()
 	}
+
+	/// Hardcoded tailscale IPs for the proxy hosts, used when tailscale DNS
+	/// (100.100.100.100) is unreachable but the tailnet otherwise is.
+	fn hardcoded_proxy_addrs(self) -> Vec<SocketAddr> {
+		match self {
+			// bestool-proxy-tools
+			Self::Tools => vec![
+				SocketAddr::new(IpAddr::V4(Ipv4Addr::new(100, 101, 191, 59)), 443),
+				SocketAddr::new(
+					IpAddr::V6(Ipv6Addr::new(
+						0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0x7d01, 0xbf3c,
+					)),
+					443,
+				),
+			],
+			// bestool-proxy-servers
+			Self::Servers => vec![
+				SocketAddr::new(IpAddr::V4(Ipv4Addr::new(100, 80, 8, 4)), 443),
+				SocketAddr::new(
+					IpAddr::V6(Ipv6Addr::new(
+						0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0x5f01, 0x0808,
+					)),
+					443,
+				),
+			],
+			Self::Meta => Vec::new(),
+		}
+	}
+}
+
+async fn probe_tcp_reachable(addrs: &[SocketAddr]) -> bool {
+	for &addr in addrs {
+		match timeout(PROBE_TIMEOUT, TcpStream::connect(addr)).await {
+			Ok(Ok(_)) => return true,
+			Ok(Err(err)) => debug!(?addr, %err, "tcp probe failed"),
+			Err(_) => debug!(?addr, "tcp probe timed out"),
+		}
+	}
+	false
 }
 
 fn tailscale_resolver() -> Resolver<impl ConnectionProvider> {


### PR DESCRIPTION
🤖

## Summary

When tailscale's DNS endpoint (100.100.100.100) is unreachable but the tailnet IPs themselves are still routable (broken/misconfigured magic DNS, partial connectivity), we previously fell straight through to the public-internet path. This adds a middle step: hardcoded tailnet IPs for the three hosts we care about, probed before giving up.

### Canopy (alertd)

`probe_tailscale` now:
1. Resolves `canopy` against the tailscale DNS server (100.100.100.100) and probes with `resolve_to_addrs` directed at the result.
2. On empty/failed probe, retries with hardcoded canopy tailnet IPs (100.99.98.97 / fd7a:115c:a1e0::9337:fb52).
3. On failure, `CanopyClient::new` continues to its existing mTLS fallback.

`hickory-resolver` is now a direct dep on alertd.

### Proxies (download)

`source_alternatives` now:
1. Looks up `bestool-proxy-{tools,servers}` via the existing `tailscale_resolver`.
2. On empty result, TCP-probes the hardcoded v4+v6 IPs at :443.
3. On probe failure, returns empty so reqwest falls through to public DNS (unchanged).

### Notes

- Some duplication between the canopy and proxy paths (separate `tailscale_resolver()` in each crate, separate hardcoded tables) — deliberate, the two call sites are quite different.
- Hardcoded IPs verified against `tailscale status --json` at the time of writing.