### PR TITLE
feat(alertd): target alerts to central/facility/both server kinds

### DIFF
--- a/crates/alertd/src/alert.rs
+++ b/crates/alertd/src/alert.rs
@@ -99,8 +99,38 @@ pub struct AlertDefinition {
 	#[serde(default)]
 	pub send: Vec<crate::targets::SendTarget>,
 
+	/// Restrict this alert to a daemon with a particular `server_kind`. The
+	/// value is an opaque string; alertd treats `central`, `facility`, or
+	/// anything else identically — equality with the daemon's configured
+	/// `server_kind` is the only criterion. Absence means "run anywhere",
+	/// which is the implicit "all" — there's no explicit `both`/`all` value.
+	///
+	/// Named `server_kind` (serialised as `server-kind` in YAML) rather than
+	/// `target` because alertd already uses `target` for delivery targets
+	/// inside the `send:` list (e.g. `send: [{ target: external, ... }]`),
+	/// and reusing the word at the top level would be confusing.
+	#[serde(default)]
+	pub server_kind: Option<String>,
+
 	#[serde(flatten)]
 	pub source: TicketSource,
+}
+
+/// Whether an alert with this `server_kind` filter should run on a daemon
+/// configured with the given `server_kind`.
+///
+/// - alert `None` ("any") → always runs.
+/// - alert `Some(k)`, daemon `None` → permissive: the daemon isn't
+///   configured to filter, so we don't drop anything. Better to run too
+///   many alerts than to silently swallow targeted ones because someone
+///   forgot to set the daemon kind.
+/// - alert `Some(k)`, daemon `Some(d)` → runs iff `k == d` (case-sensitive
+///   string equality).
+pub fn server_kind_matches(alert: Option<&str>, daemon: Option<&str>) -> bool {
+	match (alert, daemon) {
+		(None, _) | (_, None) => true,
+		(Some(a), Some(d)) => a == d,
+	}
 }
 
 #[derive(serde::Deserialize, Debug, Default, Clone)]
@@ -812,5 +842,47 @@ send:
 			}
 			_ => panic!("Expected Detailed variant"),
 		}
+	}
+
+	#[test]
+	fn server_kind_defaults_to_none_when_absent() {
+		let yaml = "sql: \"SELECT 1\"\nsend:\n  - id: x\n    subject: s\n    template: t\n";
+		let alert: AlertDefinition = serde_yaml::from_str(yaml).unwrap();
+		assert_eq!(alert.server_kind, None);
+	}
+
+	#[test]
+	fn server_kind_parses_as_arbitrary_string() {
+		// alertd doesn't enforce a vocabulary — `central` / `facility` are
+		// just what bestool-tamanu happens to pass through. Whatever string
+		// the daemon's `server_kind` is configured with is what alerts match
+		// against.
+		for text in ["central", "facility", "kiosk", "edge"] {
+			let yaml = format!(
+				"sql: \"SELECT 1\"\nserver-kind: {text}\nsend:\n  - id: x\n    subject: s\n    template: t\n"
+			);
+			let alert: AlertDefinition = serde_yaml::from_str(&yaml).unwrap();
+			assert_eq!(alert.server_kind.as_deref(), Some(text));
+		}
+	}
+
+	#[test]
+	fn server_kind_matches_truth_table() {
+		// Absent on the alert → always runs.
+		assert!(server_kind_matches(None, Some("central")));
+		assert!(server_kind_matches(None, Some("facility")));
+		assert!(server_kind_matches(None, None));
+
+		// Absent on the daemon → permissive: every alert applies.
+		assert!(server_kind_matches(Some("central"), None));
+		assert!(server_kind_matches(Some("facility"), None));
+
+		// Both present → equality.
+		assert!(server_kind_matches(Some("central"), Some("central")));
+		assert!(!server_kind_matches(Some("central"), Some("facility")));
+		assert!(!server_kind_matches(Some("facility"), Some("central")));
+
+		// Match is case-sensitive.
+		assert!(!server_kind_matches(Some("Central"), Some("central")));
 	}
 }

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -157,6 +157,7 @@ pub async fn run_with_shutdown_and_reload(
 		ctx.clone(),
 		daemon_config.email.clone(),
 		daemon_config.dry_run,
+		daemon_config.server_kind,
 	));
 
 	// Resolve the persistence file path and seed cold-start state from it.

--- a/crates/alertd/src/events.rs
+++ b/crates/alertd/src/events.rs
@@ -31,6 +31,10 @@ fn synthetic_alert(event_type: &EventType, entity_key: Option<&str>) -> AlertDef
 		always_send: crate::alert::AlwaysSend::Boolean(false),
 		when_changed: crate::alert::WhenChanged::default(),
 		send: Vec::new(),
+		// Synthesised internal-event alerts (e.g. source-error, definition-error)
+		// aren't tied to a specific server kind — they run wherever the daemon
+		// does. `None` means "any" (no filter).
+		server_kind: None,
 		source: crate::alert::TicketSource::Event {
 			event: event_type.clone(),
 		},

--- a/crates/alertd/src/http_server/endpoints/alert.rs
+++ b/crates/alertd/src/http_server/endpoints/alert.rs
@@ -94,7 +94,7 @@ mod tests {
 			http_client: reqwest::Client::new(),
 			canopy_client: None,
 		});
-		let scheduler = Arc::new(Scheduler::new(vec![], ctx.clone(), None, true));
+		let scheduler = Arc::new(Scheduler::new(vec![], ctx.clone(), None, true, None));
 
 		let (reload_tx, _reload_rx) = mpsc::channel::<()>(10);
 

--- a/crates/alertd/src/http_server/endpoints/reload.rs
+++ b/crates/alertd/src/http_server/endpoints/reload.rs
@@ -43,7 +43,7 @@ mod tests {
 			http_client: reqwest::Client::new(),
 			canopy_client: None,
 		});
-		let scheduler = Arc::new(Scheduler::new(vec![], ctx.clone(), None, true));
+		let scheduler = Arc::new(Scheduler::new(vec![], ctx.clone(), None, true, None));
 
 		let (reload_tx, mut reload_rx) = mpsc::channel::<()>(10);
 

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -22,6 +22,7 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		ctx.clone(),
 		None,
 		true, // dry_run
+		None, // server_kind
 	));
 
 	let (reload_tx, _reload_rx) = mpsc::channel::<()>(10);

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -21,7 +21,9 @@ pub mod templates;
 #[cfg(windows)]
 pub mod windows_service;
 
-pub use alert::{AlertDefinition, AlwaysSend, InternalContext, TicketSource, WhenChanged};
+pub use alert::{
+	AlertDefinition, AlwaysSend, InternalContext, TicketSource, WhenChanged, server_kind_matches,
+};
 pub use daemon::{run, run_with_shutdown, run_with_shutdown_and_reload};
 pub use events::EventType;
 pub use targets::{
@@ -88,6 +90,14 @@ pub struct DaemonConfig {
 	/// Each task ticks at its own `interval()`. Errors are logged but do not
 	/// kill the daemon. Activity from each tick counts towards the watchdog.
 	pub background_tasks: Vec<Arc<dyn BackgroundTask>>,
+
+	/// Opaque label identifying this daemon's deployment role, used to
+	/// filter alert definitions by their `server-kind:` field. Alertd is
+	/// agnostic about what the string means — it's whatever the configurer
+	/// (e.g. `bestool tamanu alertd`) decides to pass through. `None` means
+	/// "no filtering": every alert applies regardless of its declared
+	/// `server-kind`.
+	pub server_kind: Option<String>,
 }
 
 impl fmt::Debug for DaemonConfig {
@@ -110,6 +120,7 @@ impl fmt::Debug for DaemonConfig {
 					.map(|t| t.name())
 					.collect::<Vec<_>>(),
 			)
+			.field("server_kind", &self.server_kind)
 			.finish()
 	}
 }
@@ -127,7 +138,13 @@ impl DaemonConfig {
 			server_addrs: Vec::new(),
 			watchdog_timeout: Some(Duration::from_secs(10 * 60)),
 			background_tasks: Vec::new(),
+			server_kind: None,
 		}
+	}
+
+	pub fn with_server_kind(mut self, kind: impl Into<String>) -> Self {
+		self.server_kind = Some(kind.into());
+		self
 	}
 
 	pub fn with_task(mut self, task: Arc<dyn BackgroundTask>) -> Self {

--- a/crates/alertd/src/loader.rs
+++ b/crates/alertd/src/loader.rs
@@ -6,7 +6,7 @@ use walkdir::WalkDir;
 
 use crate::{
 	LogError,
-	alert::AlertDefinition,
+	alert::{AlertDefinition, server_kind_matches},
 	canopy::{DEFAULT_CANOPY_URL, Severity},
 	glob_resolver::ResolvedPaths,
 	targets::{AlertTargets, CanopyConfig, ExternalTarget, TargetCanopy, TargetConnection},
@@ -27,6 +27,7 @@ pub struct DefinitionError {
 pub fn load_alerts_from_paths(
 	resolved: &ResolvedPaths,
 	canopy_available: bool,
+	server_kind: Option<&str>,
 ) -> Result<LoadedAlerts> {
 	let mut alerts = Vec::<AlertDefinition>::new();
 	let mut external_targets = HashMap::new();
@@ -91,7 +92,9 @@ pub fn load_alerts_from_paths(
 			.filter(|e| e.file_type().is_file())
 		{
 			match load_alert_from_file(entry.path()) {
-				LoadAlertResult::Success(alert) => alerts.push(alert),
+				LoadAlertResult::Success(alert) => {
+					push_if_targeted(&mut alerts, alert, server_kind)
+				}
 				LoadAlertResult::Error(err) => definition_errors.push(err),
 				LoadAlertResult::Disabled | LoadAlertResult::Skip => {}
 			}
@@ -101,7 +104,7 @@ pub fn load_alerts_from_paths(
 	// Load alerts from individual files
 	for file in &resolved.files {
 		match load_alert_from_file(file) {
-			LoadAlertResult::Success(alert) => alerts.push(alert),
+			LoadAlertResult::Success(alert) => push_if_targeted(&mut alerts, alert, server_kind),
 			LoadAlertResult::Error(err) => definition_errors.push(err),
 			LoadAlertResult::Disabled | LoadAlertResult::Skip => {}
 		}
@@ -178,6 +181,26 @@ pub fn load_alerts_from_paths(
 	})
 }
 
+/// Push an alert onto the accumulator iff its `server-kind:` matches the
+/// daemon's configured server kind. Logs the drop at debug so an operator
+/// wondering where a facility-only alert went can spot it in trace output.
+fn push_if_targeted(
+	alerts: &mut Vec<AlertDefinition>,
+	alert: AlertDefinition,
+	server_kind: Option<&str>,
+) {
+	if server_kind_matches(alert.server_kind.as_deref(), server_kind) {
+		alerts.push(alert);
+	} else {
+		debug!(
+			file = %alert.file.display(),
+			alert_kind = ?alert.server_kind,
+			daemon_kind = ?server_kind,
+			"skipping alert: server-kind does not match daemon"
+		);
+	}
+}
+
 enum LoadAlertResult {
 	Success(AlertDefinition),
 	Disabled,
@@ -244,7 +267,7 @@ mod tests {
 		let tmp = TempDir::new().unwrap();
 		let resolved = empty_resolved(tmp.path());
 
-		let loaded = load_alerts_from_paths(&resolved, true).unwrap();
+		let loaded = load_alerts_from_paths(&resolved, true, None).unwrap();
 		assert!(loaded.external_targets.contains_key("default"));
 		let default = &loaded.external_targets["default"][0];
 		assert_eq!(default.id, "default");
@@ -256,7 +279,7 @@ mod tests {
 		let tmp = TempDir::new().unwrap();
 		let resolved = empty_resolved(tmp.path());
 
-		let loaded = load_alerts_from_paths(&resolved, false).unwrap();
+		let loaded = load_alerts_from_paths(&resolved, false, None).unwrap();
 		assert!(loaded.external_targets.is_empty());
 	}
 
@@ -274,7 +297,7 @@ targets:
 		.unwrap();
 		let resolved = empty_resolved(tmp.path());
 
-		let loaded = load_alerts_from_paths(&resolved, true).unwrap();
+		let loaded = load_alerts_from_paths(&resolved, true, None).unwrap();
 		let default = &loaded.external_targets["default"][0];
 		// User's explicit email default wins; no canopy injection.
 		assert!(matches!(default.conn, TargetConnection::Email(_)));
@@ -297,7 +320,7 @@ send:
 		.unwrap();
 		let resolved = empty_resolved(tmp.path());
 
-		let loaded = load_alerts_from_paths(&resolved, true).unwrap();
+		let loaded = load_alerts_from_paths(&resolved, true, None).unwrap();
 		assert_eq!(loaded.alerts.len(), 1);
 		let (_, resolved_targets) = &loaded.alerts[0];
 		assert_eq!(resolved_targets.len(), 1);
@@ -305,5 +328,57 @@ send:
 			resolved_targets[0].conn,
 			TargetConnection::Canopy(_)
 		));
+	}
+
+	fn write_alert(dir: &Path, name: &str, server_kind: Option<&str>) {
+		let server_kind_line = server_kind
+			.map(|t| format!("server-kind: {t}\n"))
+			.unwrap_or_default();
+		std::fs::write(
+			dir.join(name),
+			format!(
+				"sql: \"SELECT 1\"\n\
+				send:\n  - id: default\n    subject: \"x\"\n    template: \"y\"\n\
+				{server_kind_line}"
+			),
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn target_filter_keeps_matching_alerts_only() {
+		let tmp = TempDir::new().unwrap();
+		write_alert(tmp.path(), "central-only.yml", Some("central"));
+		write_alert(tmp.path(), "facility-only.yml", Some("facility"));
+		write_alert(tmp.path(), "kiosk-only.yml", Some("kiosk"));
+		write_alert(tmp.path(), "no-target.yml", None);
+		let resolved = empty_resolved(tmp.path());
+
+		let loaded = load_alerts_from_paths(&resolved, true, Some("central")).unwrap();
+		let kept: Vec<String> = loaded
+			.alerts
+			.iter()
+			.map(|(a, _)| a.file.file_name().unwrap().to_string_lossy().into_owned())
+			.collect();
+		assert!(kept.contains(&"central-only.yml".into()));
+		assert!(kept.contains(&"no-target.yml".into()));
+		assert!(!kept.contains(&"facility-only.yml".into()));
+		assert!(
+			!kept.contains(&"kiosk-only.yml".into()),
+			"alertd matches the daemon's server_kind by string equality; unrelated kinds are dropped"
+		);
+	}
+
+	#[test]
+	fn target_filter_absent_kind_admits_everything() {
+		// alertd running with no `server_kind` configured (e.g. outside a
+		// Tamanu install) shouldn't silently swallow targeted alerts.
+		let tmp = TempDir::new().unwrap();
+		write_alert(tmp.path(), "central-only.yml", Some("central"));
+		write_alert(tmp.path(), "facility-only.yml", Some("facility"));
+		let resolved = empty_resolved(tmp.path());
+
+		let loaded = load_alerts_from_paths(&resolved, true, None).unwrap();
+		assert_eq!(loaded.alerts.len(), 2);
 	}
 }

--- a/crates/alertd/src/scheduler.rs
+++ b/crates/alertd/src/scheduler.rs
@@ -103,6 +103,9 @@ pub struct Scheduler {
 	/// and restored on the next start — that way a recovery that happens
 	/// while the daemon was down still produces a canopy clear.
 	database_was_down: Arc<RwLock<bool>>,
+	/// Configured Tamanu server kind, threaded into the loader so alerts
+	/// whose `target:` doesn't match get dropped at load time.
+	server_kind: Option<String>,
 }
 
 impl Scheduler {
@@ -111,6 +114,7 @@ impl Scheduler {
 		ctx: Arc<InternalContext>,
 		email: Option<EmailConfig>,
 		dry_run: bool,
+		server_kind: Option<String>,
 	) -> Self {
 		let glob_resolver = GlobResolver::new(alert_globs);
 		Self {
@@ -130,6 +134,7 @@ impl Scheduler {
 			pending_hydration: Arc::new(Mutex::new(None)),
 			last_definition_error_files: Arc::new(RwLock::new(HashSet::new())),
 			database_was_down: Arc::new(RwLock::new(false)),
+			server_kind,
 		}
 	}
 
@@ -239,7 +244,7 @@ impl Scheduler {
 			alerts,
 			external_targets,
 			definition_errors,
-		} = load_alerts_from_paths(&resolved, canopy_available)?;
+		} = load_alerts_from_paths(&resolved, canopy_available, self.server_kind.as_deref())?;
 
 		// Update resolved paths
 		*self.resolved_paths.write().await = resolved;
@@ -379,7 +384,7 @@ impl Scheduler {
 			alerts,
 			external_targets,
 			definition_errors,
-		} = load_alerts_from_paths(&resolved, canopy_available)?;
+		} = load_alerts_from_paths(&resolved, canopy_available, self.server_kind.as_deref())?;
 
 		// Separate event alerts from regular alerts
 		let (event_alerts, regular_alerts): (Vec<_>, Vec<_>) = alerts

--- a/crates/alertd/tests/database_health.rs
+++ b/crates/alertd/tests/database_health.rs
@@ -52,6 +52,7 @@ fn test_database_down_default_template_renders() {
 		always_send: AlwaysSend::Boolean(false),
 		when_changed: WhenChanged::default(),
 		send: Vec::new(),
+		server_kind: None,
 		source: TicketSource::Event {
 			event: EventType::DatabaseDown,
 		},

--- a/crates/alertd/tests/reload.rs
+++ b/crates/alertd/tests/reload.rs
@@ -42,6 +42,7 @@ async fn test_status_endpoint_response_format() {
 		ctx.clone(),
 		None,
 		true,
+		None,
 	));
 
 	let state = Arc::new(bestool_alertd::http_server::ServerState {

--- a/crates/alertd/tests/state_persistence.rs
+++ b/crates/alertd/tests/state_persistence.rs
@@ -55,6 +55,7 @@ async fn hydration_seeds_triggered_at_for_matched_alert() {
 		ctx,
 		None,
 		true, // dry_run keeps task wakeups inert for the test
+		None,
 	);
 
 	scheduler.set_pending_hydration(persisted).await;
@@ -101,6 +102,7 @@ async fn hydration_ignores_entries_for_unknown_alerts() {
 		ctx,
 		None,
 		true,
+		None,
 	);
 
 	scheduler.set_pending_hydration(persisted).await;
@@ -145,6 +147,7 @@ async fn snapshot_round_trips_through_persistence() {
 		ctx,
 		None,
 		true,
+		None,
 	);
 	scheduler.set_pending_hydration(persisted).await;
 	scheduler.load_and_schedule_alerts().await.unwrap();

--- a/crates/bestool/src/actions/tamanu/alertd.rs
+++ b/crates/bestool/src/actions/tamanu/alertd.rs
@@ -356,7 +356,8 @@ async fn build_config(
 			.with_dry_run(dry_run)
 			.with_no_server(no_server)
 			.with_server_addrs(server_addr)
-			.with_watchdog_timeout(watchdog);
+			.with_watchdog_timeout(watchdog)
+			.with_server_kind(detect_server_kind(&config, &database_url).await);
 
 	if !no_healthchecks {
 		daemon_config = daemon_config.with_task(Arc::new(DoctorTask::new(
@@ -376,6 +377,38 @@ async fn build_config(
 	}
 
 	Ok(daemon_config)
+}
+
+/// Resolve the Tamanu server kind for alertd's alert-definition filter.
+///
+/// Opens a short-lived DB connection so [`bestool_tamanu::detect_kind`] can
+/// check `local_system_facts`; the daemon itself uses a fresh pool later.
+/// Alertd is plugin-agnostic — it takes the kind as an opaque string and
+/// compares against alert YAML `server-kind:` values by equality. The Tamanu
+/// vocabulary (`central` / `facility`) is decided here, at the integration
+/// boundary, not by alertd.
+async fn detect_server_kind(
+	config: &bestool_tamanu::config::TamanuConfig,
+	database_url: &str,
+) -> &'static str {
+	let db = match tokio_postgres::connect(database_url, tokio_postgres::NoTls).await {
+		Ok((client, conn)) => {
+			tokio::spawn(async move {
+				if let Err(err) = conn.await {
+					tracing::warn!("kind-detection connection error: {err}");
+				}
+			});
+			Some(client)
+		}
+		Err(err) => {
+			tracing::debug!(%err, "no DB for kind detection; falling back to config-only");
+			None
+		}
+	};
+	match bestool_tamanu::detect_kind(config, db.as_ref()).await {
+		bestool_tamanu::ApiServerKind::Central => "central",
+		bestool_tamanu::ApiServerKind::Facility => "facility",
+	}
 }
 
 async fn default_dirs(root: &std::path::Path) -> Vec<String> {


### PR DESCRIPTION
🤖

Stacks on #372.

Alertd YAML alerts gain an optional `server-kind:` field — an opaque string that the daemon matches against its configured `server_kind` by equality. Alertd is agnostic about the vocabulary; the integration layer (e.g. `bestool tamanu alertd`) picks the strings.

```yaml
sql: "SELECT 1"
server-kind: facility   # opaque string; "central", "facility", or whatever else the daemon is configured with
send:
  - target: external    # different meaning of "target": the delivery target
    id: default
    subject: "..."
    template: "..."
```

The match logic:

| alert `server-kind:` | daemon `server_kind` configured | Runs? |
|----------------------|---------------------------------|-------|
| absent               | (any)                           | yes   |
| present              | absent                          | yes (permissive — daemon isn't filtering) |
| `central`            | `central`                       | yes   |
| `central`            | `facility`                      | no    |
| `kiosk`              | `kiosk`                         | yes   |

There's no `both` / `all` value — absence is the implicit "any". An alert without `server-kind:` runs on every daemon regardless of how the daemon is configured. A daemon without a `server_kind` configured runs every alert (permissive on absence, so a forgotten config doesn't silently swallow targeted alerts).

`bestool tamanu alertd` detects the kind once at startup via `bestool_tamanu::detect_kind` (using a throwaway DB connection) and passes `"central"` or `"facility"` into `DaemonConfig::with_server_kind`. The Tamanu vocabulary is decided at that integration boundary, not by alertd.

Tests cover the truth table on `server_kind_matches`, YAML parsing as arbitrary strings, default-when-absent, and the loader filter dropping the right files on a real on-disk fixture (including an unrelated-kind case to demonstrate alertd doesn't know about Tamanu's vocabulary).
