### PR TITLE
ci(release-bestool): fix Windows cloudfront invalidation path mangled by MSYS

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -231,7 +231,7 @@ jobs:
           version="${{ steps.version.outputs.version }}"
           echo -n "$version" > latest-version.txt
           aws s3 cp latest-version.txt s3://bes-ops-tools/bestool/latest-version.txt --no-progress
-          aws cloudfront create-invalidation --distribution-id=EDAG0UBS1MN74 --paths '/bestool/latest-version.txt'
+          MSYS_NO_PATHCONV=1 aws cloudfront create-invalidation --distribution-id=EDAG0UBS1MN74 --paths '/bestool/latest-version.txt'
 
       - name: Upload for GHA
         shell: bash


### PR DESCRIPTION
🤖 The Windows release job fails on the `Upload version file` step with:

```
aws: [ERROR]: An error occurred (InvalidArgument) when calling the CreateInvalidation operation: Your request contains one or more invalid invalidation paths.
```

Cause: Git Bash on Windows runs MSYS path conversion on arguments that look like Unix paths, mangling `/bestool/latest-version.txt` into a Windows path before it reaches the AWS CLI. The other invalidations in this workflow happen to escape this because their paths contain a `*` wildcard, which MSYS leaves alone.

Setting `MSYS_NO_PATHCONV=1` for the failing command disables that conversion for just this invocation.
