### PR TITLE
feat(tamanu/psql): fetch snippets via canopy/tailscale

### DIFF
--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -165,7 +165,7 @@ tamanu-greenmask = ["__tamanu", "tamanu-config", "dep:bestool-psql", "dep:dunce"
 tamanu-lifecycle = ["__tamanu", "tamanu-config", "dep:owo-colors", "dep:privilege"]
 tamanu-logs = ["__tamanu", "tamanu-config", "dep:owo-colors", "dep:sysinfo"]
 tamanu-meta-ticket = ["__tamanu", "tamanu-config", "bestool-tamanu/meta-ticket", "dep:base64", "dep:bestool-psql", "dep:p256", "dep:rand_core", "dep:sysinfo", "dep:tokio-postgres"]
-tamanu-psql = ["__tamanu", "tamanu-config", "dep:bestool-psql"]
+tamanu-psql = ["__tamanu", "tamanu-config", "dep:bestool-canopy", "dep:bestool-psql"]
 __tamanu = [ # internal feature to enable the tamanu subcommand common code
 	"dep:bestool-tamanu",
 	"dep:dirs",

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -1,5 +1,6 @@
 use std::{collections::{BTreeMap, HashSet}, path::PathBuf, sync::Arc, time::Duration};
 
+use bestool_canopy::CanopyClient;
 use bestool_psql::column_extractor::ColumnRef;
 use bestool_psql::SnippetLookupProvider;
 use clap::{Parser, ValueEnum};
@@ -27,15 +28,20 @@ struct Snippet {
 ///
 /// Snippets are cached to disk. On startup, cached snippets are loaded immediately,
 /// then the remote API is fetched in the background to update the cache.
+///
+/// If a canopy client is available, snippets are fetched via the canopy connection
+/// (tailscale-preferred). Otherwise a direct fetch over the public internet is used.
 #[derive(Clone)]
 struct AsyncSnippetProvider {
 	snippets: Arc<RwLock<Option<BTreeMap<String, Snippet>>>>,
+	canopy: Option<Arc<CanopyClient>>,
 }
 
 impl AsyncSnippetProvider {
-	fn new() -> Self {
+	fn new(canopy: Option<Arc<CanopyClient>>) -> Self {
 		Self {
 			snippets: Arc::new(RwLock::new(None)),
+			canopy,
 		}
 	}
 
@@ -93,23 +99,10 @@ impl AsyncSnippetProvider {
 	}
 
 	async fn fetch_and_update_snippets(&self) -> Result<usize> {
-		let url = DownloadSource::Meta
-			.host()
-			.join("bestool/snippets")
-			.into_diagnostic()?;
-
-		let response = tokio::time::timeout(
-			Duration::from_secs(10),
-			reqwest_client()
-				.await?
-				.get(url.to_string())
-				.send(),
-		)
-		.await
-		.into_diagnostic()?
-		.into_diagnostic()?;
-
-		let snippets: BTreeMap<String, Snippet> = response.json().await.into_diagnostic()?;
+		let snippets = tokio::time::timeout(Duration::from_secs(10), self.fetch_snippets_body())
+			.await
+			.into_diagnostic()
+			.wrap_err("snippet fetch timed out")??;
 
 		let count = snippets.len();
 		let mut cached = self.snippets.write().await;
@@ -125,6 +118,45 @@ impl AsyncSnippetProvider {
 		});
 
 		Ok(count)
+	}
+
+	/// Fetch the snippets payload, preferring the canopy connection if available
+	/// so the request can ride tailscale. Falls back to direct meta.tamanu.app
+	/// fetch on canopy failure or absence.
+	async fn fetch_snippets_body(&self) -> Result<BTreeMap<String, Snippet>> {
+		let meta_url = DownloadSource::Meta.host();
+
+		if let Some(canopy) = &self.canopy {
+			match canopy
+				.get(&meta_url, "/public/bestool/snippets", "/bestool/snippets")
+				.await
+			{
+				Ok(response) if response.status().is_success() => {
+					return response.json().await.into_diagnostic();
+				}
+				Ok(response) => {
+					debug!(
+						status = %response.status(),
+						"canopy snippets fetch returned non-success; falling back to direct"
+					);
+				}
+				Err(err) => {
+					debug!("canopy snippets fetch failed ({err:#}); falling back to direct");
+				}
+			}
+		}
+
+		let url = meta_url
+			.join("/bestool/snippets")
+			.into_diagnostic()
+			.wrap_err("building direct snippets URL")?;
+		let response = reqwest_client()
+			.await?
+			.get(url.to_string())
+			.send()
+			.await
+			.into_diagnostic()?;
+		response.json().await.into_diagnostic()
 	}
 
 	async fn save_to_cache_impl(path: std::path::PathBuf, snippets: &BTreeMap<String, Snippet>) -> Result<()> {
@@ -143,7 +175,7 @@ impl AsyncSnippetProvider {
 
 impl Default for AsyncSnippetProvider {
 	fn default() -> Self {
-		Self::new()
+		Self::new(None)
 	}
 }
 
@@ -374,7 +406,31 @@ pub async fn run(args: PsqlArgs, ctx: Context) -> Result<()> {
 		(false, HashSet::new())
 	};
 
-	let snippet_provider = Arc::new(AsyncSnippetProvider::new());
+	let canopy = if let Some(ref tamanu_version) = version {
+		let device_key = read_device_key();
+		match CanopyClient::new(tamanu_version.clone(), device_key.as_deref()).await {
+			Ok(Some(client)) => {
+				if client.is_tailscale().await {
+					debug!("canopy ready via tailscale for snippet fetch");
+				} else {
+					debug!("canopy ready via mTLS for snippet fetch");
+				}
+				Some(Arc::new(client))
+			}
+			Ok(None) => {
+				debug!("no canopy auth path; snippet fetch will go direct");
+				None
+			}
+			Err(err) => {
+				warn!("failed to build canopy client for snippets: {err:#}");
+				None
+			}
+		}
+	} else {
+		None
+	};
+
+	let snippet_provider = Arc::new(AsyncSnippetProvider::new(canopy));
 	snippet_provider.clone().load_snippets_background();
 
 	bestool_psql::run(
@@ -395,6 +451,21 @@ pub async fn run(args: PsqlArgs, ctx: Context) -> Result<()> {
 		},
 	)
 	.await
+}
+
+/// Read the Tamanu device key from the standard on-disk path.
+///
+/// Tries the file-based source only. `bestool-tamanu`'s full `fetch_device_key`
+/// also falls back to the Tamanu DB, but pulling in that path here would drag
+/// the doctor-only tokio runtime into the psql feature for what's a small
+/// best-effort lookup — psql's canopy use degrades cleanly to direct fetches
+/// when the device key isn't readable.
+fn read_device_key() -> Option<String> {
+	let path = bestool_tamanu::server_info::standard_device_key_path();
+	match std::fs::read_to_string(&path) {
+		Ok(s) if !s.trim().is_empty() => Some(s),
+		_ => None,
+	}
 }
 
 async fn get_tamanu_version(pool: &bestool_psql::PgPool) -> Option<String> {

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -278,6 +278,45 @@ impl CanopyClient {
 		Ok(())
 	}
 
+	/// GET a path on the canopy server, routed via tailscale when available.
+	///
+	/// In tailscale mode, the request goes to `{TAILSCALE_URL}{tailscale_path}`
+	/// (typically `/public/...`, the only mount that accepts tagged-device
+	/// tailscale callers). In mTLS mode, the request goes to `{base_url}{mtls_path}`.
+	///
+	/// Returns the raw response — the caller is responsible for status checks
+	/// and body parsing so they can choose how to fall back if the response
+	/// isn't usable.
+	pub async fn get(
+		&self,
+		base_url: &Url,
+		tailscale_path: &str,
+		mtls_path: &str,
+	) -> Result<reqwest::Response> {
+		let (http, url) = {
+			let state = self.state.read().await;
+			let url = match &*state {
+				State::Tailscale(_) => format!("{TAILSCALE_URL}{tailscale_path}")
+					.parse::<Url>()
+					.into_diagnostic()
+					.wrap_err("building tailscale GET URL")?,
+				State::Mtls(_) => base_url
+					.join(mtls_path)
+					.into_diagnostic()
+					.wrap_err("building mTLS GET URL")?,
+			};
+			(state.http(), url)
+		};
+
+		debug!(%url, "GET via canopy");
+		http.get(url)
+			.header("X-Version", &self.tamanu_version)
+			.send()
+			.await
+			.into_diagnostic()
+			.wrap_err("GET via canopy")
+	}
+
 	/// POST an event to the canopy server.
 	///
 	/// In tailscale mode, `base_url` is ignored and [`TAILSCALE_URL`] is used.


### PR DESCRIPTION
🤖

The snippet fetcher hit \`meta.tamanu.app\` over the public internet. This routes through the canopy connection when available so the request rides tailscale (preferred) or mTLS — matching how the alertd daemon talks to canopy.

Adds a generic \`CanopyClient::get(base_url, tailscale_path, mtls_path)\` helper, since canopy previously only exposed POST-shaped methods. The psql snippet provider builds a canopy client from the running Tamanu install's \`tamanu_version\` + device key, falling back to direct fetch when canopy isn't reachable or returns a non-success status.

The expected tailscale endpoint is \`/public/bestool/snippets\` (under the only mount accessible to tagged-device callers); mTLS keeps the existing \`/bestool/snippets\` path.