### PR TITLE
ci: only enable auto-merge if autorelease label is still on release PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -69,8 +69,13 @@ jobs:
           PR_JSON: ${{ steps.release-plz-pr.outputs.pr }}
         run: |
           pr_number=$(printf '%s' "$PR_JSON" | jq -r '.number // empty')
-          if [ -n "$pr_number" ]; then
+          if [ -z "$pr_number" ]; then
+            exit 0
+          fi
+          if gh pr view "$pr_number" --json labels --jq '.labels[].name' | grep -qx autorelease; then
             gh pr merge --auto --squash "$pr_number"
+          else
+            echo "autorelease label absent on PR #$pr_number; release is held, skipping auto-merge"
           fi
 
   release-plz-hold:

--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ Commits should follow the [Conventional Commits](https://www.conventionalcommits
 ### Releasing
 
 Releases are automated by [release-plz](https://release-plz.dev). Pushing to `main` opens a `repo: release` PR with per-crate version bumps determined from conventional commits and `cargo-semver-checks`; merging that PR (auto-merge is enabled once CI is green) publishes the affected crates to crates.io, pushes per-crate tags, and triggers the binary-build workflows.
+
+#### Holding a release
+
+To bundle several features or fixes into one release, remove the `autorelease` label from the open `repo: release` PR. The CI then turns auto-merge off and won't turn it back on while the label is absent, so subsequent merges to `main` keep updating the PR without shipping it. Re-add the label (and re-enable auto-merge manually, or push another commit to `main` to let the workflow do it) when you're ready to ship.


### PR DESCRIPTION
:robot:

## Summary
- Before turning auto-merge on, the workflow now queries the release PR's labels and only enables it when `autorelease` is still present.
- Without this, every push to main that updated the existing release PR re-enabled auto-merge, undoing #347.
- Combined with #347, removing the `autorelease` label is a sticky way to hold a release.
- Also documents the hold flow in README.md.