### PR TITLE
fix(tamanu): fhir worker enabled lives at integrations.fhir.worker.enabled

### DIFF
--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -537,7 +537,7 @@ mod tests {
 	fn cfg(facility: bool, fhir_worker: bool) -> TamanuConfig {
 		let mut json = serde_json::json!({
 			"db": { "name": "x", "username": "u", "password": "p" },
-			"fhir": { "worker": { "enabled": fhir_worker } },
+			"integrations": { "fhir": { "worker": { "enabled": fhir_worker } } },
 		});
 		if facility {
 			json["serverFacilityIds"] = serde_json::json!(["facility-x"]);

--- a/crates/tamanu/src/config/structure.rs
+++ b/crates/tamanu/src/config/structure.rs
@@ -13,7 +13,7 @@ pub struct TamanuConfig {
 	pub primary_time_zone: Option<String>,
 	pub country_time_zone: Option<String>,
 	#[serde(default)]
-	pub fhir: Fhir,
+	pub integrations: Integrations,
 }
 
 impl TamanuConfig {
@@ -38,8 +38,20 @@ impl TamanuConfig {
 	}
 
 	pub fn fhir_worker_enabled(&self) -> bool {
-		self.fhir.worker.enabled
+		self.integrations.fhir.worker.enabled
 	}
+}
+
+/// The `integrations` block of the Tamanu config.
+///
+/// Tamanu groups all third-party / optional subsystem toggles here. The only
+/// field we currently care about is `fhir` (so we know whether the FHIR worker
+/// services should be Up or Down), but the struct exists as its own type so
+/// future integration probes have an obvious home.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct Integrations {
+	pub fhir: Fhir,
 }
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
@@ -84,4 +96,48 @@ pub struct Mailgun {
 
 	#[serde(rename = "from")]
 	pub sender: String,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn parse(json: serde_json::Value) -> TamanuConfig {
+		serde_json::from_value(json).expect("test config should parse")
+	}
+
+	fn base() -> serde_json::Value {
+		serde_json::json!({
+			"db": { "name": "x", "username": "u", "password": "p" },
+		})
+	}
+
+	#[test]
+	fn fhir_worker_enabled_reads_integrations_path() {
+		let mut json = base();
+		json["integrations"] = serde_json::json!({ "fhir": { "worker": { "enabled": true } } });
+		assert!(parse(json).fhir_worker_enabled());
+	}
+
+	#[test]
+	fn fhir_worker_disabled_when_integrations_says_false() {
+		let mut json = base();
+		json["integrations"] = serde_json::json!({ "fhir": { "worker": { "enabled": false } } });
+		assert!(!parse(json).fhir_worker_enabled());
+	}
+
+	#[test]
+	fn fhir_worker_disabled_when_integrations_missing() {
+		assert!(!parse(base()).fhir_worker_enabled());
+	}
+
+	#[test]
+	fn legacy_top_level_fhir_field_is_ignored() {
+		// The old (wrong) location. We don't honour it — the actual schema
+		// puts this under `integrations.fhir.worker.enabled`, and pretending
+		// the top-level key still works would hide real misconfigurations.
+		let mut json = base();
+		json["fhir"] = serde_json::json!({ "worker": { "enabled": true } });
+		assert!(!parse(json).fhir_worker_enabled());
+	}
 }

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -410,7 +410,7 @@ mod tests {
 		let json = serde_json::json!({
 			"db": { "name": "x", "username": "u", "password": "p" },
 			"serverFacilityIds": ["facility-x"],
-			"fhir": { "worker": { "enabled": fhir_worker } },
+			"integrations": { "fhir": { "worker": { "enabled": fhir_worker } } },
 		});
 		serde_json::from_value(json).unwrap()
 	}
@@ -418,7 +418,7 @@ mod tests {
 	fn central_cfg(fhir_worker: bool) -> TamanuConfig {
 		let json = serde_json::json!({
 			"db": { "name": "x", "username": "u", "password": "p" },
-			"fhir": { "worker": { "enabled": fhir_worker } },
+			"integrations": { "fhir": { "worker": { "enabled": fhir_worker } } },
 		});
 		serde_json::from_value(json).unwrap()
 	}

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -166,26 +166,33 @@ pub fn expected(
 
 	match kind {
 		ApiServerKind::Central => {
-			if config.fhir_worker_enabled() {
-				let (resolve, refresh) = match supervisor {
-					Supervisor::Pm2 => ("tamanu-fhir-resolve", "tamanu-fhir-refresh"),
-					Supervisor::Systemd => {
-						("tamanu-central-fhir-resolve", "tamanu-central-fhir-refresh")
-					}
-				};
-				out.push(Expectation {
-					name: resolve,
-					instances: Instances::Single,
-					state: ExpectedState::Up,
-					criticality: Criticality::Background,
-				});
-				out.push(Expectation {
-					name: refresh,
-					instances: Instances::Single,
-					state: ExpectedState::Up,
-					criticality: Criticality::Background,
-				});
-			}
+			let (resolve, refresh) = match supervisor {
+				Supervisor::Pm2 => ("tamanu-fhir-resolve", "tamanu-fhir-refresh"),
+				Supervisor::Systemd => {
+					("tamanu-central-fhir-resolve", "tamanu-central-fhir-refresh")
+				}
+			};
+			// FHIR services are expected Up when the worker is enabled in
+			// config, and explicitly Down when it isn't — that way the doctor
+			// catches the case where a deployment leaves the worker units
+			// running after `integrations.fhir.worker.enabled` is flipped off.
+			let fhir_state = if config.fhir_worker_enabled() {
+				ExpectedState::Up
+			} else {
+				ExpectedState::Down
+			};
+			out.push(Expectation {
+				name: resolve,
+				instances: Instances::Single,
+				state: fhir_state,
+				criticality: Criticality::Background,
+			});
+			out.push(Expectation {
+				name: refresh,
+				instances: Instances::Single,
+				state: fhir_state,
+				criticality: Criticality::Background,
+			});
 		}
 		ApiServerKind::Facility => {
 			let sync_name = match supervisor {
@@ -266,7 +273,7 @@ mod tests {
 	fn cfg(fhir_worker: bool) -> TamanuConfig {
 		let json = serde_json::json!({
 			"db": { "name": "x", "username": "u", "password": "p" },
-			"fhir": { "worker": { "enabled": fhir_worker } },
+			"integrations": { "fhir": { "worker": { "enabled": fhir_worker } } },
 		});
 		serde_json::from_value(json).unwrap()
 	}
@@ -287,9 +294,29 @@ mod tests {
 	}
 
 	#[test]
-	fn central_pm2_no_fhir_skips_fhir_units() {
+	fn central_pm2_with_fhir_disabled_expects_fhir_units_down() {
+		// With the FHIR worker disabled in config, we want the doctor to
+		// alert if the corresponding services are still running — that's
+		// usually a deploy that's flipped the toggle without taking the
+		// units down. So the expectations exist, but with state Down.
 		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(false));
-		assert_eq!(names(&es), vec!["tamanu-tasks", "tamanu-api"]);
+		assert_eq!(
+			names(&es),
+			vec![
+				"tamanu-tasks",
+				"tamanu-api",
+				"tamanu-fhir-resolve",
+				"tamanu-fhir-refresh",
+			]
+		);
+		for n in ["tamanu-fhir-resolve", "tamanu-fhir-refresh"] {
+			let e = es.iter().find(|e| e.name == n).unwrap();
+			assert_eq!(
+				e.state,
+				ExpectedState::Down,
+				"{n} should be expected Down when fhir.worker.enabled = false"
+			);
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
🤖

We were reading \`fhir.worker.enabled\` at the top of the config, but the real path is \`integrations.fhir.worker.enabled\`. The top-level field simply doesn't exist, so \`fhir_worker_enabled()\` was always returning false on any deployment with FHIR turned on — making the doctor *not* expect the FHIR worker units on central servers that actually run them.

While we're here: when \`integrations.fhir.worker.enabled\` is **false** on a central server, the FHIR services are now expected explicitly Down rather than just dropped from the expectation set. That catches the inverse problem — a deployment that flips the toggle off in config without taking the actual systemd / pm2 units down.

- New \`Integrations\` config struct with \`fhir: Fhir\` underneath.
- \`fhir_worker_enabled()\` reads \`integrations.fhir.worker.enabled\`.
- Central FHIR expectations always present; state Up when enabled, Down when not.
- Test fixtures updated to use the new path; new config-side tests cover the integrations path, missing block, and the legacy top-level field being intentionally ignored.