### PR TITLE
feat(kopia): add bestool kopia skeleton + info command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "base64 0.22.1",
  "bestool-alertd",
  "bestool-canopy",
+ "bestool-kopia",
  "bestool-postgres",
  "bestool-psql",
  "bestool-tamanu",

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 algae-cli = { version = "1.0.20", path = "../algae-cli", optional = true }
 bestool-alertd = { version = "6.0.0", path = "../alertd", default-features = false, optional = true }
 bestool-canopy = { version = "0.1.1", path = "../canopy", optional = true }
+bestool-kopia = { version = "0.1.0", path = "../kopia", optional = true }
 bestool-postgres = { version = "1.0.10", path = "../postgres", optional = true }
 bestool-psql = { version = "1.5.5", path = "../psql", default-features = false, optional = true }
 bestool-tamanu = { version = "0.6.0", path = "../tamanu", default-features = false, optional = true }
@@ -100,7 +101,7 @@ windows-service = { version = "0.8.0", optional = true }
 windows_exe_info = { version = "0.5.2", features = ["manifest"] }
 
 [features]
-default = ["caddy", "completions", "crypto", "rdp", "self-update", "ssh", "tamanu"]
+default = ["caddy", "completions", "crypto", "kopia", "rdp", "self-update", "ssh", "tamanu"]
 
 ## Common dep groups (not meant to be used directly)
 download = ["dep:binstalk-downloader", "dep:detect-targets", "dep:hickory-resolver"]
@@ -110,6 +111,7 @@ caddy = ["download", "dep:tera"]
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 crypto = ["dep:algae-cli", "dep:blake3", "dep:merkle_hash"]
 file = ["dep:blake3", "dep:indicatif", "dep:tokio-util"]
+kopia = ["dep:bestool-kopia", "bestool-kopia/cli"]
 rdp = ["dep:duct", "dep:privilege", "dep:quick-xml", "dep:tauri-winrt-notification", "dep:windows-service"]
 self-update = ["download", "dep:semver", "dep:upgrade", "dep:windows-env"]
 ssh = ["dep:dirs", "dep:duct", "dep:fs4", "dep:ssh-key", "dep:privilege", "dep:windows-acl"]

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -31,6 +31,8 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool iti lcd off`↴](#bestool-iti-lcd-off)
 * [`bestool iti sparks`↴](#bestool-iti-sparks)
 * [`bestool iti temperature`↴](#bestool-iti-temperature)
+* [`bestool kopia`↴](#bestool-kopia)
+* [`bestool kopia info`↴](#bestool-kopia-info)
 * [`bestool rdp`↴](#bestool-rdp)
 * [`bestool rdp monitor`↴](#bestool-rdp-monitor)
 * [`bestool rdp service`↴](#bestool-rdp-service)
@@ -85,6 +87,7 @@ Didn't expect this much output? Use the short '-h' flag to get short help.
 * `crypto` — Cryptographic operations
 * `file` — File utilities
 * `iti` — Tamanu Iti subcommands
+* `kopia` — Operate on a kopia repository
 * `rdp` — Windows RDP session tooling
 * `self-update` — Update this bestool
 * `ssh` — SSH helpers
@@ -908,6 +911,39 @@ Get core temperature from the Raspberry Pi
 * `--watch <WATCH>` — Keep updating at an interval.
 
    Syntax is a number followed by a unit, such as "5s" or "1m".
+
+
+
+## `bestool kopia`
+
+Operate on a kopia repository.
+
+Wraps the `kopia` CLI to add ergonomics for our deployments: defaults scoped to the current host, snapshot pickers, and on Linux a transparent re-exec under the system `kopia` user so the operator doesn't need to remember `sudo -u kopia`.
+
+**Usage:** `bestool kopia [OPTIONS] <COMMAND>`
+
+###### **Subcommands:**
+
+* `info` — Show kopia repository connection status
+
+###### **Options:**
+
+* `--no-sudo` — Don't auto re-exec under the `kopia` user on Linux.
+
+   By default, when running as a non-`kopia` user on Linux and the system kopia install is present, the command re-execs itself via `sudo -u kopia --` so it can read the system kopia config (which is owned by the `kopia` user). This flag opts out — useful when you've set up your own kopia config under your own user account.
+* `--kopia-bin <PATH>` — Override the kopia binary location.
+
+   By default the command searches for `kopia` in `PATH`, then falls back to known KopiaUI install locations on Windows.
+
+
+
+## `bestool kopia info`
+
+Show kopia repository connection status.
+
+Wraps `kopia repository status`. Useful as a quick check that the configured repository is reachable and we're connected.
+
+**Usage:** `bestool kopia info`
 
 
 

--- a/crates/bestool/src/actions.rs
+++ b/crates/bestool/src/actions.rs
@@ -81,6 +81,9 @@ subcommands! {
 	file => File(FileArgs),
 	#[cfg(feature = "__iti")]
 	iti => Iti(ItiArgs),
+	#[cfg(feature = "kopia")]
+	#[clap(alias = "k")]
+	kopia => Kopia(KopiaArgs),
 	#[cfg(feature = "rdp")]
 	rdp => Rdp(RdpArgs),
 	#[cfg(feature = "self-update")]

--- a/crates/bestool/src/actions/kopia.rs
+++ b/crates/bestool/src/actions/kopia.rs
@@ -1,0 +1,49 @@
+use clap::{Parser, Subcommand};
+use miette::Result;
+
+use crate::args::Args;
+
+use super::Context;
+
+pub mod common;
+
+/// Operate on a kopia repository.
+///
+/// Wraps the `kopia` CLI to add ergonomics for our deployments: defaults
+/// scoped to the current host, snapshot pickers, and on Linux a transparent
+/// re-exec under the system `kopia` user so the operator doesn't need to
+/// remember `sudo -u kopia`.
+#[derive(Debug, Clone, Parser)]
+pub struct KopiaArgs {
+	/// Don't auto re-exec under the `kopia` user on Linux.
+	///
+	/// By default, when running as a non-`kopia` user on Linux and the
+	/// system kopia install is present, the command re-execs itself via
+	/// `sudo -u kopia --` so it can read the system kopia config (which is
+	/// owned by the `kopia` user). This flag opts out — useful when you've
+	/// set up your own kopia config under your own user account.
+	#[arg(long, global = true)]
+	pub no_sudo: bool,
+
+	/// Override the kopia binary location.
+	///
+	/// By default the command searches for `kopia` in `PATH`, then falls
+	/// back to known KopiaUI install locations on Windows.
+	#[arg(long, global = true, value_name = "PATH")]
+	pub kopia_bin: Option<std::path::PathBuf>,
+
+	#[command(subcommand)]
+	pub action: Action,
+}
+
+super::subcommands! {
+	[KopiaArgs => |args: KopiaArgs, mut ctx: Context| -> Result<(Action, Context)> {
+		let _top: &Args = ctx.require();
+		common::maybe_reexec_as_kopia(&args)?;
+		let action = args.action.clone();
+		ctx.provide(args);
+		Ok((action, ctx))
+	}]
+
+	info => Info(InfoArgs)
+}

--- a/crates/bestool/src/actions/kopia/common.rs
+++ b/crates/bestool/src/actions/kopia/common.rs
@@ -1,0 +1,68 @@
+//! Thin layer between the parent `KopiaArgs` and the shared `bestool-kopia`
+//! crate. The actual logic (binary location, elevation, snapshot types,
+//! filters, picker, …) lives in `bestool-kopia` so the doctor check and
+//! this subcommand share one implementation; leaf commands import the
+//! pieces they need from `bestool_kopia` directly.
+
+use bestool_kopia::{Elevation, LINUX_KOPIA_USER, find_kopia_binary, linux_elevation};
+use miette::{Result, miette};
+use tracing::debug;
+
+use super::KopiaArgs;
+
+/// Resolve the kopia binary to invoke, honouring `--kopia-bin` on `KopiaArgs`.
+pub fn kopia_binary(args: &KopiaArgs) -> Result<std::path::PathBuf> {
+	find_kopia_binary(args.kopia_bin.as_deref()).ok_or_else(|| {
+		miette!("could not find a `kopia` binary in PATH; install kopia or pass --kopia-bin")
+	})
+}
+
+/// On Linux, if there's a system kopia install and we're a non-`kopia`
+/// user, re-exec the current command under `sudo -u kopia --`. If `sudo`
+/// can't elevate (no NOPASSWD rule, no TTY), the resulting kopia invocation
+/// will fail loudly. The `--no-sudo` flag on `KopiaArgs` skips this
+/// entirely.
+///
+/// Doesn't return on a successful re-exec — `exec` replaces the process
+/// image.
+pub fn maybe_reexec_as_kopia(args: &KopiaArgs) -> Result<()> {
+	if args.no_sudo {
+		return Ok(());
+	}
+	if !cfg!(target_os = "linux") {
+		return Ok(());
+	}
+	match linux_elevation() {
+		Elevation::Direct => Ok(()),
+		Elevation::Sudo => {
+			debug!("re-executing under sudo -u {LINUX_KOPIA_USER}");
+			exec_under_sudo(LINUX_KOPIA_USER)
+		}
+		Elevation::Skip(reason) => {
+			debug!("not re-executing under kopia: {reason}");
+			Ok(())
+		}
+	}
+}
+
+/// Replace the current process with `sudo -u <user> -- <argv>`. Only
+/// returns if the exec itself failed.
+#[cfg(unix)]
+fn exec_under_sudo(user: &str) -> Result<()> {
+	use std::os::unix::process::CommandExt;
+
+	let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
+	let Some((exe, rest)) = argv.split_first() else {
+		return Err(miette!("no argv to re-exec"));
+	};
+
+	let mut cmd = std::process::Command::new("sudo");
+	cmd.arg("-u").arg(user).arg("--").arg(exe).args(rest);
+	let err = cmd.exec();
+	Err(miette!("failed to re-exec under sudo: {err}"))
+}
+
+#[cfg(not(unix))]
+fn exec_under_sudo(_user: &str) -> Result<()> {
+	Err(miette!("sudo re-exec only supported on Unix"))
+}

--- a/crates/bestool/src/actions/kopia/info.rs
+++ b/crates/bestool/src/actions/kopia/info.rs
@@ -1,0 +1,35 @@
+use std::process::Stdio;
+
+use clap::Parser;
+use miette::{Context as _, IntoDiagnostic as _, Result};
+
+use super::{KopiaArgs, common::kopia_binary};
+use crate::actions::Context;
+
+/// Show kopia repository connection status.
+///
+/// Wraps `kopia repository status`. Useful as a quick check that the
+/// configured repository is reachable and we're connected.
+#[derive(Debug, Clone, Parser)]
+pub struct InfoArgs {}
+
+pub async fn run(_args: InfoArgs, ctx: Context) -> Result<()> {
+	let kopia = ctx.require::<KopiaArgs>();
+	let bin = kopia_binary(kopia)?;
+
+	let status = std::process::Command::new(&bin)
+		.args(["repository", "status"])
+		.env("KOPIA_CHECK_FOR_UPDATES", "false")
+		.stdin(Stdio::inherit())
+		.stdout(Stdio::inherit())
+		.stderr(Stdio::inherit())
+		.status()
+		.into_diagnostic()
+		.wrap_err_with(|| format!("invoking {}", bin.display()))?;
+
+	if !status.success() {
+		std::process::exit(status.code().unwrap_or(1));
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
🤖 Adds a top-level `bestool kopia` subcommand (alias `k`) that wraps the kopia CLI.

The skeleton ships:
- `KopiaArgs` with `--no-sudo` and `--kopia-bin` global flags
- `common.rs`: kopia binary location (PATH + Windows KopiaUI fallbacks), current-user detection (`id -un` on Unix), transparent re-exec under `runuser -u kopia --` when running on Linux with a system kopia install and we're not already the `kopia` user
- `bestool kopia info`: passes through `kopia repository status`

Behind a `kopia` feature, on by default. Subsequent PRs in this stack add `list`, `restore`, and `mount`.

Stacks on top of #(plan PR — see below).
