### PR TITLE
feat(tamanu): broader, signal-redundant facility/central detection

### DIFF
--- a/crates/bestool/src/actions/tamanu.rs
+++ b/crates/bestool/src/actions/tamanu.rs
@@ -8,7 +8,6 @@ use crate::args::Args;
 
 use super::Context;
 
-pub use bestool_tamanu::find_package;
 use bestool_tamanu::find_tamanu as _find_tamanu;
 
 #[cfg(feature = "tamanu-lifecycle")]

--- a/crates/bestool/src/actions/tamanu/backup_configs.rs
+++ b/crates/bestool/src/actions/tamanu/backup_configs.rs
@@ -17,12 +17,17 @@ use crate::{
 	actions::{
 		tamanu::{
 			backup::{process_backup, Then},
-			find_package, find_tamanu, TamanuArgs,
+			find_tamanu, TamanuArgs,
 		},
 		Context,
 	},
 	now_time,
 };
+
+/// Packages that may carry config under `root/packages/<name>/config/`.
+/// Both are tried so the backup picks up whichever is actually installed
+/// without needing to commit to a "this is a central / facility" detection.
+const TAMANU_PACKAGES: &[&str] = &["central-server", "facility-server"];
 
 /// Backup local Tamanu-related config files to a zip archive.
 ///
@@ -171,8 +176,12 @@ pub async fn run(args: BackupConfigsArgs, ctx: Context) -> Result<()> {
 		.wrap_err("creating dest dir")?;
 
 	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
-	let kind = find_package(&root);
-	let config = load_config(&root, Some(kind.package_name()))?;
+	// Load config without forcing a specific package: load_config tries each
+	// package directory in order and picks the first that exists. Combined
+	// with the now-broader `is_facility()` detection, this avoids the old
+	// `find_package` filesystem walk (which doesn't work for container-based
+	// Linux deployments where there's no `packages/` dir at all).
+	let config = load_config(&root, None)?;
 
 	let output = Path::new(&args.write_to).join(make_backup_filename(&config));
 
@@ -200,8 +209,14 @@ pub async fn run(args: BackupConfigsArgs, ctx: Context) -> Result<()> {
 	add_file(&mut zip, root.join("pm2.config.cjs"), "pm2.config.cjs");
 	add_dir(&mut zip, root.join("alerts"), "alerts/version")?;
 	add_dir(&mut zip, r"C:\Tamanu\alerts", "alerts/global")?;
-	if let Some(path) = find_config_dir(&root, Some(kind.package_name()), ".") {
-		add_dir(&mut zip, path, kind.package_name())?;
+	// Back up whichever package config dirs exist on this host. We don't try
+	// to commit to "this is a facility / central" here — both could in
+	// principle be present on a host that's been re-roled, and there's no
+	// cost to archiving both if both directories are populated.
+	for package in TAMANU_PACKAGES {
+		if let Some(path) = find_config_dir(&root, Some(package), ".") {
+			add_dir(&mut zip, path, package)?;
+		}
 	}
 
 	zip.finish()

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -11,7 +11,7 @@ use node_semver::Version;
 use owo_colors::OwoColorize;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use bestool_tamanu::{
 	config::{TamanuConfig, load_config},
@@ -186,10 +186,14 @@ pub(super) async fn perform_sweep(
 		Err(_) => None,
 	};
 
+	let kind = bestool_tamanu::detect_kind(&config, db.as_deref()).await;
+	debug!(?kind, "detected Tamanu server kind for doctor sweep");
+
 	let check_ctx = CheckContext {
 		tamanu_version: version.clone(),
 		tamanu_root: root.to_path_buf(),
 		config: config.clone(),
+		kind,
 		database_url: database_url.to_owned(),
 		db: db.clone(),
 		http_client,

--- a/crates/tamanu/src/config/structure.rs
+++ b/crates/tamanu/src/config/structure.rs
@@ -7,13 +7,19 @@ use url::Url;
 pub struct TamanuConfig {
 	pub canonical_host_name: Option<Url>,
 	pub canonical_url: Option<Url>,
+	/// Current (multi-facility) form. Newer installs only.
 	pub server_facility_ids: Option<Vec<String>>,
+	/// Legacy single-facility form. Still in use on older facility installs.
+	pub server_facility_id: Option<String>,
 	pub db: Database,
 	pub mailgun: Option<Mailgun>,
 	pub primary_time_zone: Option<String>,
 	pub country_time_zone: Option<String>,
 	#[serde(default)]
 	pub integrations: Integrations,
+	/// `sync` block. Only configured on facility servers — central servers have
+	/// no sync target, so its presence is a reliable "is this a facility" signal.
+	pub sync: Option<Sync>,
 }
 
 impl TamanuConfig {
@@ -23,10 +29,27 @@ impl TamanuConfig {
 			.or(self.canonical_url.as_ref())
 	}
 
+	/// Identify the server as a facility from any one of three independent
+	/// config signals.
+	///
+	/// Central servers have *none* of these populated; any one being present is
+	/// taken as facility. We check all three because real-world facility
+	/// installs vary by Tamanu vintage:
+	///
+	///   * `serverFacilityIds` (plural) — current multi-facility form
+	///   * `serverFacilityId` (singular) — legacy single-facility form, still
+	///     in active use on older facility installs
+	///   * `sync.host` — only configured on facilities (centrals have no
+	///     upstream to sync to)
 	pub fn is_facility(&self) -> bool {
 		self.server_facility_ids
 			.as_ref()
 			.is_some_and(|ids| !ids.is_empty())
+			|| self
+				.server_facility_id
+				.as_ref()
+				.is_some_and(|id| !id.is_empty())
+			|| self.sync.as_ref().is_some_and(|s| s.host.is_some())
 	}
 
 	/// Mirrors `getPrimaryTimeZone()` in Tamanu: prefers `primaryTimeZone`,
@@ -52,6 +75,14 @@ impl TamanuConfig {
 #[serde(default, rename_all = "camelCase")]
 pub struct Integrations {
 	pub fhir: Fhir,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Sync {
+	/// URL of the central server this facility syncs against. Only set on
+	/// facility servers.
+	pub host: Option<Url>,
 }
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
@@ -110,6 +141,58 @@ mod tests {
 		serde_json::json!({
 			"db": { "name": "x", "username": "u", "password": "p" },
 		})
+	}
+
+	#[test]
+	fn central_has_no_facility_signals() {
+		assert!(!parse(base()).is_facility());
+	}
+
+	#[test]
+	fn server_facility_ids_plural_marks_facility() {
+		let mut json = base();
+		json["serverFacilityIds"] = serde_json::json!(["facility-x"]);
+		assert!(parse(json).is_facility());
+	}
+
+	#[test]
+	fn empty_server_facility_ids_does_not_mark_facility() {
+		let mut json = base();
+		json["serverFacilityIds"] = serde_json::json!([]);
+		assert!(!parse(json).is_facility());
+	}
+
+	#[test]
+	fn legacy_singular_server_facility_id_marks_facility() {
+		// Older facility installs use the singular form. This was the case
+		// that misclassified a real facility as central in production.
+		let mut json = base();
+		json["serverFacilityId"] = serde_json::json!("facility-x");
+		assert!(parse(json).is_facility());
+	}
+
+	#[test]
+	fn empty_singular_server_facility_id_does_not_mark_facility() {
+		let mut json = base();
+		json["serverFacilityId"] = serde_json::json!("");
+		assert!(!parse(json).is_facility());
+	}
+
+	#[test]
+	fn sync_host_marks_facility() {
+		// Central servers have no upstream to sync to; presence of `sync.host`
+		// is a positive facility signal independent of the serverFacilityId(s)
+		// fields.
+		let mut json = base();
+		json["sync"] = serde_json::json!({ "host": "https://central.example.org" });
+		assert!(parse(json).is_facility());
+	}
+
+	#[test]
+	fn empty_sync_block_does_not_mark_facility() {
+		let mut json = base();
+		json["sync"] = serde_json::json!({});
+		assert!(!parse(json).is_facility());
 	}
 
 	#[test]

--- a/crates/tamanu/src/doctor/checks.rs
+++ b/crates/tamanu/src/doctor/checks.rs
@@ -9,7 +9,7 @@ use std::{path::PathBuf, sync::Arc};
 use node_semver::Version;
 use tokio_postgres::Client as PgClient;
 
-use crate::config::TamanuConfig;
+use crate::{ApiServerKind, config::TamanuConfig};
 
 use super::check::Check;
 
@@ -44,6 +44,11 @@ pub struct CheckContext {
 	pub tamanu_version: Version,
 	pub tamanu_root: PathBuf,
 	pub config: Arc<TamanuConfig>,
+	/// Whether this install is a central or facility server. Determined once
+	/// at doctor startup from the most authoritative available signals (DB
+	/// `local_system_facts` first, then config), then shared so checks don't
+	/// each have to re-decide.
+	pub kind: ApiServerKind,
 	pub database_url: String,
 	pub db: Option<Arc<PgClient>>,
 	pub http_client: reqwest::Client,

--- a/crates/tamanu/src/doctor/checks/tamanu_found.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_found.rs
@@ -1,11 +1,10 @@
 use super::CheckContext;
-use crate::doctor::check::Check;
+use crate::{ApiServerKind, doctor::check::Check};
 
 pub async fn run(ctx: CheckContext) -> Check {
-	let kind = if ctx.config.is_facility() {
-		"facility"
-	} else {
-		"central"
+	let kind = match ctx.kind {
+		ApiServerKind::Facility => "facility",
+		ApiServerKind::Central => "central",
 	};
 	let summary = format!(
 		"Tamanu {} at {} ({kind})",

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -4,7 +4,6 @@ use serde_json::{Value, json};
 
 use super::CheckContext;
 use crate::{
-	ApiServerKind,
 	doctor::check::Check,
 	pm2,
 	services::{Expectation, ExpectedState, Instances, Supervisor, expected, parse_systemd_unit},
@@ -20,12 +19,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 			.with_detail("skipped", true);
 	};
 
-	let kind = if ctx.config.is_facility() {
-		ApiServerKind::Facility
-	} else {
-		ApiServerKind::Central
-	};
-	let expectations = expected(supervisor, kind, &ctx.config);
+	let expectations = expected(supervisor, ctx.kind, &ctx.config);
 
 	let mut pm2_source: Option<pm2::Source> = None;
 	let mut discovered = match supervisor {
@@ -445,8 +439,7 @@ fn outcome_to_json(o: &Outcome) -> Value {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::config::TamanuConfig;
-	use crate::doctor::check::CheckStatus;
+	use crate::{ApiServerKind, config::TamanuConfig, doctor::check::CheckStatus};
 
 	fn cfg(fhir_worker: bool) -> TamanuConfig {
 		let json = serde_json::json!({

--- a/crates/tamanu/src/lib.rs
+++ b/crates/tamanu/src/lib.rs
@@ -1,10 +1,8 @@
 use std::{
 	fmt::Debug,
-	fs,
 	path::{Path, PathBuf},
 };
 
-use itertools::Itertools;
 use miette::{IntoDiagnostic, Result, miette};
 use node_semver::Version;
 use tracing::{debug, instrument};
@@ -62,21 +60,125 @@ pub fn find_tamanu(root: Option<&Path>) -> Result<(Version, PathBuf)> {
 	inner(root).inspect(|(version, root)| debug!(?root, ?version, "found Tamanu root"))
 }
 
-#[instrument(level = "debug")]
-pub fn find_package(root: impl AsRef<Path> + Debug) -> ApiServerKind {
-	fn inner(root: &Path) -> Result<ApiServerKind> {
-		fs::read_dir(root.join("packages"))
-			.into_diagnostic()?
-			.filter_map_ok(|e| e.file_name().into_string().ok())
-			.process_results(|mut iter| {
-				iter.find_map(|dir_name| ApiServerKind::from_str_ci(&dir_name))
-					.ok_or_else(|| miette!("Tamanu servers not found"))
-			})
-			.into_diagnostic()?
+/// Decide whether a Tamanu install is a facility or a central server.
+///
+/// Two complementary signals, in order of trust:
+///
+/// 1. **Tamanu's local DB**, when available. The `local_system_facts` table
+///    carries `facilityIds` and `syncHost` rows that the application itself
+///    only populates on facility servers. This is the most authoritative
+///    signal we have, since it reflects what the running Tamanu actually
+///    thinks it is — independent of config-file vintage or layout.
+/// 2. **The loaded config** (`TamanuConfig::is_facility`), which is checked
+///    when the DB signal isn't conclusive (no DB client, or no matching
+///    rows). Looks at three independent fields: `serverFacilityIds` (plural,
+///    new), `serverFacilityId` (singular, legacy — still in real-world
+///    facility use), and `sync.host` (only set on facilities).
+///
+/// On disagreement between DB and config, the DB wins and we log a debug
+/// breadcrumb. Filesystem-based detection (looking at `packages/<name>`) was
+/// previously used here but is too fragile — container-based deployments
+/// don't have a `packages/` directory at all, and stale package directories
+/// on bare-metal installs misclassify the host.
+#[instrument(level = "debug", skip(db_client))]
+pub async fn detect_kind(
+	config: &config::TamanuConfig,
+	db_client: Option<&tokio_postgres::Client>,
+) -> ApiServerKind {
+	let config_says = if config.is_facility() {
+		Some(ApiServerKind::Facility)
+	} else {
+		None
+	};
+
+	let db_says = match db_client {
+		Some(c) => detect_kind_from_db(c).await,
+		None => None,
+	};
+
+	match (db_says, config_says) {
+		(Some(db), Some(cfg)) if db != cfg => {
+			debug!(?db, ?cfg, "DB and config disagree on kind; trusting DB");
+			db
+		}
+		(Some(k), _) | (_, Some(k)) => k,
+		(None, None) => {
+			debug!("no facility signal from DB or config; assuming central");
+			ApiServerKind::Central
+		}
+	}
+}
+
+/// Look at `local_system_facts` for facility-only keys.
+///
+/// `facilityIds` and `syncHost` are written by Tamanu's facility codepaths;
+/// their presence is a positive "this is a facility" signal. Absence isn't
+/// conclusive (the rows might just not have landed yet on a brand-new install),
+/// so we return `None` rather than `Some(Central)` when no facility key is
+/// found — leaving the caller to fall back to config-based detection.
+async fn detect_kind_from_db(client: &tokio_postgres::Client) -> Option<ApiServerKind> {
+	match client
+		.query_opt(
+			"SELECT 1 FROM local_system_facts WHERE key IN ('facilityIds', 'syncHost') LIMIT 1",
+			&[],
+		)
+		.await
+	{
+		Ok(Some(_)) => Some(ApiServerKind::Facility),
+		Ok(None) => None,
+		Err(err) => {
+			debug!(%err, "could not query local_system_facts for kind detection");
+			None
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn cfg_from(json: serde_json::Value) -> config::TamanuConfig {
+		serde_json::from_value(json).expect("test config should parse")
 	}
 
-	inner(root.as_ref())
-		.inspect(|kind| debug!(?root, ?kind, "using this Tamanu for config"))
-		.map_err(|err| debug!(?err, "failed to detect package, assuming facility"))
-		.unwrap_or(ApiServerKind::Facility)
+	#[tokio::test]
+	async fn no_db_no_signal_defaults_to_central() {
+		// Config without any facility marker and no DB → central. That's
+		// the "fresh empty config" path; we used to return Facility from
+		// `find_package` here, which is wrong on container deployments.
+		let cfg = cfg_from(serde_json::json!({
+			"db": { "name": "x", "username": "u", "password": "p" },
+		}));
+		assert_eq!(detect_kind(&cfg, None).await, ApiServerKind::Central);
+	}
+
+	#[tokio::test]
+	async fn config_facility_signal_without_db() {
+		let cfg = cfg_from(serde_json::json!({
+			"db": { "name": "x", "username": "u", "password": "p" },
+			"serverFacilityIds": ["f1"],
+		}));
+		assert_eq!(detect_kind(&cfg, None).await, ApiServerKind::Facility);
+	}
+
+	#[tokio::test]
+	async fn legacy_singular_field_detected_without_db() {
+		// The real-world case the user flagged: a facility using the
+		// pre-multi-facility singular `serverFacilityId` field was being
+		// reported as central. After this change, no DB call needed.
+		let cfg = cfg_from(serde_json::json!({
+			"db": { "name": "x", "username": "u", "password": "p" },
+			"serverFacilityId": "f1",
+		}));
+		assert_eq!(detect_kind(&cfg, None).await, ApiServerKind::Facility);
+	}
+
+	#[tokio::test]
+	async fn sync_host_detected_without_db() {
+		let cfg = cfg_from(serde_json::json!({
+			"db": { "name": "x", "username": "u", "password": "p" },
+			"sync": { "host": "https://central.example.org" },
+		}));
+		assert_eq!(detect_kind(&cfg, None).await, ApiServerKind::Facility);
+	}
 }


### PR DESCRIPTION
🤖

A facility install was being misclassified as central because it uses the legacy singular `serverFacilityId` field name, which our `is_facility()` didn't check. The previous detector also leaned on a filesystem walk of `root/packages/*` that doesn't work at all for container-based deployments (no `packages/` dir).

Changes:

- `TamanuConfig::is_facility()` now accepts any of three independent signals:
  - `serverFacilityIds` (plural, current form)
  - `serverFacilityId` (singular, legacy — still in active use)
  - `sync.host` (only configured on facilities; centrals have no upstream)
- New `bestool_tamanu::detect_kind(&config, db_client)` combines that with a DB-side check: rows in `local_system_facts` with key `facilityIds` or `syncHost` are written by Tamanu only on facility servers, so their presence is an authoritative facility signal. DB wins on disagreement.
- `CheckContext` now carries a single `kind: ApiServerKind`, computed once at doctor startup. `tamanu_found` and `tamanu_service` consume it instead of each recomputing from the config.
- Removed `find_package` (the directory-based detector) — too brittle, doesn't apply to container deployments. `backup_configs` (the only other caller) now iterates both possible package config dirs and archives whichever it finds.

Tests cover all three config signals (including the legacy singular form), the no-signal default, and the new `detect_kind` precedence rules.
