### PR TITLE
docs: add READMEs for each crate

### DIFF
--- a/crates/alertd/README.md
+++ b/crates/alertd/README.md
@@ -1,0 +1,63 @@
+# bestool-alertd
+
+An alert daemon that watches a set of YAML alert definitions, runs them on a
+schedule, and dispatches the results to one or more targets (email, HTTP
+endpoints, etc.).
+
+This crate is part of [BES tooling][repo], and is in particular what powers
+the `tamanu alerts` workflow. It is published as both a library and a
+standalone binary; the `bestool` umbrella tool also embeds it.
+
+[repo]: https://github.com/beyondessential/bestool
+
+## Install
+
+```console
+$ cargo install bestool-alertd
+```
+
+Pre-built binaries are attached to each `bestool-alertd-v*` GitHub release.
+
+## Use
+
+```console
+$ bestool-alertd run \
+    --database-url postgresql://localhost/mydb \
+    --glob '/etc/myapp/alerts/**/*.yml'
+```
+
+Common flags:
+
+- `--glob PATTERN` (repeatable): where to find alert definition files. Patterns
+  may match a directory (read recursively) or individual files. Globs are
+  watched for changes and re-evaluated periodically.
+- `--database-url URL` / `DATABASE_URL`: PostgreSQL connection for SQL alerts.
+- `--email-from`, `--mailgun-api-key`, `--mailgun-domain`: enable email
+  targets via Mailgun.
+- `--device-key-file PATH` / `DEVICE_KEY_FILE`: PEM identity used when posting
+  to canopy `/events` targets.
+- `--dry-run`: execute every alert once and exit; useful in CI.
+- `--server-addr`: where the local HTTP control API listens
+  (default `[::1]:8271` and `127.0.0.1:8271`).
+
+`bestool-alertd` exposes additional subcommands that talk to a running daemon
+via its HTTP API: `status`, `reload`, `loaded-alerts`, `pause-alert`,
+`validate`. SIGHUP also triggers a reload on Unix.
+
+On Windows, `bestool-alertd install` registers a native service named
+`bestool-alertd`; `uninstall` and `configure-recovery` are also provided.
+
+## Defining alerts and targets
+
+- Alert files: see [ALERTS.md](./ALERTS.md).
+- Target files: see [TARGETS.md](./TARGETS.md).
+
+## Library
+
+The crate also exposes a library API (`bestool_alertd::run`,
+`DaemonConfig`, …) so other tools can embed the daemon without going through
+the binary.
+
+## License
+
+GPL-3.0-or-later.

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -10,6 +10,7 @@ description = "BES Deployment tooling"
 keywords = ["bes", "tamanu", "tupaia"]
 categories = ["command-line-utilities"]
 repository = "https://github.com/beyondessential/bestool"
+readme = "../../README.md"
 exclude.workspace = true
 
 [lints]

--- a/crates/improv-wifi/README.md
+++ b/crates/improv-wifi/README.md
@@ -1,0 +1,65 @@
+# improv-wifi
+
+A Rust implementation of the [Improv Wi-Fi] BLE peripheral protocol — the
+*device* side of the provisioning conversation. Use it on a headless Linux box
+to advertise itself over Bluetooth Low Energy so a mobile app or
+[improv-wifi.com](https://www.improv-wifi.com) in the browser can hand over
+Wi-Fi credentials without a display or keyboard.
+
+[Improv Wi-Fi]: https://www.improv-wifi.com
+
+## Scope
+
+Currently this crate covers:
+
+- **BLE transport, via BlueZ on Linux.** The GATT service, advertisement, RPC
+  reassembly, and the full state machine (authorisation → provisioning →
+  provisioned) are implemented on top of zbus.
+- **A `WifiConfigurator` trait** that decouples the protocol from how the
+  device actually talks to its network stack. Implement it yourself, or enable
+  the `networkmanager` feature for a built-in backend that drives Wi-Fi via
+  NetworkManager's D-Bus API.
+
+## Use
+
+```toml
+[dependencies]
+improv-wifi = { version = "0.1", features = ["networkmanager"] }
+```
+
+The high-level flow:
+
+1. Connect to the system bus and find a BlueZ adapter with `find_adapter` /
+   `power_on_adapter`.
+2. Construct an `ImprovWifi` with your `WifiConfigurator` and an
+   `ImprovWifiConfig` (authorisation mode, advertised local name, etc.).
+3. Call `ImprovWifi::run` to drive advertising and the state machine until
+   the device is provisioned.
+
+If your device gates provisioning on a physical button press, hold an
+`AuthHandle` from another task and call `authorize()` when the user interacts.
+
+See the crate-level rustdoc for the full API.
+
+## Not yet implemented, but we'd take patches
+
+The Improv-Wi-Fi spec describes more than just the BLE transport on Linux, and
+this crate is happy to grow:
+
+- **Serial transport.** Improv-Wi-Fi defines a USB/UART variant of the same
+  RPC; useful for microcontrollers and for devices that already expose a
+  serial console.
+- **Embedded / `no_std` targets.** The protocol itself (RPC framing,
+  reassembly, state machine) does not need an allocator or BlueZ; it would
+  be useful as a transport-agnostic core that an ESP32 or similar could
+  drive directly.
+- **Other Linux backends.** A direct `wpa_supplicant` or `iwd` backend, for
+  systems that don't run NetworkManager.
+- **Other host operating systems.** macOS or Windows BLE peripherals if
+  someone has a use case.
+
+If any of these would be useful to you, open an issue or PR.
+
+## License
+
+GPL-3.0-or-later.

--- a/crates/postgres/README.md
+++ b/crates/postgres/README.md
@@ -1,0 +1,54 @@
+# bestool-postgres
+
+PostgreSQL connection-pool utilities shared by the [BES tooling][repo]. Wraps
+[`tokio-postgres`] with [`mobc`] pooling and [`rustls`] TLS, and adds a few
+quality-of-life helpers we want everywhere.
+
+[repo]: https://github.com/beyondessential/bestool
+[`tokio-postgres`]: https://docs.rs/tokio-postgres
+[`mobc`]: https://docs.rs/mobc
+[`rustls`]: https://docs.rs/rustls
+
+## What's in it
+
+- `PgPool::create_pool(url, application_name)` — build a pool from a libpq
+  connection URL. Handles a few things that bare `tokio-postgres` does not:
+  - Unix-socket connection strings (`postgresql:///db?host=/var/run/postgresql`,
+    percent-encoded host, or empty host with auto-detect).
+  - `sslmode=prefer` fallback to disabled TLS when the server refuses.
+  - Interactive password prompt (via `rpassword`) if the URL has no password
+    and the server returns an auth error.
+- `pg_interval::Interval` — a `Duration` newtype that implements `ToSql` for
+  PostgreSQL's `INTERVAL` type.
+- `stringify::postgres_to_json_value` — best-effort row-cell → `serde_json::Value`
+  conversion across the common PG types.
+- `text_cast` — extract any column as its text representation regardless of
+  declared type, useful for generic dump/inspect tools.
+- `error` — shared error types and a `miette`-friendly diagnostic style.
+
+## Use
+
+```toml
+[dependencies]
+bestool-postgres = "1"
+```
+
+```rust,no_run
+use bestool_postgres::pool::create_pool;
+
+# async fn run() -> miette::Result<()> {
+let pool = create_pool("postgresql://localhost/mydb", "my-app").await?;
+let conn = pool.get().await.unwrap();
+conn.simple_query("SELECT 1").await.unwrap();
+# Ok(()) }
+```
+
+## Scope
+
+This crate exists to support BES tools (alertd, psql, bestool itself); it is
+deliberately opinionated rather than a general-purpose pool. That said, the
+helpers are reusable, and patches that broaden them sensibly are welcome.
+
+## License
+
+GPL-3.0-or-later.

--- a/crates/rpi-st7789v2-driver/README.md
+++ b/crates/rpi-st7789v2-driver/README.md
@@ -1,0 +1,59 @@
+# rpi-st7789v2-driver
+
+A Raspberry Pi driver for the [WaveShare 1.69" 240×280 LCD module][wiki], which
+uses Sitronix's ST7789V2 TFT controller over SPI.
+
+[wiki]: https://www.waveshare.com/wiki/1.69inch_LCD_Module
+
+The crate exposes two flavours of interface:
+
+- A simple `SimpleImage` buffer (`Driver::image()` → `solid`, `pixel`, `print`)
+  for the common case of "draw something and push the whole frame".
+- The full [`embedded-graphics`] `DrawTarget` trait, so you can use any of the
+  existing graphics primitives, fonts, and image decoders from that ecosystem.
+
+[`embedded-graphics`]: https://docs.rs/embedded-graphics
+
+## Use
+
+```toml
+[dependencies]
+rpi-st7789v2-driver = "0.3"
+```
+
+```rust,no_run
+use embedded_graphics::pixelcolor::Rgb565;
+use rpi_st7789v2_driver::{Driver, Result};
+
+fn main() -> Result<()> {
+    let mut lcd = Driver::new(Default::default())?;
+    lcd.init()?;
+    lcd.probe_buffer_length()?;
+
+    let mut image = lcd.image();
+    image.solid(Rgb565::new(255, 0, 255));
+    lcd.print((0, 0), &image)?;
+    Ok(())
+}
+```
+
+`DriverArgs::default()` matches WaveShare's [reference wiring][wiki]:
+SPI0/CE0, DC on GPIO 25, RESET on GPIO 27, backlight on GPIO 18, 20 MHz SCK.
+Override any field you have wired differently.
+
+## Features
+
+- `miette` — derive `miette::Diagnostic` on the crate's error type, for nicer
+  CLI error reporting.
+
+## Platform
+
+Linux-only; uses [`rppal`] to talk to `/dev/spidev` and `/dev/gpiochip`.
+Targeted at the Raspberry Pi family, but should work on any SBC `rppal`
+supports.
+
+[`rppal`]: https://docs.rs/rppal
+
+## License
+
+GPL-3.0-or-later.


### PR DESCRIPTION
🤖 Adds a README to each workspace crate that didn't have one (alertd, postgres, rpi-st7789v2-driver, improv-wifi), so they have something other than the description string on crates.io.

For the `bestool` crate, the root `README.md` is already the right content, so I just pointed its `Cargo.toml` `readme` field at `../../README.md` rather than duplicate it. `cargo package -p bestool --list` confirms the file ends up bundled in the `.crate`.

The new improv-wifi README also calls out where we'd happily take patches (serial transport, no_std, other host backends/OSes).