### PR TITLE
fix(tamanu): exclude non-active sessions from external_users check

### DIFF
--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -555,10 +555,8 @@ fn parse_source_name(source_name: &str) -> Option<(&str, &str)> {
 
 	let schema = if schema_part == "tamanu" {
 		"public"
-	} else if let Some(stripped) = schema_part.strip_suffix("__tamanu") {
-		stripped
 	} else {
-		return None;
+		schema_part.strip_suffix("__tamanu")?
 	};
 
 	Some((schema, table))

--- a/crates/psql/src/column_extractor.rs
+++ b/crates/psql/src/column_extractor.rs
@@ -390,12 +390,12 @@ mod tests {
 
 		// Print the structure to understand it
 		for stmt in &result.protobuf.stmts {
-			if let Some(s) = &stmt.stmt {
-				if let Some(pg_query::NodeEnum::SelectStmt(select)) = &s.node {
-					eprintln!("Target list length: {}", select.target_list.len());
-					for (i, target) in select.target_list.iter().enumerate() {
-						eprintln!("Target {}: {:?}", i, target.node);
-					}
+			if let Some(s) = &stmt.stmt
+				&& let Some(pg_query::NodeEnum::SelectStmt(select)) = &s.node
+			{
+				eprintln!("Target list length: {}", select.target_list.len());
+				for (i, target) in select.target_list.iter().enumerate() {
+					eprintln!("Target {}: {:?}", i, target.node);
 				}
 			}
 		}

--- a/crates/psql/src/query.rs
+++ b/crates/psql/src/query.rs
@@ -475,7 +475,7 @@ async fn execute_single_statement<W: AsyncWrite + Unpin>(
 			// Build a map of column index to cast result
 			let mut cast_map = std::collections::HashMap::new();
 			if let Some(results) = cast_results {
-				for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+				for (cell, result) in unprintable_cells.iter().zip(results) {
 					cast_map.insert(cell.col_idx, result);
 				}
 			}

--- a/crates/psql/src/query/display/csv.rs
+++ b/crates/psql/src/query/display/csv.rs
@@ -47,7 +47,7 @@ pub async fn display<W: AsyncWrite + Unpin>(ctx: &mut super::DisplayContext<'_, 
 	// Build index for looking up cast results
 	let mut cast_map = std::collections::HashMap::new();
 	if let Some(results) = cast_results {
-		for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+		for (cell, result) in unprintable_cells.iter().zip(results) {
 			cast_map.insert(*cell, result);
 		}
 	}

--- a/crates/psql/src/query/display/excel.rs
+++ b/crates/psql/src/query/display/excel.rs
@@ -56,7 +56,7 @@ pub async fn display(
 	// Build index for looking up cast results
 	let mut cast_map = std::collections::HashMap::new();
 	if let Some(results) = cast_results {
-		for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+		for (cell, result) in unprintable_cells.iter().zip(results) {
 			cast_map.insert(*cell, result);
 		}
 	}

--- a/crates/psql/src/query/display/expanded.rs
+++ b/crates/psql/src/query/display/expanded.rs
@@ -35,7 +35,7 @@ pub async fn display<W: AsyncWrite + Unpin>(ctx: &mut super::DisplayContext<'_, 
 	// Build index for looking up cast results
 	let mut cast_map = std::collections::HashMap::new();
 	if let Some(results) = cast_results {
-		for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+		for (cell, result) in unprintable_cells.iter().zip(results) {
 			cast_map.insert(*cell, result);
 		}
 	}

--- a/crates/psql/src/query/display/json.rs
+++ b/crates/psql/src/query/display/json.rs
@@ -45,7 +45,7 @@ pub async fn display<W: AsyncWrite + Unpin>(
 	// Build index for looking up cast results
 	let mut cast_map = std::collections::HashMap::new();
 	if let Some(results) = cast_results {
-		for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+		for (cell, result) in unprintable_cells.iter().zip(results) {
 			cast_map.insert(*cell, result);
 		}
 	}
@@ -277,7 +277,7 @@ mod tests {
 
 		let output2 = String::from_utf8(buffer2).expect("Invalid UTF-8");
 		let parsed2: serde_json::Value =
-			serde_json::from_str(&output2.trim()).expect("Should be valid JSON array");
+			serde_json::from_str(output2.trim()).expect("Should be valid JSON array");
 		assert!(parsed2.is_array());
 		let array = parsed2.as_array().unwrap();
 		assert_eq!(array.len(), 1);

--- a/crates/psql/src/query/display/normal.rs
+++ b/crates/psql/src/query/display/normal.rs
@@ -42,7 +42,7 @@ pub async fn display<W: AsyncWrite + Unpin>(ctx: &mut super::DisplayContext<'_, 
 	// Build index for looking up cast results
 	let mut cast_map = std::collections::HashMap::new();
 	if let Some(results) = cast_results {
-		for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+		for (cell, result) in unprintable_cells.iter().zip(results) {
 			cast_map.insert(*cell, result);
 		}
 	}

--- a/crates/psql/src/query/display/sqlite.rs
+++ b/crates/psql/src/query/display/sqlite.rs
@@ -84,7 +84,7 @@ pub async fn display(
 		// Build index for looking up cast results
 		let mut cast_map = std::collections::HashMap::new();
 		if let Some(results) = cast_results {
-			for (cell, result) in unprintable_cells.iter().zip(results.into_iter()) {
+			for (cell, result) in unprintable_cells.iter().zip(results) {
 				cast_map.insert(*cell, result);
 			}
 		}

--- a/crates/tamanu/src/doctor/checks/external_users.rs
+++ b/crates/tamanu/src/doctor/checks/external_users.rs
@@ -345,15 +345,21 @@ fn parse_quser(text: &str) -> Vec<ExternalUser> {
 		// without one (disconnected sessions). Detect by whether the second
 		// column parses as a session id (integer): if so, SESSIONNAME is
 		// absent; otherwise SESSIONNAME is in the second column and ID is
-		// in the third.
-		let (name, sessionname) = if tokens[1].parse::<u32>().is_ok() {
-			(tokens[0], None)
+		// in the third. STATE follows ID.
+		let (name, sessionname, state) = if tokens[1].parse::<u32>().is_ok() {
+			(tokens[0], None, tokens[2])
 		} else if tokens.len() >= 7 && tokens[2].parse::<u32>().is_ok() {
-			(tokens[0], Some(tokens[1]))
+			(tokens[0], Some(tokens[1]), tokens[3])
 		} else {
 			trace!(?line, "could not locate session id column in quser line");
 			continue;
 		};
+		// Skip non-active sessions: disconnected ones are stale login state
+		// the OS hasn't cleaned up yet, not a real connected user.
+		if !state.eq_ignore_ascii_case("Active") {
+			trace!(?line, ?state, "skipping non-active quser session");
+			continue;
+		}
 		let logon_tokens = &tokens[tokens.len().saturating_sub(3)..];
 		if logon_tokens.len() != 3 {
 			continue;
@@ -516,15 +522,25 @@ mod tests {
 	}
 
 	#[test]
-	fn parses_quser_disconnected_session_without_sessionname() {
+	fn skips_quser_disconnected_session() {
 		// `quser` omits SESSIONNAME for disconnected sessions: the ID column
-		// then sits where SESSIONNAME used to.
+		// then sits where SESSIONNAME used to. These aren't active users —
+		// the OS just hasn't cleaned the session up yet.
 		let text = " USERNAME              SESSIONNAME        ID  STATE   IDLE TIME  LOGON TIME\n\
 		             dave                                      3  Disc    .          5/21/2026 2:00 AM\n";
 		let out = parse_quser(text);
-		assert_eq!(out.len(), 1);
-		assert_eq!(out[0].name, "dave");
-		assert_eq!(out[0].line, "(disconnected)");
+		assert!(out.is_empty());
+	}
+
+	#[test]
+	fn keeps_only_active_quser_sessions() {
+		let text = " USERNAME              SESSIONNAME        ID  STATE   IDLE TIME  LOGON TIME\n\
+		            >administrator         console             1  Active  none       5/21/2026 4:00 AM\n\
+		             bob                   rdp-tcp#0           2  Active  10:30      5/21/2026 3:55 AM\n\
+		             besd                                      3  Disc    .          5/22/2026 4:17 PM\n";
+		let out = parse_quser(text);
+		assert_eq!(out.len(), 2);
+		assert!(out.iter().all(|u| u.name != "besd"));
 	}
 
 	#[test]

--- a/crates/tamanu/src/pm2.rs
+++ b/crates/tamanu/src/pm2.rs
@@ -92,13 +92,7 @@ pub fn find_command() -> Option<PathBuf> {
 		}
 	}
 
-	for candidate in candidate_install_paths() {
-		if probe(&candidate) {
-			return Some(candidate);
-		}
-	}
-
-	None
+	candidate_install_paths().into_iter().find(|c| probe(c))
 }
 
 fn probe(path: &Path) -> bool {
@@ -369,10 +363,10 @@ fn read_pid_file(home: &Path, name: &str, pm_id: Option<i64>) -> Option<u32> {
 		],
 	};
 	for path in candidates {
-		if let Ok(contents) = std::fs::read_to_string(&path) {
-			if let Ok(pid) = contents.trim().parse::<u32>() {
-				return Some(pid);
-			}
+		if let Ok(contents) = std::fs::read_to_string(&path)
+			&& let Ok(pid) = contents.trim().parse::<u32>()
+		{
+			return Some(pid);
 		}
 	}
 	None

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -481,13 +481,12 @@ pub fn detect_virtualisation() -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-	use std::sync::Mutex;
-
+	use tokio::sync::Mutex;
 	use tokio_postgres::NoTls;
 
 	use super::*;
 
-	static DB_TEST_MUTEX: Mutex<()> = Mutex::new(());
+	static DB_TEST_MUTEX: Mutex<()> = Mutex::const_new(());
 
 	async fn test_db_client() -> tokio_postgres::Client {
 		let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
@@ -520,7 +519,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_get_or_create_server_id_generates_new() {
-		let _lock = DB_TEST_MUTEX.lock().unwrap();
+		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
 		let id = get_or_create_server_id(&client).await.unwrap();
@@ -540,7 +539,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_get_or_create_server_id_returns_existing() {
-		let _lock = DB_TEST_MUTEX.lock().unwrap();
+		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
 		client
@@ -557,7 +556,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_get_or_create_server_id_is_stable() {
-		let _lock = DB_TEST_MUTEX.lock().unwrap();
+		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
 		let id1 = get_or_create_server_id(&client).await.unwrap();
@@ -687,7 +686,7 @@ mod tests {
 	async fn test_get_or_create_device_key_generates_new() {
 		use p256::{SecretKey, pkcs8::DecodePrivateKey as _};
 
-		let _lock = DB_TEST_MUTEX.lock().unwrap();
+		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
 		let pem = get_or_create_device_key(&client).await.unwrap();
@@ -697,7 +696,7 @@ mod tests {
 	#[cfg(feature = "meta-ticket")]
 	#[tokio::test]
 	async fn test_get_or_create_device_key_returns_existing_from_db() {
-		let _lock = DB_TEST_MUTEX.lock().unwrap();
+		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
 		let canned = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgVvhzsYiidp38GYn1\nKxD5Wipc/h8lglVsy1UFZq/SZbGhRANCAAT2EsEq7xjeWVnim9XwdYXga/LBbppm\nfXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN\n-----END PRIVATE KEY-----\n";
@@ -716,7 +715,7 @@ mod tests {
 	#[cfg(feature = "meta-ticket")]
 	#[tokio::test]
 	async fn test_get_or_create_device_key_is_stable() {
-		let _lock = DB_TEST_MUTEX.lock().unwrap();
+		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
 		let a = get_or_create_device_key(&client).await.unwrap();

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -91,9 +91,9 @@ impl Instances {
 	pub fn required_systemd_units(&self, base: &str) -> Vec<String> {
 		match self {
 			Instances::Single => vec![format!("{base}.service")],
-			Instances::NumericAtLeast(n) => (1..=*n)
-				.map(|i| format!("{base}@{i}.service"))
-				.collect(),
+			Instances::NumericAtLeast(n) => {
+				(1..=*n).map(|i| format!("{base}@{i}.service")).collect()
+			}
 			Instances::Named(xs) => xs.iter().map(|s| format!("{base}@{s}.service")).collect(),
 		}
 	}


### PR DESCRIPTION
Disconnected ("Disc") sessions on Windows are stale login state the OS hasn't cleaned up — they aren't real connected users, but the check was treating them as such and could trip the 24h fail threshold for a session nobody is actually using.

Filter the quser parser to keep only "Active" sessions.