### PR TITLE
fix(tamanu/doctor): truncate the Outstanding line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "tauri-winrt-notification",
  "tempfile",
  "tera",
+ "terminal_size",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -76,6 +76,7 @@ sysinfo = { workspace = true, optional = true }
 target-tuples = { version = "0.16.1", optional = true }
 tempfile = "3.21.0"
 tera = { version = "1.19.1", optional = true }
+terminal_size = { version = "0.4.4", optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-uuid-1"], optional = true }
@@ -159,6 +160,7 @@ tamanu-doctor = [
 	"dep:bestool-psql",
 	"dep:owo-colors",
 	"dep:p256",
+	"dep:terminal_size",
 	"dep:tokio-postgres",
 ]
 tamanu-url = ["__tamanu", "tamanu-config", "dep:percent-encoding"]

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -828,9 +828,10 @@ fn write_result_line<W: Write>(
 }
 
 /// Streams check results to `out` as they come in over `rx`, with a rewriting
-/// "Outstanding: ..." line below the printed results. Falls back gracefully if
-/// `out` doesn't accept the ANSI line-erase escape (the trailing newline ensures
-/// no half-erased line is left over).
+/// "Outstanding: ..." line below the printed results. The outstanding line is
+/// truncated to the terminal width so `\r\x1b[2K` reliably erases it on the
+/// next update; without that, terminal wrapping leaves orphaned rows behind
+/// as the cursor only sits on the last wrapped row.
 fn render_live<W: Write>(
 	out: &mut W,
 	selected_names: &[&'static str],
@@ -838,9 +839,12 @@ fn render_live<W: Write>(
 	use_colours: bool,
 ) -> std::io::Result<()> {
 	let name_width = selected_names.iter().map(|n| n.len()).max().unwrap_or(0);
+	let term_width = terminal_size::terminal_size()
+		.map(|(terminal_size::Width(w), _)| w)
+		.unwrap_or(80);
 	let mut outstanding: Vec<&'static str> = selected_names.to_vec();
 
-	write_outstanding(out, &outstanding, use_colours)?;
+	write_outstanding(out, &outstanding, term_width, use_colours)?;
 	out.flush()?;
 
 	while let Some(event) = rx.blocking_recv() {
@@ -849,7 +853,7 @@ fn render_live<W: Write>(
 				clear_current_line(out)?;
 				write_check_line(out, &check, name_width, use_colours)?;
 				outstanding.retain(|n| *n != check.name);
-				write_outstanding(out, &outstanding, use_colours)?;
+				write_outstanding(out, &outstanding, term_width, use_colours)?;
 				out.flush()?;
 			}
 		}
@@ -875,17 +879,39 @@ fn render_summary<W: Write>(
 fn write_outstanding<W: Write>(
 	out: &mut W,
 	outstanding: &[&'static str],
+	term_width: u16,
 	use_colours: bool,
 ) -> std::io::Result<()> {
 	if outstanding.is_empty() {
 		return Ok(());
 	}
-	let label = if use_colours {
-		format!("{}", "Outstanding:".dimmed())
+	let plain = format!("Outstanding: {}", outstanding.join(", "));
+	let truncated = truncate_to_width(&plain, term_width);
+	if use_colours {
+		write!(out, "{}", truncated.dimmed())
 	} else {
-		"Outstanding:".to_string()
-	};
-	write!(out, "{label} {}", outstanding.join(", "))
+		write!(out, "{truncated}")
+	}
+}
+
+/// Truncate `s` to fit within `width` display columns, appending `…` when the
+/// string is cut. Treats each char as one column — fine for the ASCII-only
+/// check names this is used with.
+fn truncate_to_width(s: &str, width: u16) -> String {
+	let width = width as usize;
+	if width == 0 {
+		return String::new();
+	}
+	if s.chars().count() <= width {
+		return s.to_string();
+	}
+	if width == 1 {
+		return "…".to_string();
+	}
+	let take = width - 1;
+	let mut out: String = s.chars().take(take).collect();
+	out.push('…');
+	out
 }
 
 fn clear_current_line<W: Write>(out: &mut W) -> std::io::Result<()> {
@@ -1084,6 +1110,32 @@ mod tests {
 	fn selected_names_unknown_skip_is_error() {
 		let err = selected_names_for_render(&[], &["does_not_exist".into()]).unwrap_err();
 		assert!(format!("{err}").contains("does_not_exist"));
+	}
+
+	#[test]
+	fn truncate_to_width_pads_short_strings_unchanged() {
+		assert_eq!(truncate_to_width("abc", 10), "abc");
+	}
+
+	#[test]
+	fn truncate_to_width_chops_with_ellipsis() {
+		assert_eq!(truncate_to_width("abcdefghij", 5), "abcd…");
+	}
+
+	#[test]
+	fn truncate_to_width_handles_exact_fit() {
+		assert_eq!(truncate_to_width("abcde", 5), "abcde");
+	}
+
+	#[test]
+	fn write_outstanding_truncates_to_one_terminal_row() {
+		let mut buf = Vec::new();
+		let names = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
+		write_outstanding(&mut buf, &names, 30, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert_eq!(out.chars().count(), 30);
+		assert!(out.ends_with('…'));
+		assert!(out.starts_with("Outstanding: "));
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 The live `tamanu doctor` render writes a single "Outstanding: ..." line without a newline and erases it with `\r\x1b[2K` on each update. When the line was longer than the terminal it wrapped onto multiple rows; the cursor only sat on the last wrapped row, so the erase cleared the tail and left the head visible above. The result was that every update appended a fresh half-line of "Outstanding: ..." for the operator to scroll through:

```
Outstanding: tamanu_found, db_connect, db_version, server_id, migrations, disk_free, memory, load, uptime, tim
  PASS    tamanu_found     Tamanu 2.54.5 at /etc/tamanu/v2.54.5 (central)
Outstanding: db_connect, db_version, server_id, migrations, disk_free, memory, load, uptime, time_sync, tamanu
  PASS    server_id        metaServerId: 5dd0c872-11c7-4b70-8e21-d08d6366872c
...
```

## Fix

- Read the terminal width with `terminal_size` (already in the dep tree via clap → terminal-colorsaurus).
- Truncate the plain text to fit one row, appending `…` when cut. Dimming is applied after truncation so the ANSI escapes don't throw off the column count.
- `render_live` looks the width up itself, so call sites stay unchanged.