### PR TITLE
feat(tamanu_service): split raw service inventory from healthcheck diagnostics

### DIFF
--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -694,6 +694,16 @@ fn build_payload(info: &Value, results: &[(Check, bool)], overall: OverallResult
 		_ => Map::new(),
 	};
 
+	// Lift any `payload_extras` from individual checks into the top-level
+	// payload (alongside server facts like `osTimezone`). Lets a check carry
+	// bulky context-data that belongs with server facts rather than crowding
+	// its diagnostic entry in `health[]`.
+	for (check, _) in results {
+		for (k, v) in &check.payload_extras {
+			payload.insert(k.clone(), v.clone());
+		}
+	}
+
 	let health: Vec<Value> = results
 		.iter()
 		.filter(|(_, on_wire)| *on_wire)
@@ -970,6 +980,36 @@ mod tests {
 			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let payload = build_payload(&Value::Object(Default::default()), &results, overall);
 		assert_eq!(payload["healthy"], false);
+	}
+
+	#[test]
+	fn payload_lifts_payload_extras_into_top_level() {
+		// `payload_extras` is for data a check wants alongside server facts
+		// (osTimezone etc), not in its per-check entry. The tamanu_service
+		// check uses it for raw service inventory.
+		let mut info = serde_json::Map::new();
+		info.insert("osTimezone".into(), "Pacific/Auckland".into());
+		let info_value = Value::Object(info);
+
+		let check = Check::pass("svc", "ok")
+			.with_detail("supervisor", "systemd")
+			.with_payload_extra(
+				"services",
+				serde_json::json!({"supervisor": "systemd", "expectations": []}),
+			);
+		let results = vec![(check, true)];
+		let overall =
+			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let payload = build_payload(&info_value, &results, overall);
+
+		assert_eq!(payload["osTimezone"], "Pacific/Auckland");
+		// Lifted into the top level, alongside osTimezone.
+		assert_eq!(payload["services"]["supervisor"], "systemd");
+		// And NOT duplicated into the per-check entry.
+		assert!(payload["health"][0].get("services").is_none());
+		// But the lean per-check detail (supervisor label) is still on the
+		// `health[]` entry.
+		assert_eq!(payload["health"][0]["supervisor"], "systemd");
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -441,6 +441,7 @@ mod tests {
 			instances: Instances::Single,
 			state: ExpectedState::Up,
 			criticality: Criticality::Background,
+			reason: "test".into(),
 		}
 	}
 
@@ -450,6 +451,7 @@ mod tests {
 			instances: Instances::NumericAtLeast(2),
 			state: ExpectedState::Up,
 			criticality: Criticality::Critical,
+			reason: "test".into(),
 		}
 	}
 

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -165,6 +165,7 @@ mod tests {
 			instances: Instances::Single,
 			state: ExpectedState::Up,
 			criticality: crit,
+			reason: "test".into(),
 		}
 	}
 

--- a/crates/tamanu/src/doctor/check.rs
+++ b/crates/tamanu/src/doctor/check.rs
@@ -46,6 +46,13 @@ pub struct Check {
 	pub summary: String,
 	/// Extra JSON fields merged into the per-check wire payload.
 	pub details: Map<String, Value>,
+	/// Fields a check wants to attach to the *top-level* status payload
+	/// (alongside `osTimezone` etc.), rather than to its own `health[]`
+	/// entry. Lifted by `build_payload` and never serialised into
+	/// per-check wire output. Used for bulky data (raw service inventory,
+	/// for instance) that belongs with server facts, not with
+	/// diagnostics.
+	pub payload_extras: Map<String, Value>,
 }
 
 impl Check {
@@ -55,6 +62,7 @@ impl Check {
 			status: CheckStatus::Pass,
 			summary: summary.into(),
 			details: Map::new(),
+			payload_extras: Map::new(),
 		}
 	}
 
@@ -69,6 +77,7 @@ impl Check {
 			status: CheckStatus::Skip(reason.into()),
 			summary: summary.into(),
 			details,
+			payload_extras: Map::new(),
 		}
 	}
 
@@ -82,6 +91,7 @@ impl Check {
 			status: CheckStatus::Warning(reason.into()),
 			summary: summary.into(),
 			details: Map::new(),
+			payload_extras: Map::new(),
 		}
 	}
 
@@ -91,6 +101,7 @@ impl Check {
 			status: CheckStatus::Fail(reason.into()),
 			summary: summary.into(),
 			details: Map::new(),
+			payload_extras: Map::new(),
 		}
 	}
 
@@ -101,6 +112,14 @@ impl Check {
 
 	pub fn with_details(mut self, details: Map<String, Value>) -> Self {
 		self.details = details;
+		self
+	}
+
+	/// Attach a key/value to the top-level status payload (alongside server
+	/// facts like `osTimezone`) rather than this check's own `health[]`
+	/// entry. See [`Self::payload_extras`].
+	pub fn with_payload_extra(mut self, key: &str, value: impl Into<Value>) -> Self {
+		self.payload_extras.insert(key.to_string(), value.into());
 		self
 	}
 
@@ -175,6 +194,7 @@ impl Check {
 			status,
 			summary,
 			details,
+			payload_extras: Map::new(),
 		})
 	}
 }

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -304,6 +304,7 @@ fn evaluate(
 ) -> Check {
 	let mut matched_any: Vec<bool> = vec![false; discovered.len()];
 	let mut per_expectation: Vec<Value> = Vec::new();
+	let mut diagnostics: Vec<Value> = Vec::new();
 	let mut failures: Vec<String> = Vec::new();
 
 	for exp in expectations {
@@ -313,44 +314,35 @@ fn evaluate(
 		}
 		per_expectation.push(json!({
 			"name": exp.name,
-			"state": match exp.state {
-				ExpectedState::Up => "up",
-				ExpectedState::Down => "down",
-			},
+			"state": expected_state_label(exp.state),
 			"instances": instances_to_json(&exp.instances),
 			"outcome": outcome_to_json(&outcome),
+			"reason": exp.reason,
 		}));
-		match &outcome {
-			Outcome::Ok => {}
-			Outcome::Missing => failures.push(format!("missing {}", exp.name)),
-			Outcome::Shortfall {
-				running,
-				needed,
-				not_running,
-				missing_named,
-			} => {
-				if !missing_named.is_empty() {
-					failures.push(format!(
-						"{}: missing instance(s) {}",
-						exp.name,
-						missing_named.join(", ")
-					));
-				} else if !not_running.is_empty() {
-					failures.push(format!(
-						"{}: not running ({})",
-						exp.name,
-						not_running.join(", ")
-					));
-				} else {
-					failures.push(format!(
-						"{}: only {running}/{needed} instance(s) running",
-						exp.name
-					));
-				}
+
+		if !matches!(outcome, Outcome::Ok) {
+			let (actual, detail) = actual_for_outcome(exp, &outcome);
+			let expected_label = expected_state_label(exp.state);
+			let mut diag = json!({
+				"name": exp.name,
+				"expected": expected_label,
+				"reason": exp.reason,
+				"actual": actual,
+			});
+			if let Some(ref d) = detail {
+				diag["detail"] = Value::String(d.clone());
 			}
-			Outcome::Forbidden { units } => {
-				failures.push(format!("forbidden present: {}", units.join(", ")));
+			diagnostics.push(diag);
+
+			let mut line = format!(
+				"{}: expected {expected_label} ({reason}), got {actual}",
+				exp.name,
+				reason = exp.reason,
+			);
+			if let Some(d) = detail {
+				line.push_str(&format!(" ({d})"));
 			}
+			failures.push(line);
 		}
 	}
 
@@ -393,14 +385,52 @@ fn evaluate(
 		Check::fail("tamanu_service", summary, failures.join("; "))
 	};
 
+	// Per-check (`health[]`) details are kept lean: a per-service diagnostic
+	// list aimed at humans, plus the supervisor label. The bulky raw data
+	// (full expectations, discovered units, extras, supervisor) goes into the
+	// top-level status payload via `payload_extras` under `services`, so each
+	// piece lives in its natural home.
+	let payload_services = json!({
+		"supervisor": supervisor_label,
+		"expectations": Value::Array(per_expectation),
+		"discovered": services_json,
+		"extras": Value::Array(extras.into_iter().map(Value::String).collect()),
+	});
+
 	check
 		.with_detail("supervisor", supervisor_label)
-		.with_detail("expectations", Value::Array(per_expectation))
-		.with_detail("services", services_json)
-		.with_detail(
-			"extras",
-			Value::Array(extras.into_iter().map(Value::String).collect()),
-		)
+		.with_detail("diagnostics", Value::Array(diagnostics))
+		.with_payload_extra("services", payload_services)
+}
+
+fn expected_state_label(s: ExpectedState) -> &'static str {
+	match s {
+		ExpectedState::Up => "up",
+		ExpectedState::Down => "down",
+	}
+}
+
+fn actual_for_outcome(exp: &Expectation, outcome: &Outcome) -> (&'static str, Option<String>) {
+	match outcome {
+		Outcome::Ok => (expected_state_label(exp.state), None),
+		Outcome::Missing => ("missing", None),
+		Outcome::Shortfall {
+			running,
+			needed,
+			not_running,
+			missing_named,
+		} => {
+			let mut parts = vec![format!("{running}/{needed} instance(s) running")];
+			if !missing_named.is_empty() {
+				parts.push(format!("missing {}", missing_named.join(", ")));
+			}
+			if !not_running.is_empty() {
+				parts.push(format!("not running: {}", not_running.join(", ")));
+			}
+			("partial", Some(parts.join("; ")))
+		}
+		Outcome::Forbidden { units } => ("up", Some(units.join(", "))),
+	}
 }
 
 fn evaluate_with_source(
@@ -578,8 +608,12 @@ mod tests {
 		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
 		match &check.status {
 			CheckStatus::Fail(reason) => {
-				assert!(reason.contains("forbidden"), "reason was {reason:?}");
+				assert!(reason.contains("expected down"), "reason was {reason:?}");
 				assert!(reason.contains("tamanu-facility"), "reason was {reason:?}");
+				assert!(
+					reason.contains("legacy singleton unit must not be present"),
+					"reason was {reason:?}"
+				);
 			}
 			other => panic!("{other:?}"),
 		}
@@ -600,7 +634,14 @@ mod tests {
 		discovered.push(d("tamanu-patientportal", None, true));
 		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
 		assert!(matches!(check.status, CheckStatus::Pass), "{check:?}");
-		let extras = check.details.get("extras").unwrap().as_array().unwrap();
+		let services = check
+			.payload_extras
+			.get("services")
+			.expect("services payload_extra");
+		let extras = services
+			.get("extras")
+			.and_then(Value::as_array)
+			.expect("extras array");
 		assert_eq!(extras.len(), 1);
 		assert_eq!(extras[0].as_str().unwrap(), "tamanu-patientportal.service");
 	}
@@ -769,5 +810,125 @@ mod tests {
 			}
 			other => panic!("{other:?}"),
 		}
+	}
+
+	#[test]
+	fn diagnostics_carry_per_service_reason_and_state() {
+		// Patient-portal Down with the service actually running is the case
+		// that triggered this restructuring: the wire output should make it
+		// trivial to read "expected down (DB setting features.patientPortal is
+		// false), got up (tamanu-patientportal.service)" rather than parsing
+		// expectations + services arrays.
+		let cfg = central_cfg(true);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg, false);
+		let discovered = vec![
+			d("tamanu-central-tasks", None, true),
+			d("tamanu-frontend", Some("a"), true),
+			d("tamanu-frontend", Some("b"), true),
+			d("tamanu-central-api", Some("1"), true),
+			d("tamanu-central-api", Some("2"), true),
+			d("tamanu-central-fhir-resolve", None, true),
+			d("tamanu-central-fhir-refresh", None, true),
+			d("tamanu-patientportal", None, true),
+		];
+		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
+		let diagnostics = check
+			.details
+			.get("diagnostics")
+			.and_then(Value::as_array)
+			.expect("diagnostics array");
+		// Only the failing portal entry should appear — everything else
+		// matched its expectation and lives only in the top-level raw payload.
+		assert_eq!(diagnostics.len(), 1);
+		let portal = &diagnostics[0];
+		assert_eq!(
+			portal.get("name").and_then(Value::as_str),
+			Some("tamanu-patientportal")
+		);
+		assert_eq!(portal.get("expected").and_then(Value::as_str), Some("down"));
+		assert_eq!(portal.get("actual").and_then(Value::as_str), Some("up"));
+		assert_eq!(
+			portal.get("reason").and_then(Value::as_str),
+			Some("DB setting features.patientPortal is false")
+		);
+		assert_eq!(
+			portal.get("detail").and_then(Value::as_str),
+			Some("tamanu-patientportal.service")
+		);
+	}
+
+	#[test]
+	fn diagnostics_empty_when_everything_matches() {
+		// Happy path: no per-service diagnostics in the health[] entry. The
+		// raw inventory is still in the top-level payload under `services`
+		// for anyone who wants to audit what was checked.
+		let cfg = cfg(false);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let discovered = vec![
+			d("tamanu-facility-tasks", None, true),
+			d("tamanu-frontend", Some("a"), true),
+			d("tamanu-frontend", Some("b"), true),
+			d("tamanu-facility-api", Some("1"), true),
+			d("tamanu-facility-api", Some("2"), true),
+			d("tamanu-facility-sync", None, true),
+		];
+		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
+		assert!(matches!(check.status, CheckStatus::Pass));
+		let diagnostics = check
+			.details
+			.get("diagnostics")
+			.and_then(Value::as_array)
+			.expect("diagnostics array");
+		assert!(diagnostics.is_empty(), "{diagnostics:?}");
+		// Raw inventory is still available in the top-level payload.
+		assert!(check.payload_extras.get("services").is_some());
+	}
+
+	#[test]
+	fn raw_data_lives_in_payload_extras_not_check_details() {
+		// Bulky data (raw expectations / discovered units / supervisor /
+		// extras) belongs in the top-level status payload via
+		// `payload_extras["services"]`, not under per-check `details`. Keeps
+		// the `health[]` entry focused on human-readable diagnostics.
+		let cfg = cfg(false);
+		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let discovered = vec![
+			d("tamanu-facility-tasks", None, true),
+			d("tamanu-frontend", Some("a"), true),
+			d("tamanu-frontend", Some("b"), true),
+			d("tamanu-facility-api", Some("1"), true),
+			d("tamanu-facility-api", Some("2"), true),
+			d("tamanu-facility-sync", None, true),
+		];
+		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
+
+		assert!(!check.details.contains_key("expectations"));
+		assert!(!check.details.contains_key("extras"));
+		// `services` in details used to be the raw discovered-units array;
+		// it now lives in the top-level payload under that same key.
+		assert!(!check.details.contains_key("services"));
+
+		let services = check
+			.payload_extras
+			.get("services")
+			.expect("services payload extra");
+		assert_eq!(
+			services.get("supervisor").and_then(Value::as_str),
+			Some("systemd")
+		);
+		let raw_exps = services
+			.get("expectations")
+			.and_then(Value::as_array)
+			.expect("raw expectations");
+		assert!(!raw_exps.is_empty());
+		// Each raw expectation carries its reason so the payload is
+		// self-describing without the diagnostics list.
+		assert!(
+			raw_exps
+				.iter()
+				.all(|e| e.get("reason").and_then(Value::as_str).is_some())
+		);
+		assert!(services.get("discovered").is_some());
+		assert!(services.get("extras").is_some());
 	}
 }

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -35,6 +35,12 @@ pub struct Expectation {
 	/// Availability constraint when restarting. Only meaningful for
 	/// `ExpectedState::Up` services.
 	pub criticality: Criticality,
+	/// Why this expectation has its current shape — surfaced in doctor
+	/// diagnostics so operators can see *why* a given service is expected up
+	/// or down. Examples: `"always required"`, `"kind is facility"`,
+	/// `"config integrations.fhir.worker.enabled is false"`,
+	/// `"DB setting features.patientPortal is true"`.
+	pub reason: String,
 }
 
 /// Whether a service must keep at least one instance up at all times.
@@ -142,6 +148,7 @@ pub fn expected(
 		instances: Instances::Single,
 		state: ExpectedState::Up,
 		criticality: Criticality::Background,
+		reason: "always required".into(),
 	});
 
 	if matches!(supervisor, Supervisor::Systemd) {
@@ -150,6 +157,7 @@ pub fn expected(
 			instances: Instances::Named(&["a", "b"]),
 			state: ExpectedState::Up,
 			criticality: Criticality::Critical,
+			reason: "always required on systemd".into(),
 		});
 		out.push(Expectation {
 			name: "tamanu-facility",
@@ -157,6 +165,7 @@ pub fn expected(
 			state: ExpectedState::Down,
 			// criticality is unused for Down; Background is the harmless default.
 			criticality: Criticality::Background,
+			reason: "legacy singleton unit must not be present".into(),
 		});
 	}
 
@@ -172,6 +181,7 @@ pub fn expected(
 		instances: Instances::NumericAtLeast(2),
 		state: ExpectedState::Up,
 		criticality: Criticality::Critical,
+		reason: "always required".into(),
 	});
 
 	match kind {
@@ -186,22 +196,26 @@ pub fn expected(
 			// config, and explicitly Down when it isn't — that way the doctor
 			// catches the case where a deployment leaves the worker units
 			// running after `integrations.fhir.worker.enabled` is flipped off.
-			let fhir_state = if config.fhir_worker_enabled() {
+			let fhir_enabled = config.fhir_worker_enabled();
+			let fhir_state = if fhir_enabled {
 				ExpectedState::Up
 			} else {
 				ExpectedState::Down
 			};
+			let fhir_reason = format!("config integrations.fhir.worker.enabled is {fhir_enabled}");
 			out.push(Expectation {
 				name: resolve,
 				instances: Instances::Single,
 				state: fhir_state,
 				criticality: Criticality::Background,
+				reason: fhir_reason.clone(),
 			});
 			out.push(Expectation {
 				name: refresh,
 				instances: Instances::Single,
 				state: fhir_state,
 				criticality: Criticality::Background,
+				reason: fhir_reason,
 			});
 
 			// The patient portal quadlet (`tamanu-patientportal.service`) is
@@ -220,6 +234,9 @@ pub fn expected(
 					instances: Instances::Single,
 					state: portal_state,
 					criticality: Criticality::Background,
+					reason: format!(
+						"DB setting features.patientPortal is {patient_portal_enabled}"
+					),
 				});
 			}
 		}
@@ -233,6 +250,7 @@ pub fn expected(
 				instances: Instances::Single,
 				state: ExpectedState::Up,
 				criticality: Criticality::Background,
+				reason: "kind is facility".into(),
 			});
 		}
 	}
@@ -584,6 +602,7 @@ mod tests {
 			instances: Instances::Single,
 			state: ExpectedState::Up,
 			criticality: Criticality::Background,
+			reason: "test".into(),
 		}
 	}
 


### PR DESCRIPTION
🤖

The `tamanu_service` healthcheck used to ship its entire raw inventory (full expectations, discovered units, supervisor, extras) inside the per-check `health[]` entry sent to canopy. For what's often a one-line ops question ("why did this fail?") this drowned the signal in serialised JSON.

Splits the data:

- The per-check `health[]` entry now carries a `diagnostics` array with one item per *failing* service — empty in the happy case. Each entry is `{name, expected, reason, actual, detail?}`; failure summaries read as e.g. `tamanu-patientportal: expected down (DB setting features.patientPortal is false), got up (tamanu-patientportal.service)`.
- The bulky raw inventory (full expectations with reasons, discovered units, supervisor label, unmatched extras) is lifted to the top-level status payload under a `services` key, alongside server facts like `osTimezone` — so the audit data is still on the wire for anyone who wants it, just not in the diagnostics entry.

To make the diagnostics self-describing, `Expectation` gains a `reason: String` populated in `expected()`:

- `always required` for unconditional services (tasks, api, frontend)
- `kind is facility` for sync
- `config integrations.fhir.worker.enabled is {true|false}` for the FHIR worker pair
- `DB setting features.patientPortal is {true|false}` for the patient portal quadlet
- `legacy singleton unit must not be present` for the leftover `tamanu-facility` unit

Plumbing: `Check` grows a `payload_extras: Map<String, Value>` that `build_payload` lifts into the top-level payload (and that `to_wire` deliberately does not include in the per-check entry).
