### PR TITLE
feat(tamanu): expect tamanu-patientportal on central (systemd) when configured

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -44,7 +44,7 @@ pub fn config_and_expectations(tamanu: &TamanuArgs) -> Result<(Supervisor, Vec<E
 		ApiServerKind::Central
 	};
 
-	let expectations = services::expected(supervisor, kind, &config);
+	let expectations = services::expected(supervisor, kind, &config, false);
 	Ok((supervisor, expectations))
 }
 

--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -142,7 +142,7 @@ pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
 		bail!("tamanu logs is only supported on Linux (systemd) and Windows (pm2)");
 	};
 
-	let all_expectations = services::expected(supervisor, kind, &config);
+	let all_expectations = services::expected(supervisor, kind, &config, false);
 	let up_expectations: Vec<&Expectation> = all_expectations
 		.iter()
 		.filter(|e| e.state == ExpectedState::Up)
@@ -896,7 +896,7 @@ mod tests {
 
 	#[test]
 	fn journalctl_pattern_handles_each_instance_kind() {
-		let exps = services::expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(true, false));
+		let exps = services::expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(true, false), false);
 		let tasks = exps.iter().find(|e| e.name == "tamanu-facility-tasks").unwrap();
 		assert_eq!(journalctl_pattern(tasks), "tamanu-facility-tasks.service");
 

--- a/crates/tamanu/Cargo.toml
+++ b/crates/tamanu/Cargo.toml
@@ -38,7 +38,7 @@ regex = "1.11.2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 sysinfo = { workspace = true }
-tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-uuid-1"] }
+tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-serde_json-1", "with-uuid-1"] }
 tracing = { workspace = true }
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.1", features = ["v4"] }

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -19,7 +19,15 @@ pub async fn run(ctx: CheckContext) -> Check {
 			.with_detail("skipped", true);
 	};
 
-	let expectations = expected(supervisor, ctx.kind, &ctx.config);
+	// Patient-portal expectation is gated on Tamanu's own `features.patientPortal`
+	// DB setting. Without a DB client (e.g. unreachable), treat the flag as off
+	// — same as the `expected()` default for missing-config callers.
+	let patient_portal_enabled = match ctx.db.as_deref() {
+		Some(client) => crate::server_info::query_patient_portal_enabled(client).await,
+		None => false,
+	};
+
+	let expectations = expected(supervisor, ctx.kind, &ctx.config, patient_portal_enabled);
 
 	let mut pm2_source: Option<pm2::Source> = None;
 	let mut discovered = match supervisor {
@@ -475,7 +483,7 @@ mod tests {
 	#[test]
 	fn happy_facility_systemd() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -491,7 +499,7 @@ mod tests {
 	#[test]
 	fn fails_when_tasks_missing() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			d("tamanu-frontend", Some("a"), true),
 			d("tamanu-frontend", Some("b"), true),
@@ -512,7 +520,7 @@ mod tests {
 	#[test]
 	fn fails_on_api_shortfall() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -532,7 +540,7 @@ mod tests {
 	#[test]
 	fn fails_on_frontend_named_missing() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -556,7 +564,7 @@ mod tests {
 	#[test]
 	fn fails_when_forbidden_facility_singleton_present() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -580,7 +588,7 @@ mod tests {
 	#[test]
 	fn extras_recorded_but_dont_fail() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let mut discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -600,7 +608,7 @@ mod tests {
 	#[test]
 	fn central_with_fhir_requires_workers() {
 		let cfg = central_cfg(true);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg, false);
 		let discovered = vec![
 			d("tamanu-central-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -627,8 +635,11 @@ mod tests {
 
 	#[test]
 	fn central_without_fhir_doesnt_require_workers() {
+		// `central_cfg(false)` has no `patientPortal` block, so the doctor
+		// expects `tamanu-patientportal` Down — i.e. absent from `discovered`
+		// is the pass case.
 		let cfg = central_cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg, false);
 		let discovered = vec![
 			d("tamanu-central-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -643,7 +654,7 @@ mod tests {
 	#[test]
 	fn pm2_facility_happy() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			Discovered {
 				name: "tamanu-tasks".into(),
@@ -738,7 +749,7 @@ mod tests {
 	#[test]
 	fn not_running_listed_as_diagnosis() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, false), // not running
 			d("tamanu-frontend", Some("a"), true),

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -327,6 +327,39 @@ where
 	Some(pem)
 }
 
+/// Query the central server's `settings` table for `features.patientPortal`.
+///
+/// Tamanu mounts the patient portal API conditionally on this flag (see
+/// `packages/central-server/app/createApi.js`), so a `true` value here is the
+/// authoritative "this deployment runs the portal" signal — independent of
+/// the ansible-side `PatientPortalFQDN` tag or the unused `patientPortal.portalUrl`
+/// config field.
+///
+/// Settings are stored as one row per dotted leaf path, with the value column
+/// as `JSONB`. The default if the row is absent is `false` (per the global
+/// schema in `packages/settings/src/schema/global.ts`), so we treat missing
+/// rows and decode failures as `false`.
+pub async fn query_patient_portal_enabled(client: &tokio_postgres::Client) -> bool {
+	match client
+		.query_opt(
+			"SELECT value FROM settings WHERE key = 'features.patientPortal' LIMIT 1",
+			&[],
+		)
+		.await
+	{
+		Ok(Some(row)) => row
+			.try_get::<_, serde_json::Value>(0)
+			.ok()
+			.and_then(|v| v.as_bool())
+			.unwrap_or(false),
+		Ok(None) => false,
+		Err(err) => {
+			debug!(%err, "could not query features.patientPortal setting");
+			false
+		}
+	}
+}
+
 /// Query `local_system_facts.deviceKey` on an existing Tamanu DB client.
 ///
 /// Logs at warn/info on errors and missing rows, returning `None`. Suitable

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -113,10 +113,20 @@ impl Instances {
 }
 
 /// All services expected to exist (or be absent) for this deployment.
+///
+/// `patient_portal_enabled` is the `features.patientPortal` setting read from
+/// the central server's DB. Callers without a DB connection should pass
+/// `false`; we'll then emit a Down expectation, which is the same thing the
+/// doctor would have asserted on a deployment that hasn't opted into the
+/// portal. The signal is sourced from the DB rather than `local.json5`
+/// because Tamanu's central-server code reads the setting (not the unused
+/// `patientPortal.portalUrl` config field) to decide whether to mount the
+/// portal API.
 pub fn expected(
 	supervisor: Supervisor,
 	kind: ApiServerKind,
 	config: &TamanuConfig,
+	patient_portal_enabled: bool,
 ) -> Vec<Expectation> {
 	let mut out = Vec::new();
 
@@ -193,6 +203,25 @@ pub fn expected(
 				state: fhir_state,
 				criticality: Criticality::Background,
 			});
+
+			// The patient portal quadlet (`tamanu-patientportal.service`) is
+			// expected Up iff the Tamanu DB setting `features.patientPortal`
+			// is true. If the flag is on but the container isn't running,
+			// that's an ops misalignment worth flagging — exactly the case
+			// the doctor exists to catch.
+			if matches!(supervisor, Supervisor::Systemd) {
+				let portal_state = if patient_portal_enabled {
+					ExpectedState::Up
+				} else {
+					ExpectedState::Down
+				};
+				out.push(Expectation {
+					name: "tamanu-patientportal",
+					instances: Instances::Single,
+					state: portal_state,
+					criticality: Criticality::Background,
+				});
+			}
 		}
 		ApiServerKind::Facility => {
 			let sync_name = match supervisor {
@@ -284,7 +313,7 @@ mod tests {
 
 	#[test]
 	fn facility_pm2_no_fhir() {
-		let es = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false));
+		let es = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false), false);
 		assert_eq!(
 			names(&es),
 			vec!["tamanu-tasks", "tamanu-api", "tamanu-sync"]
@@ -299,7 +328,7 @@ mod tests {
 		// alert if the corresponding services are still running — that's
 		// usually a deploy that's flipped the toggle without taking the
 		// units down. So the expectations exist, but with state Down.
-		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(false));
+		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(false), false);
 		assert_eq!(
 			names(&es),
 			vec![
@@ -321,7 +350,7 @@ mod tests {
 
 	#[test]
 	fn central_pm2_with_fhir_adds_resolve_and_refresh() {
-		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(true));
+		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(true), false);
 		assert_eq!(
 			names(&es),
 			vec![
@@ -335,7 +364,12 @@ mod tests {
 
 	#[test]
 	fn facility_systemd_includes_frontend_and_forbids_legacy_facility() {
-		let es = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(false));
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg(false),
+			false,
+		);
 		assert_eq!(
 			names(&es),
 			vec![
@@ -355,7 +389,12 @@ mod tests {
 
 	#[test]
 	fn central_systemd_with_fhir_uses_central_prefixed_units() {
-		let es = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg(true));
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(true),
+			true,
+		);
 		assert_eq!(
 			names(&es),
 			vec![
@@ -365,13 +404,75 @@ mod tests {
 				"tamanu-central-api",
 				"tamanu-central-fhir-resolve",
 				"tamanu-central-fhir-refresh",
+				"tamanu-patientportal",
 			]
 		);
 	}
 
 	#[test]
+	fn central_systemd_expects_patient_portal_up_when_db_flag_on() {
+		// `features.patientPortal = true` in the central DB means Tamanu has
+		// mounted the portal API; the doctor expects the matching unit running.
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			true,
+		);
+		let pp = es
+			.iter()
+			.find(|e| e.name == "tamanu-patientportal")
+			.expect("patient portal expectation should be present");
+		assert_eq!(pp.state, ExpectedState::Up);
+		assert_eq!(pp.instances, Instances::Single);
+	}
+
+	#[test]
+	fn central_systemd_expects_patient_portal_down_when_db_flag_off() {
+		// `features.patientPortal = false` → Tamanu's portal API is unmounted.
+		// If the container's still running we want to know (stale install),
+		// so the expectation stays in the list but with state Down.
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			false,
+		);
+		let pp = es
+			.iter()
+			.find(|e| e.name == "tamanu-patientportal")
+			.expect("patient portal expectation should still be listed (as Down)");
+		assert_eq!(pp.state, ExpectedState::Down);
+	}
+
+	#[test]
+	fn facility_systemd_does_not_include_patient_portal() {
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg(false),
+			true,
+		);
+		assert!(es.iter().all(|e| e.name != "tamanu-patientportal"));
+	}
+
+	#[test]
+	fn central_pm2_does_not_include_patient_portal() {
+		// pm2 is Windows-only; tamanu-patientportal is a systemd-managed unit
+		// in our Linux deployments, so the pm2 expectation list shouldn't
+		// include it regardless of the DB flag.
+		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(true), true);
+		assert!(es.iter().all(|e| e.name != "tamanu-patientportal"));
+	}
+
+	#[test]
 	fn frontend_named_instances() {
-		let es = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(false));
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg(false),
+			false,
+		);
 		let fe = es.iter().find(|e| e.name == "tamanu-frontend").unwrap();
 		assert_eq!(fe.instances, Instances::Named(&["a", "b"]));
 		assert_eq!(fe.instances.min_count(), 2);
@@ -379,7 +480,12 @@ mod tests {
 
 	#[test]
 	fn api_min_count_two() {
-		let es = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(false));
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg(false),
+			false,
+		);
 		let api = es.iter().find(|e| e.name == "tamanu-facility-api").unwrap();
 		assert_eq!(api.instances, Instances::NumericAtLeast(2));
 		assert_eq!(api.instances.min_count(), 2);
@@ -417,7 +523,12 @@ mod tests {
 
 	#[test]
 	fn api_and_frontend_are_critical() {
-		let central = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg(false));
+		let central = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			false,
+		);
 		assert_eq!(
 			criticality_for(&central, "tamanu-central-api"),
 			Criticality::Critical
@@ -427,7 +538,7 @@ mod tests {
 			Criticality::Critical
 		);
 
-		let facility_pm2 = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false));
+		let facility_pm2 = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false), false);
 		assert_eq!(
 			criticality_for(&facility_pm2, "tamanu-api"),
 			Criticality::Critical
@@ -436,7 +547,12 @@ mod tests {
 
 	#[test]
 	fn tasks_sync_fhir_are_background() {
-		let central = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg(true));
+		let central = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(true),
+			false,
+		);
 		assert_eq!(
 			criticality_for(&central, "tamanu-central-tasks"),
 			Criticality::Background
@@ -450,7 +566,12 @@ mod tests {
 			Criticality::Background
 		);
 
-		let facility = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(false));
+		let facility = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg(false),
+			false,
+		);
 		assert_eq!(
 			criticality_for(&facility, "tamanu-facility-sync"),
 			Criticality::Background


### PR DESCRIPTION
🤖

Revised after digging through the tamanu repo: the `patientPortal.portalUrl` field ansible writes to `local.json5` isn't read anywhere in Tamanu's code. The actual gate is the DB setting `features.patientPortal` — `packages/central-server/app/createApi.js` mounts the `/api/portal` router conditionally on that, defaulting `false` in the global settings schema.

So gating the doctor expectation on `features.patientPortal`:

- `query_patient_portal_enabled(client)` reads the setting from the `settings` table (`key = 'features.patientPortal'`, JSONB value).
- `services::expected(...)` grows a `patient_portal_enabled: bool` parameter. On central + systemd it always emits the `tamanu-patientportal` expectation: Up when the flag is on, Down when it's off.
- The doctor (`tamanu_service` check) queries the setting via the DB client it already holds and passes the result through.
- Other callers (`lifecycle`, `logs`) pass `false` — they don't open a DB, and patient-portal isn't something they need to start/stop/tail via the canonical list anyway.

This matches the user-stated semantics: if the flag's on but the container isn't running, that's an ops misalignment the doctor should flag. Conversely, if the container's running with the flag off, that's a stale install (the original FQDN tag was removed but the quadlet wasn't cleaned up) — also worth catching.

Tests cover Up when flag on, Down when flag off, absence on facility-systemd and central-pm2.
