### PR TITLE
feat(bestool): only notify of updates when remote version is higher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "reqwest",
  "rpi-st7789v2-driver",
  "rppal",
+ "semver",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -66,6 +66,7 @@ regex = { version = "1.11.2", optional = true }
 reqwest = { workspace = true }
 rpi-st7789v2-driver = { version = "0.3.13", path = "../rpi-st7789v2-driver", features = ["miette"], optional = true }
 rppal = { version = "0.22.1", optional = true }
+semver = { version = "1.0.28", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 serde_path_to_error = { version = "0.1.17", optional = true }
@@ -107,7 +108,7 @@ completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 crypto = ["dep:algae-cli", "dep:blake3", "dep:merkle_hash"]
 file = ["dep:blake3", "dep:indicatif", "dep:tokio-util"]
 rdp = ["dep:duct", "dep:privilege", "dep:quick-xml", "dep:tauri-winrt-notification", "dep:windows-service"]
-self-update = ["download", "dep:upgrade", "dep:windows-env"]
+self-update = ["download", "dep:semver", "dep:upgrade", "dep:windows-env"]
 ssh = ["dep:dirs", "dep:duct", "dep:fs4", "dep:ssh-key", "dep:privilege", "dep:windows-acl"]
 
 ## Tamanu subcommands

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -209,7 +209,7 @@ pub async fn check_for_update() -> Result<()> {
 		"Version check result"
 	);
 
-	if latest_version != current_version {
+	if remote_is_newer(current_version, &latest_version) {
 		info!(
 			current = current_version,
 			latest = %latest_version,
@@ -220,4 +220,60 @@ pub async fn check_for_update() -> Result<()> {
 	}
 
 	Ok(())
+}
+
+/// Whether the remote version is strictly higher than the current version.
+///
+/// Avoids notifying when a dev or pre-release build (e.g. installed from a
+/// branch) happens to be ahead of the published release. If either side can't
+/// be parsed as semver, falls back to string inequality so we still surface
+/// *something* — a parse failure shouldn't mask a real available update.
+pub(crate) fn remote_is_newer(current: &str, latest: &str) -> bool {
+	match (
+		semver::Version::parse(current),
+		semver::Version::parse(latest),
+	) {
+		(Ok(c), Ok(l)) => l > c,
+		_ => current != latest,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::remote_is_newer;
+
+	#[test]
+	fn remote_newer_when_remote_is_higher_patch() {
+		assert!(remote_is_newer("1.10.0", "1.10.1"));
+	}
+
+	#[test]
+	fn remote_newer_when_remote_is_higher_minor() {
+		assert!(remote_is_newer("1.10.5", "1.11.0"));
+	}
+
+	#[test]
+	fn not_newer_when_equal() {
+		assert!(!remote_is_newer("1.10.0", "1.10.0"));
+	}
+
+	#[test]
+	fn not_newer_when_local_is_ahead() {
+		// The case the TODO calls out: a dev build that's ahead of the
+		// published release shouldn't trigger an "update available" notice.
+		assert!(!remote_is_newer("1.12.0", "1.11.0"));
+	}
+
+	#[test]
+	fn double_digit_components_compared_numerically_not_lexically() {
+		// String comparison would say "1.9.0" > "1.10.0" — semver knows better.
+		assert!(remote_is_newer("1.9.0", "1.10.0"));
+		assert!(!remote_is_newer("1.10.0", "1.9.0"));
+	}
+
+	#[test]
+	fn unparseable_falls_back_to_inequality() {
+		assert!(remote_is_newer("not-semver", "1.0.0"));
+		assert!(!remote_is_newer("not-semver", "not-semver"));
+	}
 }


### PR DESCRIPTION
🤖

The "update available" notice fired any time `latest-version.txt` didn't string-match `CARGO_PKG_VERSION`, including the case where a dev build is ahead of the published release. Switches to a strict semver `latest > current` comparison so the notice no longer triggers for ahead-of-release builds. A lexical fallback keeps the previous behaviour when either version is unparseable.

A new `semver` dep is added under the `self-update` feature.