### PR TITLE
fix(tamanu/logs): drop blank lines from journalctl output

### DIFF
--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -338,6 +338,13 @@ fn run_journalctl(
 			Ok(l) => l,
 			Err(_) => break,
 		};
+		// `journalctl --output=cat` emits the raw MESSAGE field, which is empty
+		// for some service log records (e.g. heartbeat / no-op messages) and
+		// also gets emitted as a blank line when journald separators slip
+		// through. Either way they're noise — skip them.
+		if line.trim().is_empty() {
+			continue;
+		}
 		let formatted = format_log_line(&line, use_colours);
 		if writeln!(out, "{formatted}").is_err() {
 			break;


### PR DESCRIPTION
🤖

\`tamanu logs\` reading from journalctl was passing through empty lines that journald slips into the stream with \`--output=cat\` (services that log empty MESSAGE records, or boundary separators that occasionally leak through). They were just noise.

Skips lines that are empty or whitespace-only after trimming.