### PR TITLE
feat(tamanu/doctor): add Skip status; reflect unknown state honestly

### DIFF
--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -394,6 +394,7 @@ fn write_check_line<W: Write>(
 ) -> std::io::Result<()> {
 	let tag_coloured = match &check.status {
 		CheckStatus::Pass => colour_pass(use_colours, "PASS"),
+		CheckStatus::Skip(_) => colour_skip(use_colours, "SKIP"),
 		CheckStatus::Warning(_) => colour_warn(use_colours, "WARN"),
 		CheckStatus::Fail(_) => colour_fail(use_colours, "FAIL"),
 	};
@@ -404,7 +405,7 @@ fn write_check_line<W: Write>(
 		width = name_width,
 		summary = check.summary,
 	)?;
-	if let CheckStatus::Warning(r) | CheckStatus::Fail(r) = &check.status {
+	if let CheckStatus::Skip(r) | CheckStatus::Warning(r) | CheckStatus::Fail(r) = &check.status {
 		let dim = if use_colours {
 			format!("{}", r.dimmed())
 		} else {
@@ -426,10 +427,11 @@ fn write_result_line<W: Write>(
 	overall: OverallResult,
 	use_colours: bool,
 ) -> std::io::Result<()> {
-	let (mut warnings, mut fails) = (0usize, 0usize);
+	let (mut warnings, mut fails, mut skips) = (0usize, 0usize, 0usize);
 	for (check, _) in results {
 		match &check.status {
 			CheckStatus::Pass => {}
+			CheckStatus::Skip(_) => skips += 1,
 			CheckStatus::Warning(_) => warnings += 1,
 			CheckStatus::Fail(_) => fails += 1,
 		}
@@ -440,9 +442,14 @@ fn write_result_line<W: Write>(
 		OverallResult::Degraded => colour_warn(use_colours, label),
 		OverallResult::Failing => colour_fail(use_colours, label),
 	};
+	let skip_suffix = if skips > 0 {
+		format!(", {skips} skipped")
+	} else {
+		String::new()
+	};
 	writeln!(
 		out,
-		"Result: {label_coloured} ({fails} failed, {warnings} warning{plural})",
+		"Result: {label_coloured} ({fails} failed, {warnings} warning{plural}{skip_suffix})",
 		plural = if warnings == 1 { "" } else { "s" },
 	)
 }
@@ -521,6 +528,14 @@ fn colour_pass(use_colours: bool, s: &str) -> String {
 	}
 }
 
+fn colour_skip(use_colours: bool, s: &str) -> String {
+	if use_colours {
+		format!("{}", s.dimmed().bold())
+	} else {
+		s.to_string()
+	}
+}
+
 fn colour_warn(use_colours: bool, s: &str) -> String {
 	if use_colours {
 		format!("{}", s.yellow().bold())
@@ -549,6 +564,9 @@ mod tests {
 	}
 	fn fail(name: &'static str) -> (Check, bool) {
 		(Check::fail(name, "bad", "reason"), true)
+	}
+	fn skip(name: &'static str) -> (Check, bool) {
+		(Check::skip(name, "not run", "reason"), true)
 	}
 
 	#[test]
@@ -612,6 +630,38 @@ mod tests {
 		assert!(out.contains("WARN"));
 		assert!(out.contains("DEGRADED"));
 		assert!(out.contains("1 warning"));
+	}
+
+	#[test]
+	fn skip_renders_as_skip_and_doesnt_degrade_overall() {
+		// A skipped check should appear with the SKIP tag, not be counted as
+		// a warning or failure, and keep the overall result HEALTHY.
+		let results = vec![pass("a"), skip("b")];
+		let overall =
+			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		assert_eq!(overall, OverallResult::Healthy);
+
+		let mut buf = Vec::new();
+		render(&mut buf, Some("sid"), &results, overall, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert!(out.contains("SKIP"));
+		assert!(out.contains("HEALTHY"));
+		assert!(out.contains("1 skipped"));
+		// Skip should NOT bump the warning count
+		assert!(!out.contains("1 warning"));
+	}
+
+	#[test]
+	fn skip_is_healthy_on_wire() {
+		// The whole point of distinguishing Skip from Fail/Warning is that
+		// "we don't know" shouldn't fire alerts downstream of the wire format.
+		let results = vec![pass("a"), skip("b")];
+		let overall =
+			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let payload = build_payload(&Value::Object(Default::default()), &results, overall);
+		assert_eq!(payload["healthy"], true);
+		assert_eq!(payload["health"][1]["healthy"], true);
+		assert_eq!(payload["health"][1]["skipped"], true);
 	}
 
 	#[test]

--- a/crates/tamanu/src/doctor/check.rs
+++ b/crates/tamanu/src/doctor/check.rs
@@ -5,6 +5,12 @@ use serde_json::{Map, Value};
 pub enum CheckStatus {
 	/// All good.
 	Pass,
+	/// The check couldn't be run — either the platform doesn't support it, the
+	/// caller lacked the privilege to query the underlying source, or the
+	/// upstream (e.g. caddy `/metrics`) wasn't reachable. Reported as
+	/// `healthy: true` on the wire (we have no evidence of unhealth) but does
+	/// NOT count as "passing" in human-readable output.
+	Skip(String),
 	/// Non-fatal degradation. Reported as `healthy: false` per-check on the
 	/// canopy wire format, but does NOT flip the top-level `healthy` flag.
 	Warning(String),
@@ -16,12 +22,17 @@ pub enum CheckStatus {
 impl CheckStatus {
 	/// Whether this status maps to `healthy: true` in the per-check wire format.
 	pub fn is_healthy_on_wire(&self) -> bool {
-		matches!(self, CheckStatus::Pass)
+		matches!(self, CheckStatus::Pass | CheckStatus::Skip(_))
 	}
 
 	/// Whether this status is fatal (flips top-level `healthy` to false).
 	pub fn is_fatal(&self) -> bool {
 		matches!(self, CheckStatus::Fail(_))
+	}
+
+	/// Whether this status is a skip — useful for rendering and accounting.
+	pub fn is_skip(&self) -> bool {
+		matches!(self, CheckStatus::Skip(_))
 	}
 }
 
@@ -44,6 +55,20 @@ impl Check {
 			status: CheckStatus::Pass,
 			summary: summary.into(),
 			details: Map::new(),
+		}
+	}
+
+	/// Build a Skip result. The `reason` is recorded in `details.reason` (or
+	/// kept on the status) so the operator sees *why* the check couldn't be
+	/// run; the summary is the short headline shown alongside `SKIP`.
+	pub fn skip(name: &'static str, summary: impl Into<String>, reason: impl Into<String>) -> Self {
+		let mut details = Map::new();
+		details.insert("skipped".into(), Value::Bool(true));
+		Self {
+			name,
+			status: CheckStatus::Skip(reason.into()),
+			summary: summary.into(),
+			details,
 		}
 	}
 
@@ -148,6 +173,36 @@ mod tests {
 		let s = CheckStatus::Fail("f".into());
 		assert!(!s.is_healthy_on_wire());
 		assert!(s.is_fatal());
+	}
+
+	#[test]
+	fn skip_is_healthy_on_wire_and_not_fatal() {
+		// Skip means "we didn't run this check" — it must not fire alerts
+		// or flip the top-level healthy flag, since we have no evidence of
+		// unhealth either way.
+		let s = CheckStatus::Skip("reason".into());
+		assert!(s.is_healthy_on_wire());
+		assert!(!s.is_fatal());
+		assert!(s.is_skip());
+	}
+
+	#[test]
+	fn skip_does_not_change_overall_result() {
+		let with_skip = vec![Check::pass("a", ""), Check::skip("b", "", "r")];
+		assert_eq!(
+			OverallResult::from_checks(&with_skip),
+			OverallResult::Healthy
+		);
+	}
+
+	#[test]
+	fn skip_constructor_marks_skipped_detail() {
+		let c = Check::skip("memory", "not available", "platform mismatch");
+		assert_eq!(
+			c.details.get("skipped").and_then(Value::as_bool),
+			Some(true)
+		);
+		assert!(matches!(c.status, CheckStatus::Skip(_)));
 	}
 
 	#[test]

--- a/crates/tamanu/src/doctor/checks/external_users.rs
+++ b/crates/tamanu/src/doctor/checks/external_users.rs
@@ -43,9 +43,12 @@ struct ExternalUser {
 
 pub async fn run(_ctx: CheckContext) -> Check {
 	let mut users = match collect_users().await {
-		Ok(u) => u,
+		Ok(CollectOutcome::Users(u)) => u,
+		Ok(CollectOutcome::Unavailable(reason)) => {
+			return Check::skip("external_users", "could not enumerate logins", reason);
+		}
 		Err(err) => {
-			return Check::warning(
+			return Check::skip(
 				"external_users",
 				"could not enumerate logins",
 				err.to_string(),
@@ -143,8 +146,20 @@ fn humanise_age(d: Duration) -> String {
 	}
 }
 
+/// Outcome of trying to enumerate sessions.
+///
+/// `Unavailable` is distinct from `Users(empty)`: on Windows, `quser` exits
+/// non-zero (typically with "No User exists for *") both when there genuinely
+/// are no sessions *and* when the caller doesn't have the privilege to list
+/// them. Treating both the same way silently turned a permission failure into
+/// a falsely cheerful PASS, which is the opposite of what the operator needs.
+enum CollectOutcome {
+	Users(Vec<ExternalUser>),
+	Unavailable(String),
+}
+
 #[cfg(unix)]
-async fn collect_users() -> miette::Result<Vec<ExternalUser>> {
+async fn collect_users() -> miette::Result<CollectOutcome> {
 	let output = spawn_blocking(|| {
 		duct::cmd!("who")
 			.stdout_capture()
@@ -157,20 +172,24 @@ async fn collect_users() -> miette::Result<Vec<ExternalUser>> {
 	.map_err(|e| miette::miette!("running who: {e}"))?;
 
 	if !output.status.success() {
-		debug!(
-			status = ?output.status,
-			stderr = %String::from_utf8_lossy(&output.stderr),
-			"who returned non-zero"
-		);
-		return Ok(Vec::new());
+		let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+		debug!(status = ?output.status, %stderr, "who returned non-zero");
+		return Ok(CollectOutcome::Unavailable(format!(
+			"who returned non-zero{}",
+			if stderr.is_empty() {
+				String::new()
+			} else {
+				format!(": {stderr}")
+			}
+		)));
 	}
 
 	let text = String::from_utf8_lossy(&output.stdout);
-	Ok(parse_who(&text))
+	Ok(CollectOutcome::Users(parse_who(&text)))
 }
 
 #[cfg(windows)]
-async fn collect_users() -> miette::Result<Vec<ExternalUser>> {
+async fn collect_users() -> miette::Result<CollectOutcome> {
 	let output = spawn_blocking(|| {
 		duct::cmd!("quser")
 			.stdout_capture()
@@ -182,22 +201,39 @@ async fn collect_users() -> miette::Result<Vec<ExternalUser>> {
 	.map_err(|e| miette::miette!("running quser: {e}"))?
 	.map_err(|e| miette::miette!("running quser: {e}"))?;
 
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	// `quser` returns exit code 1 + "No User exists for *" when the session
+	// list is empty, but it *also* returns non-zero when access is denied.
+	// We treat the "empty list" message as a real empty, and anything else
+	// non-zero as a skip-worthy "we couldn't determine the list".
 	if !output.status.success() {
 		debug!(
 			status = ?output.status,
-			stderr = %String::from_utf8_lossy(&output.stderr),
+			%stderr,
 			"quser returned non-zero"
 		);
-		return Ok(Vec::new());
+		if stderr.to_lowercase().contains("no user exists for *") {
+			return Ok(CollectOutcome::Users(Vec::new()));
+		}
+		return Ok(CollectOutcome::Unavailable(format!(
+			"quser returned non-zero{}",
+			if stderr.trim().is_empty() {
+				String::new()
+			} else {
+				format!(": {}", stderr.trim())
+			}
+		)));
 	}
 
 	let text = String::from_utf8_lossy(&output.stdout);
-	Ok(parse_quser(&text))
+	Ok(CollectOutcome::Users(parse_quser(&text)))
 }
 
 #[cfg(not(any(unix, windows)))]
-async fn collect_users() -> miette::Result<Vec<ExternalUser>> {
-	Ok(Vec::new())
+async fn collect_users() -> miette::Result<CollectOutcome> {
+	Ok(CollectOutcome::Unavailable(
+		"session enumeration not implemented for this platform".into(),
+	))
 }
 
 /// Parse `who` output into structured sessions.

--- a/crates/tamanu/src/doctor/checks/http_errors.rs
+++ b/crates/tamanu/src/doctor/checks/http_errors.rs
@@ -105,26 +105,29 @@ async fn fetch_counts(client: &reqwest::Client) -> FetchResult {
 		Ok(resp) if resp.status().is_success() => match resp.text().await {
 			Ok(t) => t,
 			Err(err) => {
-				return FetchResult::Skip(
-					Check::pass("http_errors", "caddy /metrics body read failed")
-						.with_detail("skipped", true)
-						.with_detail("reason", err.to_string()),
-				);
+				return FetchResult::Skip(Check::skip(
+					"http_errors",
+					"caddy /metrics body read failed",
+					err.to_string(),
+				));
 			}
 		},
 		Ok(resp) => {
-			return FetchResult::Skip(
-				Check::pass(
-					"http_errors",
-					format!("caddy /metrics returned HTTP {}", resp.status().as_u16()),
-				)
-				.with_detail("skipped", true),
-			);
+			let status = resp.status().as_u16();
+			return FetchResult::Skip(Check::skip(
+				"http_errors",
+				format!("caddy /metrics returned HTTP {status}"),
+				format!(
+					"caddy is reachable but its admin /metrics endpoint isn't usable (HTTP {status}) — error rate cannot be measured"
+				),
+			));
 		}
-		Err(_) => {
-			return FetchResult::Skip(
-				Check::pass("http_errors", "caddy admin unreachable").with_detail("skipped", true),
-			);
+		Err(err) => {
+			return FetchResult::Skip(Check::skip(
+				"http_errors",
+				"caddy admin unreachable",
+				format!("could not reach caddy admin at {CADDY_METRICS_URL}: {err}"),
+			));
 		}
 	};
 

--- a/crates/tamanu/src/doctor/checks/load.rs
+++ b/crates/tamanu/src/doctor/checks/load.rs
@@ -4,12 +4,15 @@ use super::CheckContext;
 use crate::doctor::check::Check;
 
 pub async fn run(_ctx: CheckContext) -> Check {
-	let load = System::load_average();
 	if cfg!(target_os = "windows") {
-		return Check::pass("load", "load average not available on Windows")
-			.with_detail("skipped", true);
+		return Check::skip(
+			"load",
+			"not available on Windows",
+			"sysinfo does not report load average on Windows",
+		);
 	}
 
+	let load = System::load_average();
 	let summary = format!(
 		"load average: {:.2}, {:.2}, {:.2}",
 		load.one, load.five, load.fifteen

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -32,7 +32,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Supervisor::Systemd => match discover_systemd() {
 			Ok(d) => d,
 			Err(err) => {
-				return Check::fail("tamanu_service", "systemctl unavailable", err)
+				return Check::skip("tamanu_service", "systemctl unavailable", err)
 					.with_detail("supervisor", "systemd");
 			}
 		},
@@ -42,11 +42,21 @@ pub async fn run(ctx: CheckContext) -> Check {
 				d
 			}
 			Err(err) => {
-				return Check::fail("tamanu_service", "pm2 unavailable", err)
-					.with_detail("supervisor", "pm2");
+				return Check::warning(
+					"tamanu_service",
+					"pm2 status could not be queried",
+					format!(
+						"pm2 unavailable ({err}); services may be running but we can't tell from this user. Run elevated to confirm."
+					),
+				)
+				.with_detail("supervisor", "pm2");
 			}
 		},
 	};
+
+	if let Some(check) = pm2_dump_fallback_indeterminate(pm2_source, &discovered) {
+		return check;
+	}
 
 	// Probe `is-enabled` for any Down expectation whose unit didn't show up in
 	// `list-units` — catches `enabled-but-not-loaded` cases (rare but possible).
@@ -72,6 +82,38 @@ pub async fn run(ctx: CheckContext) -> Check {
 	}
 
 	evaluate_with_source(supervisor, &expectations, &discovered, pm2_source)
+}
+
+/// Decide whether we should bail out as "indeterminate" before evaluating
+/// expectations.
+///
+/// When the pm2 CLI is unreachable and we fall back to reading `dump.pm2`,
+/// we lose the only source of truth for *which* processes are actually
+/// running — running=false then just means "we couldn't read that pid file"
+/// or "we couldn't see those processes in the OS table", both of which are
+/// classic permission symptoms on Windows. Reporting FAIL here would lie:
+/// the services are probably fine, we just can't tell. Warn instead so the
+/// operator knows to re-run elevated.
+fn pm2_dump_fallback_indeterminate(
+	pm2_source: Option<pm2::Source>,
+	discovered: &[Discovered],
+) -> Option<Check> {
+	if matches!(pm2_source, Some(pm2::Source::Dump))
+		&& !discovered.is_empty()
+		&& discovered.iter().all(|d| !d.running)
+	{
+		Some(
+			Check::warning(
+				"tamanu_service",
+				"pm2 process state indeterminate",
+				"read pm2's dump file but couldn't verify any process is alive — likely a permissions issue (try running elevated)",
+			)
+			.with_detail("supervisor", "pm2")
+			.with_detail("pm2_source", pm2::Source::Dump.as_str()),
+		)
+	} else {
+		None
+	}
 }
 
 fn systemd_is_enabled(name: &str) -> bool {
@@ -641,6 +683,63 @@ mod tests {
 		];
 		let check = evaluate(Supervisor::Pm2, &exps, &discovered);
 		assert!(matches!(check.status, CheckStatus::Pass), "{check:?}");
+	}
+
+	#[test]
+	fn pm2_dump_fallback_with_all_not_running_yields_warning() {
+		let discovered = vec![
+			Discovered {
+				name: "tamanu-api".into(),
+				instance: None,
+				running: false,
+				present: true,
+				raw: "tamanu-api".into(),
+			},
+			Discovered {
+				name: "tamanu-tasks".into(),
+				instance: None,
+				running: false,
+				present: true,
+				raw: "tamanu-tasks".into(),
+			},
+		];
+		let check =
+			pm2_dump_fallback_indeterminate(Some(pm2::Source::Dump), &discovered).expect("warn");
+		assert!(matches!(check.status, CheckStatus::Warning(_)));
+	}
+
+	#[test]
+	fn pm2_dump_fallback_with_any_running_does_not_skip() {
+		let discovered = vec![
+			Discovered {
+				name: "tamanu-api".into(),
+				instance: None,
+				running: true,
+				present: true,
+				raw: "tamanu-api".into(),
+			},
+			Discovered {
+				name: "tamanu-tasks".into(),
+				instance: None,
+				running: false,
+				present: true,
+				raw: "tamanu-tasks".into(),
+			},
+		];
+		assert!(pm2_dump_fallback_indeterminate(Some(pm2::Source::Dump), &discovered).is_none());
+	}
+
+	#[test]
+	fn pm2_cli_source_skips_dump_fallback_heuristic() {
+		// CLI is authoritative — even if everything shows down, that's the truth.
+		let discovered = vec![Discovered {
+			name: "tamanu-api".into(),
+			instance: None,
+			running: false,
+			present: true,
+			raw: "tamanu-api".into(),
+		}];
+		assert!(pm2_dump_fallback_indeterminate(Some(pm2::Source::Cli), &discovered).is_none());
 	}
 
 	#[test]

--- a/crates/tamanu/src/doctor/checks/time_sync.rs
+++ b/crates/tamanu/src/doctor/checks/time_sync.rs
@@ -4,18 +4,27 @@ use super::CheckContext;
 use crate::doctor::check::Check;
 
 pub async fn run(_ctx: CheckContext) -> Check {
-	if !cfg!(target_os = "linux") {
-		return Check::pass("time_sync", "time sync check skipped (non-Linux)")
-			.with_detail("skipped", true);
+	if cfg!(target_os = "linux") {
+		return run_linux();
 	}
+	if cfg!(target_os = "windows") {
+		return run_windows();
+	}
+	Check::skip(
+		"time_sync",
+		"not supported on this platform",
+		"no time-sync probe available outside Linux and Windows",
+	)
+}
 
+fn run_linux() -> Check {
 	let output = match Command::new("timedatectl")
 		.args(["show", "-p", "NTPSynchronized", "--value"])
 		.output()
 	{
 		Ok(o) if o.status.success() => o,
 		Ok(_) | Err(_) => {
-			return Check::warning(
+			return Check::skip(
 				"time_sync",
 				"timedatectl unavailable",
 				"could not run timedatectl",
@@ -38,4 +47,146 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	check
 		.with_detail("synchronized", synced)
 		.with_detail("service", "timedatectl")
+}
+
+/// Probe Windows time service via `w32tm /query /status`.
+///
+/// We look for two signals:
+///   * a `Source:` line that *isn't* "Local CMOS Clock" / "Free-running System
+///     Clock" — anything else (an NTP peer, domain controller, etc.) means the
+///     machine is genuinely getting time from somewhere upstream;
+///   * a `Leap Indicator:` line that contains "no warning" — the standard
+///     "all good" sentinel.
+///
+/// If neither line is present (older Windows builds, locked-down configs), we
+/// skip rather than guessing.
+fn run_windows() -> Check {
+	let output = match Command::new("w32tm").args(["/query", "/status"]).output() {
+		Ok(o) if o.status.success() => o,
+		Ok(_) | Err(_) => {
+			return Check::skip(
+				"time_sync",
+				"w32tm unavailable",
+				"could not run w32tm /query /status (W32Time service not running?)",
+			)
+			.with_detail("synchronized", serde_json::Value::Null);
+		}
+	};
+	let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+	let parsed = parse_w32tm_status(&stdout);
+
+	let check = match parsed.synchronized {
+		Some(true) => Check::pass(
+			"time_sync",
+			format!(
+				"NTP synchronised{}",
+				parsed
+					.source
+					.as_deref()
+					.map(|s| format!(" via {s}"))
+					.unwrap_or_default()
+			),
+		),
+		Some(false) => Check::warning(
+			"time_sync",
+			"NTP not synchronised",
+			parsed
+				.source
+				.as_deref()
+				.map(|s| format!("source is {s}"))
+				.unwrap_or_else(|| "w32tm reports unsynchronised".to_string()),
+		),
+		None => Check::skip(
+			"time_sync",
+			"w32tm output unparseable",
+			"could not determine synchronisation state from w32tm output",
+		),
+	};
+	let mut check = check.with_detail("service", "w32tm");
+	if let Some(s) = parsed.source {
+		check = check.with_detail("source", s);
+	}
+	if let Some(b) = parsed.synchronized {
+		check = check.with_detail("synchronized", b);
+	}
+	check
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct W32TmStatus {
+	source: Option<String>,
+	synchronized: Option<bool>,
+}
+
+fn parse_w32tm_status(text: &str) -> W32TmStatus {
+	let mut out = W32TmStatus::default();
+	for line in text.lines() {
+		let line = line.trim();
+		if let Some(rest) = line.strip_prefix("Source:") {
+			let s = rest.trim().to_string();
+			if !s.is_empty() {
+				out.source = Some(s);
+			}
+		} else if let Some(rest) = line.strip_prefix("Leap Indicator:") {
+			// Sample: "Leap Indicator: 0(no warning)". "no warning" is the
+			// good signal; anything else (or absent) means not synced.
+			out.synchronized = Some(rest.to_lowercase().contains("no warning"));
+		}
+	}
+	// If we never saw the Leap Indicator line but the source is the local
+	// clock, treat that as "not synced from upstream".
+	if out.synchronized.is_none()
+		&& let Some(src) = out.source.as_deref()
+		&& (src.eq_ignore_ascii_case("Local CMOS Clock")
+			|| src.eq_ignore_ascii_case("Free-running System Clock"))
+	{
+		out.synchronized = Some(false);
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_w32tm_synchronised_with_peer() {
+		let text = "Leap Indicator: 0(no warning)\n\
+		            Stratum: 3 (secondary reference)\n\
+		            Source: time.windows.com,0x1\n";
+		assert_eq!(
+			parse_w32tm_status(text),
+			W32TmStatus {
+				source: Some("time.windows.com,0x1".into()),
+				synchronized: Some(true),
+			}
+		);
+	}
+
+	#[test]
+	fn parses_w32tm_unsynchronised_local_clock() {
+		let text = "Stratum: 0\nSource: Local CMOS Clock\n";
+		assert_eq!(
+			parse_w32tm_status(text),
+			W32TmStatus {
+				source: Some("Local CMOS Clock".into()),
+				synchronized: Some(false),
+			}
+		);
+	}
+
+	#[test]
+	fn parses_w32tm_leap_other_than_no_warning_is_unsync() {
+		let text = "Leap Indicator: 3(not synchronised)\nSource: foo\n";
+		assert_eq!(
+			parse_w32tm_status(text).synchronized,
+			Some(false),
+			"any leap indicator that isn't \"no warning\" means out of sync"
+		);
+	}
+
+	#[test]
+	fn parses_w32tm_unparseable_yields_none() {
+		assert_eq!(parse_w32tm_status("garbage\n\n").synchronized, None);
+	}
 }


### PR DESCRIPTION
🤖

Stacks on #359.

Several doctor checks have been quietly lying about state they didn't actually have:

- \`tamanu_service\` on Windows under an unprivileged user falls back to reading \`dump.pm2\` and pid files; when pid files aren't readable, every process shows running=false and the check FAILs with "services down" — but the services are almost certainly fine, we just can't see them.
- \`external_users\` falls back to an empty list when \`quser\` errors on Windows, then reports PASS "no interactive users connected" — even though the failure was likely a permissions issue.
- \`load\`, \`time_sync\`, and \`http_errors\` all returned PASS when they couldn't actually run (load: Windows; time_sync: non-Linux; http_errors: caddy /metrics unreachable or 404).

This adds a \`Skip\` variant to \`CheckStatus\` so "we couldn't check" is distinct from "we checked and it's fine":

- on the wire: \`healthy: true\` (no evidence of unhealth) with \`skipped: true\`
- in the CLI: a dim \`SKIP\` tag plus a reason on the next line
- doesn't affect the overall result or counts against warnings

Per-check updates:

- \`load\` — Windows → Skip
- \`time_sync\` — non-Linux → Skip; **adds a Windows implementation** using \`w32tm /query /status\` (parses Source and Leap Indicator)
- \`external_users\` — distinguishes \`quser\`'s "no users" message from other non-zero exits; the latter → Skip
- \`http_errors\` — caddy unreachable / metrics 404 → Skip
- \`tamanu_service\` — pm2 CLI unreachable → Warning ("queriable state unknown"); pm2 dump fallback with all processes showing not-running → Warning (very likely a permissions issue, not real outage)

Tests cover the new variant on the framework side, the dump-fallback heuristic, and the Windows w32tm output parser.