### PR TITLE
feat(tamanu): doctor reads latest sweep from local alertd when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "trycmd",

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -193,6 +193,7 @@ pub async fn run_with_shutdown_and_reload(
 		let dry_run_for_server = daemon_config.dry_run;
 		let scheduler_for_server = scheduler.clone();
 		let reload_tx_for_server = reload_tx.clone();
+		let background_tasks_for_server = daemon_config.background_tasks.clone();
 		tokio::spawn(async move {
 			// Wait for event manager to be initialised
 			let event_mgr = loop {
@@ -213,6 +214,7 @@ pub async fn run_with_shutdown_and_reload(
 				daemon_config.server_addrs.clone(),
 				scheduler_for_server,
 				watchdog_timeout_for_server,
+				&background_tasks_for_server,
 			)
 			.await;
 		});

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -1,6 +1,6 @@
 //! HTTP server for alertd daemon control and metrics.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use axum::{
 	Router,
@@ -11,7 +11,13 @@ use tokio::sync::mpsc;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::{Level, error, info, warn};
 
-use crate::{EmailConfig, alert::InternalContext, events::EventManager, scheduler::Scheduler};
+use crate::{
+	EmailConfig,
+	alert::InternalContext,
+	events::EventManager,
+	scheduler::Scheduler,
+	tasks::{BackgroundTask, TaskEndpointHandler},
+};
 
 mod endpoints;
 mod state;
@@ -36,9 +42,12 @@ pub async fn start_server(
 	addrs: Vec<std::net::SocketAddr>,
 	scheduler: Arc<Scheduler>,
 	watchdog_timeout: Option<Duration>,
+	background_tasks: &[Arc<dyn BackgroundTask>],
 ) {
 	let started_at = Timestamp::now();
 	let pid = std::process::id();
+
+	let task_endpoints = collect_task_endpoints(background_tasks);
 
 	let state = ServerState {
 		reload_tx,
@@ -50,6 +59,7 @@ pub async fn start_server(
 		dry_run,
 		scheduler,
 		watchdog_timeout,
+		task_endpoints: Arc::new(task_endpoints),
 	};
 
 	let app = Router::new()
@@ -61,6 +71,7 @@ pub async fn start_server(
 		.route("/metrics", get(handle_metrics))
 		.route("/status", get(handle_status))
 		.route("/health", get(handle_health))
+		.route("/tasks/{task}/{endpoint}", get(handle_task_endpoint))
 		.layer(
 			TraceLayer::new_for_http()
 				.make_span_with(
@@ -132,4 +143,31 @@ pub async fn start_server(
 	if let Err(e) = axum::serve(listener, app).await {
 		error!("HTTP server error: {}", e);
 	}
+}
+
+fn collect_task_endpoints(
+	tasks: &[Arc<dyn BackgroundTask>],
+) -> HashMap<(String, String), TaskEndpointHandler> {
+	let mut map = HashMap::new();
+	for task in tasks {
+		let task_name = task.name();
+		for endpoint in task.http_endpoints() {
+			let key = (task_name.to_string(), endpoint.name.to_string());
+			if map.contains_key(&key) {
+				warn!(
+					task = task_name,
+					endpoint = endpoint.name,
+					"duplicate task endpoint name; later registration wins"
+				);
+			}
+			info!(
+				task = task_name,
+				endpoint = endpoint.name,
+				path = %format!("/tasks/{task_name}/{}", endpoint.name),
+				"mounting task endpoint"
+			);
+			map.insert(key, endpoint.handler);
+		}
+	}
+	map
 }

--- a/crates/alertd/src/http_server/endpoints.rs
+++ b/crates/alertd/src/http_server/endpoints.rs
@@ -6,6 +6,7 @@ mod pause_alert;
 mod reload;
 mod status;
 mod targets;
+mod tasks;
 mod validate;
 
 pub use alerts::handle_alerts;
@@ -16,4 +17,5 @@ pub use pause_alert::handle_pause_alert;
 pub use reload::handle_reload;
 pub use status::handle_status;
 pub use targets::handle_targets;
+pub use tasks::handle_task_endpoint;
 pub use validate::handle_validate;

--- a/crates/alertd/src/http_server/endpoints/reload.rs
+++ b/crates/alertd/src/http_server/endpoints/reload.rs
@@ -57,6 +57,7 @@ mod tests {
 			dry_run: true,
 			scheduler,
 			watchdog_timeout: None,
+			task_endpoints: Arc::new(std::collections::HashMap::new()),
 		});
 
 		let response = handle_reload(State(state)).await.into_response();

--- a/crates/alertd/src/http_server/endpoints/tasks.rs
+++ b/crates/alertd/src/http_server/endpoints/tasks.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use axum::{
+	Json,
+	body::Body,
+	extract::{Path, State},
+	http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
+	response::{IntoResponse, Response},
+};
+use futures::StreamExt;
+use tracing::warn;
+
+use crate::{
+	http_server::state::ServerState,
+	tasks::{TaskContext, TaskEndpointResponse},
+};
+
+/// Route handler for `/tasks/:task/:endpoint`.
+///
+/// Looks up the handler the named background task exposed (via
+/// `BackgroundTask::http_endpoints`) and invokes it with a fresh
+/// `TaskContext` built from the daemon's internal resources. The handler's
+/// `TaskEndpointResponse` is serialised to JSON or NDJSON depending on its
+/// variant.
+pub async fn handle_task_endpoint(
+	State(state): State<Arc<ServerState>>,
+	Path((task, endpoint)): Path<(String, String)>,
+) -> Response {
+	let Some(handler) = state.task_endpoints.get(&(task.clone(), endpoint.clone())) else {
+		return (
+			StatusCode::NOT_FOUND,
+			format!("no endpoint at /tasks/{task}/{endpoint}"),
+		)
+			.into_response();
+	};
+
+	let ctx = TaskContext::from_internal(&state.internal_context);
+	let response = handler(ctx).await;
+
+	match response {
+		TaskEndpointResponse::Json(value) => Json(value).into_response(),
+		TaskEndpointResponse::JsonLines(stream) => {
+			let body = Body::from_stream(stream.map(|value| {
+				// One JSON value per line, NDJSON style. Newline-on-end keeps
+				// the last record syntactically self-contained for readers
+				// using `read_line`-style framing.
+				let mut bytes = serde_json::to_vec(&value).unwrap_or_else(|err| {
+					warn!(%err, "could not serialise task endpoint stream value");
+					b"{}".to_vec()
+				});
+				bytes.push(b'\n');
+				Ok::<_, std::convert::Infallible>(bytes)
+			}));
+			let mut response = Response::new(body);
+			response.headers_mut().insert(
+				CONTENT_TYPE,
+				HeaderValue::from_static("application/x-ndjson"),
+			);
+			response
+		}
+		TaskEndpointResponse::Error { status, message } => (
+			StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+			message,
+		)
+			.into_response(),
+	}
+}

--- a/crates/alertd/src/http_server/state.rs
+++ b/crates/alertd/src/http_server/state.rs
@@ -1,9 +1,12 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use jiff::Timestamp;
 use tokio::sync::mpsc;
 
-use crate::{EmailConfig, alert::InternalContext, events::EventManager, scheduler::Scheduler};
+use crate::{
+	EmailConfig, alert::InternalContext, events::EventManager, scheduler::Scheduler,
+	tasks::TaskEndpointHandler,
+};
 
 #[derive(Clone)]
 pub struct ServerState {
@@ -16,4 +19,8 @@ pub struct ServerState {
 	pub dry_run: bool,
 	pub scheduler: Arc<Scheduler>,
 	pub watchdog_timeout: Option<Duration>,
+	/// Endpoint handlers exposed by registered background tasks. Keyed by
+	/// `(task_name, endpoint_name)` so the `/tasks/:task/:endpoint` route can
+	/// dispatch in O(1) without walking the task registry per request.
+	pub task_endpoints: Arc<HashMap<(String, String), TaskEndpointHandler>>,
 }

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use jiff::Timestamp;
 use tokio::sync::mpsc;
@@ -36,5 +36,6 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		dry_run: true,
 		scheduler,
 		watchdog_timeout: Some(std::time::Duration::from_secs(600)),
+		task_endpoints: Arc::new(HashMap::new()),
 	})
 }

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -15,7 +15,7 @@ mod metrics;
 pub mod scheduler;
 pub mod state_file;
 mod targets;
-mod tasks;
+pub mod tasks;
 pub mod templates;
 
 #[cfg(windows)]
@@ -27,7 +27,7 @@ pub use events::EventType;
 pub use targets::{
 	AlertTargets, ExternalTarget, ResolvedTarget, SendTarget, TargetConnection, TargetEmail,
 };
-pub use tasks::{BackgroundTask, TaskContext};
+pub use tasks::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
 
 /// The version of the alertd library
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/alertd/src/tasks.rs
+++ b/crates/alertd/src/tasks.rs
@@ -1,7 +1,8 @@
 use std::{sync::Arc, time::Duration};
 
-use futures::future::BoxFuture;
+use futures::{future::BoxFuture, stream::BoxStream};
 use miette::Result;
+use serde_json::Value;
 
 use crate::{alert::InternalContext, canopy::CanopyClient};
 
@@ -31,8 +32,52 @@ impl TaskContext {
 /// The daemon spawns one tokio task per registered plugin at startup and ticks
 /// it at `interval()`. Each tick counts as activity for the watchdog. Errors
 /// returned from `run` are logged but don't kill the daemon.
+///
+/// Tasks can optionally expose HTTP endpoints (e.g. to surface their latest
+/// computed state, or to trigger an on-demand re-run) via [`Self::http_endpoints`].
+/// The daemon mounts each at `/tasks/{task-name}/{endpoint-name}` and routes
+/// matching requests to the handler.
 pub trait BackgroundTask: Send + Sync + 'static {
 	fn name(&self) -> &'static str;
 	fn interval(&self) -> Duration;
 	fn run<'a>(&'a self, ctx: &'a TaskContext) -> BoxFuture<'a, Result<()>>;
+	/// Endpoints this task wants the daemon to expose under
+	/// `/tasks/{self.name()}/{endpoint.name}`.
+	///
+	/// Default is "no endpoints". Endpoint handlers are 'static closures, so
+	/// they should capture an `Arc` of whatever shared state they need rather
+	/// than borrowing from `self`.
+	fn http_endpoints(&self) -> Vec<TaskEndpoint> {
+		Vec::new()
+	}
+}
+
+/// One HTTP endpoint a `BackgroundTask` exposes through the daemon.
+pub struct TaskEndpoint {
+	/// Name segment appended after `/tasks/{task}/` to form the URL path.
+	pub name: &'static str,
+	pub handler: TaskEndpointHandler,
+}
+
+/// Handler invoked when a request hits `/tasks/{task}/{endpoint}`.
+///
+/// The daemon hands the handler a fresh `TaskContext` (built from the
+/// daemon's own resources) and awaits the future.
+pub type TaskEndpointHandler =
+	Arc<dyn Fn(TaskContext) -> BoxFuture<'static, TaskEndpointResponse> + Send + Sync + 'static>;
+
+/// What an endpoint handler returns to the daemon for it to serialise.
+///
+/// `JsonLines` is for streaming: the daemon writes each yielded `Value` as a
+/// JSON-encoded line followed by `\n`, with `Content-Type:
+/// application/x-ndjson`. That's how the doctor's "recompute" endpoint
+/// surfaces per-check progress to consumers like `bestool tamanu doctor`.
+pub enum TaskEndpointResponse {
+	Json(Value),
+	JsonLines(BoxStream<'static, Value>),
+	/// 4xx / 5xx response with a plain-text body.
+	Error {
+		status: u16,
+		message: String,
+	},
 }

--- a/crates/alertd/tests/reload.rs
+++ b/crates/alertd/tests/reload.rs
@@ -54,6 +54,7 @@ async fn test_status_endpoint_response_format() {
 		dry_run: true,
 		scheduler,
 		watchdog_timeout: None,
+		task_endpoints: Arc::new(std::collections::HashMap::new()),
 	});
 
 	// This verifies the response structure without needing a full daemon

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -79,6 +79,7 @@ tera = { version = "1.19.1", optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-uuid-1"], optional = true }
+tokio-stream = { version = "0.1.17", optional = true }
 tokio-util = { workspace = true, optional = true }
 tracing = { workspace = true }
 upgrade = { version = "2.0.1", optional = true }
@@ -145,7 +146,7 @@ tamanu-alerts = [
 	"dep:tokio-postgres",
 	"dep:walkdir",
 ]
-tamanu-alertd = ["__tamanu", "tamanu-config", "dep:bestool-alertd", "dep:p256", "dep:serde_path_to_error", "dep:serde_yaml", "dep:tokio-postgres", "dep:walkdir"]
+tamanu-alertd = ["__tamanu", "tamanu-config", "bestool-tamanu/doctor", "dep:bestool-alertd", "dep:p256", "dep:serde_path_to_error", "dep:serde_yaml", "dep:tokio-postgres", "dep:tokio-stream", "dep:walkdir"]
 tamanu-artifacts = ["__tamanu", "dep:comfy-table", "dep:detect-targets", "dep:target-tuples"]
 tamanu-backup = ["__tamanu", "file", "tamanu-config", "dep:bestool-psql", "dep:algae-cli", "dep:duct"]
 tamanu-backup-configs = ["__tamanu", "tamanu-backup", "dep:walkdir", "dep:zip"]

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1594,9 +1594,11 @@ Aliases: db, u, url
 
 Gather server info + healthchecks for a Tamanu install
 
-Runs a set of healthchecks against the local Tamanu install and renders a
-colour-coded summary. The alertd daemon runs the same checks every minute
-and pushes results to Canopy; this command is for interactive operator use.
+If the alertd daemon is running on this host (with its HTTP server bound to
+the default localhost port), the most recently computed sweep is fetched
+from it and rendered, with a note saying when those checks were actually
+computed. Otherwise — or with `--fresh` / `--no-daemon` — the checks are
+run locally.
 
 Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING.
 
@@ -1607,6 +1609,10 @@ Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING.
 * `--json` — Emit the JSON wire payload instead of the human-readable render
 * `--check <NAME>` — Run only the named check(s). Repeatable. Defaults to all
 * `--skip <NAME>` — Skip the named check(s). Repeatable. Applied after `--check`
+* `--fresh` — Force a fresh sweep. With alertd running, asks the daemon to recompute and streams the results back as they come in; without alertd, runs the checks locally exactly like before
+* `--no-daemon` — Skip the alertd integration entirely and always compute locally.
+
+   Combined with `--fresh` this is a no-op (a local sweep is always fresh).
 
 
 

--- a/crates/bestool/src/actions/tamanu/alertd/doctor_task.rs
+++ b/crates/bestool/src/actions/tamanu/alertd/doctor_task.rs
@@ -1,19 +1,34 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use bestool_alertd::{BackgroundTask, TaskContext, canopy::DEFAULT_CANOPY_URL};
-use bestool_tamanu::config::TamanuConfig;
-use futures::future::BoxFuture;
+use bestool_alertd::{
+	BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse,
+	canopy::DEFAULT_CANOPY_URL,
+	tasks::TaskEndpointHandler,
+};
+use bestool_tamanu::{config::TamanuConfig, doctor::progress::DoctorEvent};
+use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
+use jiff::Timestamp;
 use miette::{Result, miette};
 use node_semver::Version;
 use reqwest::Url;
-use tokio::sync::Mutex;
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, mpsc};
 use tracing::warn;
 
 use crate::actions::tamanu::doctor;
 
 const DOCTOR_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Periodic doctor sweep, plus on-demand `latest` / `recompute` HTTP endpoints.
+///
+/// The outer struct just holds an `Arc<Inner>` so we can hand inner clones to
+/// the `'static` HTTP endpoint handlers without forcing the trait method
+/// `http_endpoints` to take `self: Arc<Self>`.
 pub struct DoctorTask {
+	inner: Arc<DoctorTaskInner>,
+}
+
+struct DoctorTaskInner {
 	tamanu_version: Version,
 	tamanu_root: PathBuf,
 	config: Arc<TamanuConfig>,
@@ -23,6 +38,17 @@ pub struct DoctorTask {
 	/// reaching the database. Stable for the lifetime of the PG instance, so we
 	/// reuse it across ticks instead of re-querying every minute.
 	pg_version_cache: Mutex<Option<String>>,
+	/// Latest sweep, captured on every successful tick. Served by the `latest`
+	/// HTTP endpoint so `bestool tamanu doctor` can read what the daemon
+	/// already computed instead of re-running the checks itself.
+	latest: Mutex<Option<LatestSweep>>,
+}
+
+#[derive(Clone)]
+struct LatestSweep {
+	computed_at: Timestamp,
+	payload: Value,
+	server_id: Option<String>,
 }
 
 impl DoctorTask {
@@ -33,18 +59,27 @@ impl DoctorTask {
 		database_url: String,
 	) -> Self {
 		Self {
-			tamanu_version,
-			tamanu_root,
-			config,
-			database_url,
-			canopy_base_url: DEFAULT_CANOPY_URL
-				.parse()
-				.expect("default canopy URL is valid"),
-			pg_version_cache: Mutex::new(None),
+			inner: Arc::new(DoctorTaskInner {
+				tamanu_version,
+				tamanu_root,
+				config,
+				database_url,
+				canopy_base_url: DEFAULT_CANOPY_URL
+					.parse()
+					.expect("default canopy URL is valid"),
+				pg_version_cache: Mutex::new(None),
+				latest: Mutex::new(None),
+			}),
 		}
 	}
+}
 
-	async fn tick(&self, ctx: &TaskContext) -> Result<()> {
+impl DoctorTaskInner {
+	async fn run_sweep(
+		self: &Arc<Self>,
+		ctx: &TaskContext,
+		progress: Option<bestool_tamanu::doctor::progress::ProgressSender>,
+	) -> Result<doctor::SweepResult> {
 		let cached = self.pg_version_cache.lock().await.clone();
 		let sweep = doctor::perform_sweep(
 			&self.tamanu_version,
@@ -55,7 +90,7 @@ impl DoctorTask {
 			&[],
 			&[],
 			cached,
-			None,
+			progress,
 		)
 		.await?;
 
@@ -65,6 +100,19 @@ impl DoctorTask {
 				*guard = Some(version.clone());
 			}
 		}
+
+		let latest = LatestSweep {
+			computed_at: Timestamp::now(),
+			payload: sweep.payload.clone(),
+			server_id: sweep.server_id.clone(),
+		};
+		*self.latest.lock().await = Some(latest);
+
+		Ok(sweep)
+	}
+
+	async fn tick(self: &Arc<Self>, ctx: &TaskContext) -> Result<()> {
+		let sweep = self.run_sweep(ctx, None).await?;
 
 		let Some(server_id) = sweep.server_id else {
 			warn!("no metaServerId available; skipping canopy status push");
@@ -81,6 +129,71 @@ impl DoctorTask {
 			.await
 			.map_err(|err| miette!("posting doctor status to canopy: {err}"))
 	}
+
+	/// `GET /tasks/doctor/latest` — return the last sweep this daemon
+	/// computed, or 404 if it hasn't ticked yet.
+	async fn endpoint_latest(self: Arc<Self>) -> TaskEndpointResponse {
+		let snapshot = self.latest.lock().await.clone();
+		match snapshot {
+			Some(s) => TaskEndpointResponse::Json(json!({
+				"computedAt": s.computed_at.to_string(),
+				"serverId": s.server_id,
+				"payload": s.payload,
+			})),
+			None => TaskEndpointResponse::Error {
+				status: 503,
+				message: "no doctor sweep cached yet (daemon may have just started)".into(),
+			},
+		}
+	}
+
+	/// `GET /tasks/doctor/recompute` — drive a fresh sweep and stream each
+	/// progress event back as NDJSON. Final line is the full sweep result.
+	async fn endpoint_recompute(self: Arc<Self>, ctx: TaskContext) -> TaskEndpointResponse {
+		let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<DoctorEvent>();
+		let (out_tx, out_rx) = mpsc::unbounded_channel::<Value>();
+
+		let task_self = self.clone();
+		tokio::spawn(async move {
+			let progress_forward_tx = out_tx.clone();
+			let forwarder = tokio::spawn(async move {
+				while let Some(event) = progress_rx.recv().await {
+					let DoctorEvent::Completed(check) = event;
+					let _ = progress_forward_tx.send(json!({
+						"event": "check",
+						"check": check.to_streaming_json(),
+					}));
+				}
+			});
+
+			match task_self.run_sweep(&ctx, Some(progress_tx)).await {
+				Ok(sweep) => {
+					// Make sure all `Completed` events arrived before we emit
+					// `done` — perform_sweep drops the sender on return, which
+					// closes the forwarder loop above.
+					let _ = forwarder.await;
+					let _ = out_tx.send(json!({
+						"event": "done",
+						"computedAt": Timestamp::now().to_string(),
+						"serverId": sweep.server_id,
+						"payload": sweep.payload,
+					}));
+				}
+				Err(err) => {
+					let _ = forwarder.await;
+					let _ = out_tx.send(json!({
+						"event": "error",
+						"message": format!("{err:?}"),
+					}));
+				}
+			}
+		});
+
+		let stream: BoxStream<'static, Value> = Box::pin(
+			tokio_stream::wrappers::UnboundedReceiverStream::new(out_rx).map(|v| v),
+		);
+		TaskEndpointResponse::JsonLines(stream)
+	}
 }
 
 impl BackgroundTask for DoctorTask {
@@ -93,6 +206,36 @@ impl BackgroundTask for DoctorTask {
 	}
 
 	fn run<'a>(&'a self, ctx: &'a TaskContext) -> BoxFuture<'a, Result<()>> {
-		Box::pin(self.tick(ctx))
+		let inner = self.inner.clone();
+		Box::pin(async move { inner.tick(ctx).await })
+	}
+
+	fn http_endpoints(&self) -> Vec<TaskEndpoint> {
+		let latest_handler: TaskEndpointHandler = {
+			let inner = self.inner.clone();
+			Arc::new(move |_ctx| {
+				let inner = inner.clone();
+				Box::pin(async move { inner.endpoint_latest().await })
+			})
+		};
+
+		let recompute_handler: TaskEndpointHandler = {
+			let inner = self.inner.clone();
+			Arc::new(move |ctx| {
+				let inner = inner.clone();
+				Box::pin(async move { inner.endpoint_recompute(ctx).await })
+			})
+		};
+
+		vec![
+			TaskEndpoint {
+				name: "latest",
+				handler: latest_handler,
+			},
+			TaskEndpoint {
+				name: "recompute",
+				handler: recompute_handler,
+			},
+		]
 	}
 }

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -6,7 +6,7 @@ use std::{
 
 use clap::Parser;
 use futures::stream::{FuturesUnordered, StreamExt};
-use miette::{IntoDiagnostic, Result, miette};
+use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use node_semver::Version;
 use owo_colors::OwoColorize;
 use serde_json::{Map, Value};
@@ -30,9 +30,11 @@ use crate::actions::Context;
 
 /// Gather server info + healthchecks for a Tamanu install
 ///
-/// Runs a set of healthchecks against the local Tamanu install and renders a
-/// colour-coded summary. The alertd daemon runs the same checks every minute
-/// and pushes results to Canopy; this command is for interactive operator use.
+/// If the alertd daemon is running on this host (with its HTTP server bound to
+/// the default localhost port), the most recently computed sweep is fetched
+/// from it and rendered, with a note saying when those checks were actually
+/// computed. Otherwise — or with `--fresh` / `--no-daemon` — the checks are
+/// run locally.
 ///
 /// Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING.
 #[derive(Debug, Clone, Parser)]
@@ -49,7 +51,32 @@ pub struct DoctorArgs {
 	/// Skip the named check(s). Repeatable. Applied after `--check`.
 	#[arg(long = "skip", value_name = "NAME")]
 	pub skip: Vec<String>,
+
+	/// Force a fresh sweep. With alertd running, asks the daemon to recompute
+	/// and streams the results back as they come in; without alertd, runs the
+	/// checks locally exactly like before.
+	#[arg(long)]
+	pub fresh: bool,
+
+	/// Skip the alertd integration entirely and always compute locally.
+	///
+	/// Combined with `--fresh` this is a no-op (a local sweep is always fresh).
+	#[arg(long)]
+	pub no_daemon: bool,
 }
+
+/// Where the displayed sweep came from.
+enum SweepSource {
+	/// Daemon's last periodic sweep — include `computed_at` so we can warn how
+	/// old it is in the rendered output.
+	DaemonCached { computed_at: jiff::Timestamp },
+	/// Daemon-driven fresh recompute, streamed back over the task endpoint.
+	DaemonStreamed,
+	/// Sweep we ran ourselves.
+	Local,
+}
+
+const DAEMON_BASE: &str = "http://127.0.0.1:8271";
 
 pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	let tamanu = ctx.require::<TamanuArgs>();
@@ -61,6 +88,79 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	let database_url = build_database_url(&config);
 	let http_client = reqwest::Client::new();
 
+	let (sweep, source) = if args.no_daemon {
+		(
+			run_local_sweep(
+				&version,
+				&root,
+				config.clone(),
+				&database_url,
+				http_client.clone(),
+				&args,
+				use_colours,
+			)
+			.await?,
+			SweepSource::Local,
+		)
+	} else if args.fresh {
+		match run_daemon_recompute(&http_client, &args, use_colours).await {
+			Ok(sweep) => (sweep, SweepSource::DaemonStreamed),
+			Err(err) => {
+				debug!(%err, "daemon recompute unavailable, falling back to local");
+				(
+					run_local_sweep(
+						&version,
+						&root,
+						config.clone(),
+						&database_url,
+						http_client.clone(),
+						&args,
+						use_colours,
+					)
+					.await?,
+					SweepSource::Local,
+				)
+			}
+		}
+	} else {
+		match fetch_daemon_latest(&http_client).await {
+			Ok((sweep, computed_at)) => (sweep, SweepSource::DaemonCached { computed_at }),
+			Err(err) => {
+				debug!(%err, "daemon latest unavailable, falling back to local");
+				(
+					run_local_sweep(
+						&version,
+						&root,
+						config.clone(),
+						&database_url,
+						http_client.clone(),
+						&args,
+						use_colours,
+					)
+					.await?,
+					SweepSource::Local,
+				)
+			}
+		}
+	};
+
+	render_final(&args, &sweep, &source, use_colours)?;
+
+	if sweep.overall == OverallResult::Failing {
+		std::process::exit(1);
+	}
+	Ok(())
+}
+
+async fn run_local_sweep(
+	version: &Version,
+	root: &Path,
+	config: Arc<TamanuConfig>,
+	database_url: &str,
+	http_client: reqwest::Client,
+	args: &DoctorArgs,
+	use_colours: bool,
+) -> Result<SweepResult> {
 	let live = !args.json && std::io::stdout().is_terminal();
 	let selected_names = selected_names_for_render(&args.only, &args.skip)?;
 	let renderer = if live {
@@ -78,10 +178,10 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 
 	let progress = renderer.as_ref().map(|(tx, _)| tx.clone());
 	let sweep = perform_sweep(
-		&version,
-		&root,
+		version,
+		root,
 		config,
-		&database_url,
+		database_url,
 		http_client,
 		&args.only,
 		&args.skip,
@@ -95,39 +195,303 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 		let _ = handle.await;
 	}
 
+	Ok(sweep)
+}
+
+fn render_final(
+	args: &DoctorArgs,
+	sweep: &SweepResult,
+	source: &SweepSource,
+	use_colours: bool,
+) -> Result<()> {
+	let stdout = std::io::stdout();
+	let mut out = stdout.lock();
+	let live = !args.json && std::io::stdout().is_terminal();
+
 	if args.json {
-		let stdout = std::io::stdout();
-		let mut out = stdout.lock();
-		serde_json::to_writer_pretty(&mut out, &sweep.payload).into_diagnostic()?;
+		// Embed source info alongside the payload so JSON consumers can tell
+		// where the data came from. The original payload becomes the inner
+		// `wire` field; cached daemon reads also carry `computedAt`.
+		let mut wrapped = serde_json::Map::new();
+		wrapped.insert("wire".into(), sweep.payload.clone());
+		match source {
+			SweepSource::Local => {
+				wrapped.insert("source".into(), Value::String("local".into()));
+			}
+			SweepSource::DaemonStreamed => {
+				wrapped.insert("source".into(), Value::String("daemon-streamed".into()));
+			}
+			SweepSource::DaemonCached { computed_at } => {
+				wrapped.insert("source".into(), Value::String("daemon-cached".into()));
+				wrapped.insert("computedAt".into(), Value::String(computed_at.to_string()));
+			}
+		}
+		serde_json::to_writer_pretty(&mut out, &Value::Object(wrapped)).into_diagnostic()?;
 		writeln!(out).into_diagnostic()?;
+		return Ok(());
+	}
+
+	if live {
+		// In live mode the per-check render already happened. Just append the
+		// summary + source note.
+		write_source_note(&mut out, source, use_colours).into_diagnostic()?;
+		render_summary(
+			&mut out,
+			sweep.server_id.as_deref(),
+			&sweep.results,
+			sweep.overall,
+			use_colours,
+		)
+		.into_diagnostic()?;
 	} else {
-		let stdout = std::io::stdout();
-		let mut out = stdout.lock();
-		if live {
-			render_summary(
-				&mut out,
-				sweep.server_id.as_deref(),
-				&sweep.results,
-				sweep.overall,
-				use_colours,
-			)
-			.into_diagnostic()?;
-		} else {
-			render(
-				&mut out,
-				sweep.server_id.as_deref(),
-				&sweep.results,
-				sweep.overall,
-				use_colours,
-			)
-			.into_diagnostic()?;
+		render(
+			&mut out,
+			sweep.server_id.as_deref(),
+			&sweep.results,
+			sweep.overall,
+			use_colours,
+		)
+		.into_diagnostic()?;
+		write_source_note(&mut out, source, use_colours).into_diagnostic()?;
+	}
+	Ok(())
+}
+
+fn write_source_note<W: Write>(
+	out: &mut W,
+	source: &SweepSource,
+	use_colours: bool,
+) -> std::io::Result<()> {
+	let line = match source {
+		SweepSource::Local => return Ok(()),
+		SweepSource::DaemonStreamed => "Source: alertd daemon (just now, on demand)".to_string(),
+		SweepSource::DaemonCached { computed_at } => {
+			let age = humanise_age_since(*computed_at);
+			format!("Source: alertd daemon (computed {age} ago, at {computed_at})")
+		}
+	};
+	if use_colours {
+		writeln!(out, "{}", line.dimmed())
+	} else {
+		writeln!(out, "{line}")
+	}
+}
+
+fn humanise_age_since(then: jiff::Timestamp) -> String {
+	let now = jiff::Timestamp::now();
+	let secs = now.as_second().saturating_sub(then.as_second()).max(0) as u64;
+	if secs < 60 {
+		format!("{secs}s")
+	} else if secs < 3600 {
+		format!("{}m {}s", secs / 60, secs % 60)
+	} else {
+		format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+	}
+}
+
+/// Read the alertd daemon's most recent sweep over `/tasks/doctor/latest`.
+///
+/// The short timeout is intentional: this is run on every `tamanu doctor`
+/// invocation, and if alertd isn't on this host (or its HTTP server is
+/// missing) we want to bail out fast and fall back to a local sweep.
+async fn fetch_daemon_latest(
+	http: &reqwest::Client,
+) -> Result<(SweepResult, jiff::Timestamp)> {
+	let url = format!("{DAEMON_BASE}/tasks/doctor/latest");
+	let response = http
+		.get(&url)
+		.timeout(std::time::Duration::from_secs(3))
+		.send()
+		.await
+		.into_diagnostic()
+		.wrap_err("contacting local alertd")?;
+
+	if !response.status().is_success() {
+		return Err(miette!(
+			"alertd /tasks/doctor/latest returned {}",
+			response.status()
+		));
+	}
+
+	let payload: Value = response
+		.json()
+		.await
+		.into_diagnostic()
+		.wrap_err("decoding alertd latest payload")?;
+	let computed_at: jiff::Timestamp = payload
+		.get("computedAt")
+		.and_then(Value::as_str)
+		.ok_or_else(|| miette!("alertd latest payload missing computedAt"))?
+		.parse()
+		.into_diagnostic()
+		.wrap_err("parsing computedAt timestamp")?;
+
+	let inner = payload
+		.get("payload")
+		.cloned()
+		.ok_or_else(|| miette!("alertd latest payload missing payload"))?;
+	let server_id = payload
+		.get("serverId")
+		.and_then(Value::as_str)
+		.map(str::to_string);
+
+	let overall = overall_from_payload(&inner);
+	Ok((
+		SweepResult {
+			server_id,
+			results: Vec::new(),
+			overall,
+			payload: inner,
+			pg_version: None,
+		},
+		computed_at,
+	))
+}
+
+/// Drive a fresh sweep on the daemon and stream the per-check results back.
+///
+/// Each NDJSON line is a `{"event": ...}` object; check events feed the same
+/// live renderer that local sweeps use, the final `done` event carries the
+/// full payload to render the summary off.
+async fn run_daemon_recompute(
+	http: &reqwest::Client,
+	args: &DoctorArgs,
+	use_colours: bool,
+) -> Result<SweepResult> {
+	let url = format!("{DAEMON_BASE}/tasks/doctor/recompute");
+	let response = http
+		.get(&url)
+		.timeout(std::time::Duration::from_secs(5))
+		.send()
+		.await
+		.into_diagnostic()
+		.wrap_err("contacting local alertd")?;
+
+	if !response.status().is_success() {
+		return Err(miette!(
+			"alertd /tasks/doctor/recompute returned {}",
+			response.status()
+		));
+	}
+
+	let live = !args.json && std::io::stdout().is_terminal();
+	let selected_names = selected_names_for_render(&args.only, &args.skip)?;
+	let renderer = if live {
+		let (tx, rx) = mpsc::unbounded_channel();
+		let names = selected_names.clone();
+		let handle = tokio::task::spawn_blocking(move || {
+			let stdout = std::io::stdout();
+			let mut out = stdout.lock();
+			let _ = render_live(&mut out, &names, rx, use_colours);
+		});
+		Some((tx, handle))
+	} else {
+		None
+	};
+
+	let registry = checks::all();
+	let resolve_name = |s: &str| {
+		registry
+			.iter()
+			.find(|e| e.name == s)
+			.map(|e| e.name)
+	};
+
+	let mut stream = response.bytes_stream();
+	let mut buffer = Vec::<u8>::new();
+	let mut final_payload: Option<Value> = None;
+	let mut server_id: Option<String> = None;
+
+	use futures::StreamExt as _;
+	while let Some(chunk) = stream.next().await {
+		let chunk = chunk
+			.into_diagnostic()
+			.wrap_err("reading alertd recompute stream")?;
+		buffer.extend_from_slice(&chunk);
+		while let Some(nl) = buffer.iter().position(|&b| b == b'\n') {
+			let line: Vec<u8> = buffer.drain(..=nl).collect();
+			let line = &line[..line.len() - 1];
+			if line.is_empty() {
+				continue;
+			}
+			let value: Value = match serde_json::from_slice(line) {
+				Ok(v) => v,
+				Err(err) => {
+					warn!(%err, "could not parse alertd recompute line");
+					continue;
+				}
+			};
+			match value.get("event").and_then(Value::as_str) {
+				Some("check") => {
+					if let Some(check_json) = value.get("check")
+						&& let Some(check) = Check::from_streaming_json(check_json, resolve_name)
+						&& let Some((tx, _)) = &renderer
+					{
+						let _ = tx.send(DoctorEvent::Completed(check));
+					}
+				}
+				Some("done") => {
+					final_payload = value.get("payload").cloned();
+					server_id = value
+						.get("serverId")
+						.and_then(Value::as_str)
+						.map(str::to_string);
+				}
+				Some("error") => {
+					let msg = value
+						.get("message")
+						.and_then(Value::as_str)
+						.unwrap_or("unknown");
+					return Err(miette!("alertd recompute reported error: {msg}"));
+				}
+				_ => {}
+			}
 		}
 	}
 
-	if sweep.overall == OverallResult::Failing {
-		std::process::exit(1);
+	if let Some((tx, handle)) = renderer {
+		drop(tx);
+		let _ = handle.await;
 	}
-	Ok(())
+
+	let payload = final_payload
+		.ok_or_else(|| miette!("alertd recompute stream ended without a done event"))?;
+	let overall = overall_from_payload(&payload);
+	Ok(SweepResult {
+		server_id,
+		results: Vec::new(),
+		overall,
+		payload,
+		pg_version: None,
+	})
+}
+
+fn overall_from_payload(payload: &Value) -> OverallResult {
+	let healthy = payload
+		.get("healthy")
+		.and_then(Value::as_bool)
+		.unwrap_or(true);
+	if !healthy {
+		return OverallResult::Failing;
+	}
+	// `healthy: true` covers both Healthy and Degraded — peek at the
+	// per-check entries to disambiguate. A `healthy: false` entry in a
+	// top-level-healthy payload means a warning was logged.
+	let degraded = payload
+		.get("health")
+		.and_then(Value::as_array)
+		.map(|arr| {
+			arr.iter().any(|c| {
+				c.get("healthy") == Some(&Value::Bool(false))
+					&& c.get("skipped") != Some(&Value::Bool(true))
+			})
+		})
+		.unwrap_or(false);
+	if degraded {
+		OverallResult::Degraded
+	} else {
+		OverallResult::Healthy
+	}
 }
 
 pub(super) struct SweepResult {

--- a/crates/tamanu/src/doctor/check.rs
+++ b/crates/tamanu/src/doctor/check.rs
@@ -1,4 +1,4 @@
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 
 /// Outcome of a single healthcheck.
 #[derive(Debug, Clone)]
@@ -113,6 +113,69 @@ impl Check {
 			obj.insert(k.clone(), v.clone());
 		}
 		Value::Object(obj)
+	}
+
+	/// Encode this Check for streaming over the daemon's task endpoint.
+	///
+	/// Distinct from [`Self::to_wire`]: that one is the canopy-bound payload
+	/// (which collapses Warning/Fail status to a bare `healthy: false`); this
+	/// one preserves the full `CheckStatus` enum so consumers can render the
+	/// same colours and reason lines as a local sweep.
+	pub fn to_streaming_json(&self) -> Value {
+		let (status, reason) = match &self.status {
+			CheckStatus::Pass => ("pass", None),
+			CheckStatus::Skip(r) => ("skip", Some(r.as_str())),
+			CheckStatus::Warning(r) => ("warning", Some(r.as_str())),
+			CheckStatus::Fail(r) => ("fail", Some(r.as_str())),
+		};
+		let mut obj = json!({
+			"name": self.name,
+			"status": status,
+			"summary": self.summary,
+			"details": Value::Object(self.details.clone()),
+		});
+		if let Some(r) = reason {
+			obj["reason"] = Value::String(r.to_string());
+		}
+		obj
+	}
+
+	/// Decode a [`Self::to_streaming_json`] payload back into a `Check`.
+	///
+	/// `name_resolver` is called to look the incoming name string back up to
+	/// the `&'static str` slot the registry uses, so the rendering code (which
+	/// expects `Check.name: &'static str`) keeps working. Returns `None` for
+	/// unknown names or malformed payloads — callers should drop those events.
+	pub fn from_streaming_json(
+		value: &Value,
+		name_resolver: impl FnOnce(&str) -> Option<&'static str>,
+	) -> Option<Self> {
+		let name_str = value.get("name")?.as_str()?;
+		let name = name_resolver(name_str)?;
+		let status_str = value.get("status")?.as_str()?;
+		let reason = value
+			.get("reason")
+			.and_then(Value::as_str)
+			.map(str::to_string);
+		let status = match (status_str, reason) {
+			("pass", _) => CheckStatus::Pass,
+			("skip", Some(r)) => CheckStatus::Skip(r),
+			("warning", Some(r)) => CheckStatus::Warning(r),
+			("fail", Some(r)) => CheckStatus::Fail(r),
+			_ => return None,
+		};
+		let summary = value.get("summary")?.as_str()?.to_string();
+		let details = value
+			.get("details")
+			.and_then(Value::as_object)
+			.cloned()
+			.unwrap_or_default();
+		Some(Self {
+			name,
+			status,
+			summary,
+			details,
+		})
 	}
 }
 


### PR DESCRIPTION
🤖

Stacks on #365 (depends on the live-progress + skip-status work in the doctor stack).

`bestool tamanu doctor` now talks to a locally-running alertd daemon when one's available, instead of always recomputing from scratch. The daemon already ticks the same sweep every minute and pushes to canopy; piggy-backing on that means the operator-facing command shows the same state the rest of the system sees.

### Behaviour

| Mode                     | Default      | `--fresh`                   | `--no-daemon` |
|--------------------------|--------------|-----------------------------|---------------|
| Daemon running           | cached fetch | daemon recompute (streamed) | local         |
| No daemon / fetch failed | local        | local                       | local         |

When the result comes from the daemon, the rendered output gets a dimmed "Source: alertd daemon (computed Nm Ns ago, at TIMESTAMP)" line so the operator can tell. JSON mode wraps the wire payload in `{ wire, source, computedAt? }`.

### Daemon side

The `BackgroundTask` trait grows an optional `http_endpoints()` method:

```rust
fn http_endpoints(&self) -> Vec<TaskEndpoint> { Vec::new() }
```

Returned endpoints get mounted at `/tasks/{task-name}/{endpoint-name}` by the daemon's HTTP server. Handlers can return JSON or a stream of `Value`s; the latter is emitted as `application/x-ndjson` (one JSON object per line, plain `\n`-delimited — no SSE framing).

`DoctorTask` exposes:
- `GET /tasks/doctor/latest` — last cached sweep plus its `computedAt` timestamp
- `GET /tasks/doctor/recompute` — drives a fresh sweep and streams `{event: "check", check: {...}}` per check, followed by `{event: "done", payload: {...}}`

The check stream uses a new `Check::to_streaming_json` / `Check::from_streaming_json` pair (separate from the existing `to_wire` canopy format) so the consumer sees the same `CheckStatus` enum and renders identically to a local sweep — including the per-check live render that PR #359 added.
