### PR TITLE
fix(tamanu/doctor): report bestool version from caller, not tamanu crate

### DIFF
--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -183,7 +183,12 @@ pub(super) async fn perform_sweep(
 
 	let facts = collect_server_facts(&config, db.as_deref(), cached_pg_version).await;
 	let pg_version = facts.pg_version.clone();
-	let info = server_info::gather(&version.to_string(), facts).await;
+	// `env!("CARGO_PKG_VERSION")` here resolves at *this* crate's compile time
+	// — the bestool crate — which is what we want in the wire payload. The
+	// same expression inside `bestool-tamanu` resolves to that library's
+	// version (0.1.x) and gave the wrong answer before this argument existed.
+	let info =
+		server_info::gather(env!("CARGO_PKG_VERSION"), &version.to_string(), facts).await;
 	let info_value = serde_json::to_value(&info).into_diagnostic()?;
 
 	let overall =

--- a/crates/tamanu/src/doctor/server_info.rs
+++ b/crates/tamanu/src/doctor/server_info.rs
@@ -86,7 +86,19 @@ pub struct ServerFacts {
 	pub pg_version: Option<String>,
 }
 
-pub async fn gather(tamanu_version: &str, facts: ServerFacts) -> ServerInfo {
+/// Build the status-payload `ServerInfo` block.
+///
+/// `bestool_version` is the version of the *calling* bestool binary — it must
+/// be provided by the caller (typically `env!("CARGO_PKG_VERSION")` resolved
+/// in the bestool crate) rather than evaluated here, because this code lives
+/// in the `bestool-tamanu` library crate, where `env!("CARGO_PKG_VERSION")`
+/// would resolve to that crate's own version (`bestool-tamanu`, currently 0.1.x)
+/// — the bug this signature change fixes.
+pub async fn gather(
+	bestool_version: &'static str,
+	tamanu_version: &str,
+	facts: ServerFacts,
+) -> ServerInfo {
 	let disks = Disks::new_with_refreshed_list();
 	let filesystems = disks
 		.iter()
@@ -106,7 +118,7 @@ pub async fn gather(tamanu_version: &str, facts: ServerFacts) -> ServerInfo {
 		.map(|s| s.to_string());
 
 	ServerInfo {
-		bestool_version: env!("CARGO_PKG_VERSION"),
+		bestool_version,
 		tamanu_version: tamanu_version.to_string(),
 		hostname: System::host_name(),
 		canonical_url: facts.canonical_url,


### PR DESCRIPTION
🤖

When the doctor code moved into \`bestool-tamanu\`, the \`bestoolVersion\` field in the status payload started reporting \`0.1.x\` — that's the version of the \`bestool-tamanu\` library crate, because \`env!("CARGO_PKG_VERSION")\` resolves at the crate where it's written. The actual bestool binary's version (1.11.x today) was never reaching the wire.

\`gather()\` now takes \`bestool_version: &'static str\` as a parameter, and the single caller in the bestool crate passes \`env!("CARGO_PKG_VERSION")\` from there, where it correctly resolves to bestool's version.