### PR TITLE
feat(kopia): add mount command

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -34,6 +34,7 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool kopia`↴](#bestool-kopia)
 * [`bestool kopia info`↴](#bestool-kopia-info)
 * [`bestool kopia list`↴](#bestool-kopia-list)
+* [`bestool kopia mount`↴](#bestool-kopia-mount)
 * [`bestool kopia restore`↴](#bestool-kopia-restore)
 * [`bestool rdp`↴](#bestool-rdp)
 * [`bestool rdp monitor`↴](#bestool-rdp-monitor)
@@ -928,6 +929,7 @@ Wraps the `kopia` CLI to add ergonomics for our deployments: defaults scoped to 
 
 * `info` — Show kopia repository connection status
 * `list` — List kopia snapshots, defaulting to those from this host
+* `mount` — Mount a kopia snapshot read-only via FUSE
 * `restore` — Restore a kopia snapshot to a destination directory
 
 ###### **Options:**
@@ -966,6 +968,33 @@ List kopia snapshots, defaulting to those from this host
 * `--since <DURATION>` — Only show snapshots taken within this duration (e.g. `24h`, `7d`)
 * `-n`, `--limit <N>` — Cap to the N most recent matches
 * `--json` — Emit machine-readable JSON instead of a table
+
+
+
+## `bestool kopia mount`
+
+Mount a kopia snapshot read-only via FUSE.
+
+Snapshot selection mirrors `restore`: explicit `--snapshot ID`, `--latest` (which requires `--tag` or `--path`), or an interactive picker over the filter flags when neither is given.
+
+**Usage:** `bestool kopia mount [OPTIONS] <MOUNTPOINT>`
+
+###### **Arguments:**
+
+* `<MOUNTPOINT>` — Mountpoint. The directory must exist and be empty (kopia requirement)
+
+###### **Options:**
+
+* `--snapshot <ID>` — Snapshot ID (full or short prefix). Without this or `--latest`, the command opens an interactive picker
+* `--latest` — Use the newest matching snapshot without prompting.
+
+   Requires at least one of `--tag` or `--path` so the "newest" is unambiguous — a kopia repo holds many kinds of snapshots and "the latest one for this host" would otherwise pick whichever ran most recently, regardless of what it was backing up.
+* `--source-host <HOST>` — Filter: source host. Defaults to this host
+* `--all` — Filter: list snapshots from every host
+* `--tag <KEY:VALUE>` — Filter: tag. Repeatable. Format: `key:value`
+* `--path <SUBSTR>` — Filter: source path substring (case-insensitive)
+* `--since <DURATION>` — Filter: only snapshots within this duration (e.g. `24h`, `7d`)
+* `--background` — Detach the mount process and return immediately. Unix-only; on Windows the kopia mount stays in foreground regardless
 
 
 

--- a/crates/bestool/src/actions/kopia.rs
+++ b/crates/bestool/src/actions/kopia.rs
@@ -48,5 +48,7 @@ super::subcommands! {
 	info => Info(InfoArgs),
 	#[clap(alias = "ls")]
 	list => List(ListArgs),
+	#[clap(alias = "m")]
+	mount => Mount(MountArgs),
 	restore => Restore(RestoreArgs)
 }

--- a/crates/bestool/src/actions/kopia/mount.rs
+++ b/crates/bestool/src/actions/kopia/mount.rs
@@ -1,0 +1,103 @@
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Stdio;
+
+use bestool_kopia::{SnapshotSelectorArgs, short_id};
+use clap::Parser;
+use miette::{Context as _, IntoDiagnostic as _, Result};
+#[cfg(not(unix))]
+use miette::bail;
+
+use super::{
+	KopiaArgs,
+	common::{current_hostname, kopia_binary},
+};
+use crate::actions::Context;
+
+/// Mount a kopia snapshot read-only via FUSE.
+///
+/// Snapshot selection mirrors `restore`: explicit `--snapshot ID`, `--latest`
+/// (which requires `--tag` or `--path`), or an interactive picker over the
+/// filter flags when neither is given.
+#[derive(Debug, Clone, Parser)]
+pub struct MountArgs {
+	/// Mountpoint. The directory must exist and be empty (kopia requirement).
+	#[arg(value_name = "MOUNTPOINT")]
+	pub mountpoint: PathBuf,
+
+	#[command(flatten)]
+	pub selector: SnapshotSelectorArgs,
+
+	/// Detach the mount process and return immediately. Unix-only; on
+	/// Windows the kopia mount stays in foreground regardless.
+	#[arg(long)]
+	pub background: bool,
+}
+
+pub async fn run(args: MountArgs, ctx: Context) -> Result<()> {
+	let kopia = ctx.require::<KopiaArgs>();
+	let bin = kopia_binary(kopia)?;
+
+	let chosen = args
+		.selector
+		.resolve(&bin, current_hostname(), "Choose a snapshot to mount")?;
+
+	if args.background {
+		mount_background(&bin, &chosen.id, &args.mountpoint)
+	} else {
+		println!(
+			"Mounting snapshot {} at {} (Ctrl+C to unmount)",
+			short_id(&chosen.id),
+			args.mountpoint.display()
+		);
+		mount_foreground(&bin, &chosen.id, &args.mountpoint)
+	}
+}
+
+fn mount_foreground(bin: &Path, snapshot_id: &str, mountpoint: &Path) -> Result<()> {
+	let status = std::process::Command::new(bin)
+		.arg("mount")
+		.arg(snapshot_id)
+		.arg(mountpoint)
+		.env("KOPIA_CHECK_FOR_UPDATES", "false")
+		.status()
+		.into_diagnostic()
+		.wrap_err_with(|| format!("invoking {}", bin.display()))?;
+	if !status.success() {
+		std::process::exit(status.code().unwrap_or(1));
+	}
+	Ok(())
+}
+
+#[cfg(unix)]
+fn mount_background(bin: &Path, snapshot_id: &str, mountpoint: &Path) -> Result<()> {
+	// `setsid --fork` puts the spawned process in a new session AND forks once
+	// so the resulting daemon isn't the session leader, which is the standard
+	// recipe for detaching from a controlling terminal. setsid(1) is part of
+	// util-linux and ships on every Linux distro.
+	let child = std::process::Command::new("setsid")
+		.arg("--fork")
+		.arg(bin)
+		.arg("mount")
+		.arg(snapshot_id)
+		.arg(mountpoint)
+		.env("KOPIA_CHECK_FOR_UPDATES", "false")
+		.stdin(Stdio::null())
+		.stdout(Stdio::null())
+		.stderr(Stdio::null())
+		.spawn()
+		.into_diagnostic()
+		.wrap_err("spawning `setsid --fork`; install util-linux if missing")?;
+	println!(
+		"Mounted snapshot {} at {} in the background; the kopia process detached via setsid (parent setsid pid {})",
+		short_id(snapshot_id),
+		mountpoint.display(),
+		child.id(),
+	);
+	Ok(())
+}
+
+#[cfg(not(unix))]
+fn mount_background(_bin: &Path, _snapshot_id: &str, _mountpoint: &Path) -> Result<()> {
+	bail!("--background mounts are only supported on Unix");
+}


### PR DESCRIPTION
🤖 Adds `bestool kopia mount <MOUNTPOINT>` (alias `m`) that wraps `kopia mount`.

- Foreground by default, matches kopia's own behaviour
- `--background` spawns under `setsid --fork` on Unix to properly detach from the controlling terminal
- Snapshot selection is exactly the same as `kopia restore`: shares `SnapshotSelectorArgs` from `common.rs` via `#[command(flatten)]`. Picker by default, `--snapshot ID` for explicit, `--latest` requires `--tag`/`--path` so it picks an unambiguous newest

`setsid(1)` from util-linux is required for `--background`; documented in the error message when missing.
