### PR TITLE
refactor(kopia): extract bestool-kopia library crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bestool-kopia"
+version = "0.0.0"
+
+[[package]]
 name = "bestool-postgres"
 version = "1.0.10"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "automod"
@@ -676,7 +676,17 @@ dependencies = [
 
 [[package]]
 name = "bestool-kopia"
-version = "0.0.0"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dialoguer",
+ "jiff",
+ "miette",
+ "serde",
+ "serde_json",
+ "tracing",
+ "whoami 1.6.1",
+]
 
 [[package]]
 name = "bestool-postgres"
@@ -757,6 +767,7 @@ dependencies = [
 name = "bestool-tamanu"
 version = "0.6.0"
 dependencies = [
+ "bestool-kopia",
  "dirs",
  "duct",
  "futures",
@@ -1056,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -3023,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3564,9 +3575,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3574,14 +3585,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3664,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3807,9 +3818,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
@@ -3820,7 +3831,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3898,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loom"
@@ -4067,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -4770,7 +4784,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -5032,6 +5046,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -5680,6 +5700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5733,9 +5762,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5818,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -6518,9 +6547,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "simsimd"
@@ -6561,9 +6593,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snapbox"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92ac911648d788a6435401d9b4803959039d4de9919fdabdb415a8bebd027be"
+checksum = "8de56eb4784a2c5c1efede55a0f06fbf481bc12b42b355b9525c15db1e3581a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -7194,7 +7226,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-util",
- "whoami",
+ "whoami 2.1.2",
 ]
 
 [[package]]
@@ -8032,6 +8064,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
@@ -8041,9 +8079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8054,9 +8092,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8064,9 +8102,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8074,9 +8112,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8087,9 +8125,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -8143,9 +8181,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8193,6 +8231,17 @@ dependencies = [
 
 [[package]]
 name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
+ "web-sys",
+]
+
+[[package]]
+name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
@@ -8200,7 +8249,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite",
+ "wasite 1.0.2",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"crates/bestool",
 	"crates/canopy",
 	"crates/improv-wifi",
+	"crates/kopia",
 	"crates/postgres",
 	"crates/psql",
 	"crates/rpi-st7789v2-driver",

--- a/crates/kopia/Cargo.toml
+++ b/crates/kopia/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bestool-kopia"
+version = "0.0.0"
+edition = "2024"
+authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes.au>"]
+license = "GPL-3.0-or-later"
+description = "(Internal) BES tooling: shared library for interacting with the kopia CLI"
+repository = "https://github.com/beyondessential/bestool/tree/main/crates/kopia"
+exclude.workspace = true
+
+[lints]
+workspace = true

--- a/crates/kopia/Cargo.toml
+++ b/crates/kopia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bestool-kopia"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2024"
 authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes.au>"]
 license = "GPL-3.0-or-later"
@@ -10,3 +10,19 @@ exclude.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+default = []
+cli = ["dep:clap", "dep:dialoguer"]
+
+[dependencies]
+jiff = { version = "0.2.24", features = ["serde"] }
+miette = { workspace = true }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+tracing = { workspace = true }
+whoami = "1.6.1"
+
+# cli-only
+clap = { workspace = true, optional = true }
+dialoguer = { version = "0.12.0", default-features = false, optional = true }

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -1,1 +1,842 @@
-//! Placeholder crate. Real content lands in the next release.
+//! Shared helpers for interacting with the kopia CLI.
+//!
+//! Used by `bestool-tamanu` (for the `kopia_backup` doctor check) and by
+//! `bestool` (for the `bestool kopia` subcommand suite). Has nothing
+//! tamanu-specific in it.
+//!
+//! Highlights:
+//! - [`find_kopia_binary`] / [`find_windows_kopia_binary`] /
+//!   [`find_windows_kopia_config`]: locate kopia and (on Windows) the per-user
+//!   repository config from KopiaUI's standard install locations.
+//! - [`linux_elevation`]: decide whether/how to elevate to the `kopia` system
+//!   user on Linux. Returns [`Elevation::Sudo`] when we're not the kopia user
+//!   and the system kopia install is present, [`Elevation::Direct`] when we
+//!   already have access, [`Elevation::Skip`] otherwise.
+//! - [`Snapshot`] and [`fetch_snapshots`]: deserialise `kopia snapshot list
+//!   --json` output into a typed shape.
+//! - [`SnapshotFilter`] / [`build_filter`]: in-process filtering of a snapshot
+//!   list by host, tag, path substring, and time window.
+//! - With the `cli` feature: [`SnapshotSelectorArgs`] (a `clap::Args`-derived
+//!   struct that consumer commands flatten into their own args) and
+//!   [`select_snapshot`] (a `dialoguer`-backed interactive picker).
+
+use std::{
+	collections::BTreeMap,
+	path::{Path, PathBuf},
+	process::Command,
+};
+
+use jiff::{Span, Timestamp};
+use miette::{Context as _, IntoDiagnostic as _, Result, miette};
+use serde::{Deserialize, Serialize};
+
+/// System user that owns the Linux kopia install.
+pub const LINUX_KOPIA_USER: &str = "kopia";
+
+/// Standard location of the system kopia repository config on Linux. Owned
+/// by the [`LINUX_KOPIA_USER`].
+pub const LINUX_KOPIA_CONFIG: &str = "/var/lib/kopia/.config/kopia/repository.config";
+
+/// Locate the kopia binary.
+///
+/// Order of preference:
+///   1. An explicit override path (`None` to skip)
+///   2. `kopia` (or `kopia.exe`) in `PATH`
+///   3. On Windows, well-known KopiaUI bundled binary locations
+pub fn find_kopia_binary(override_path: Option<&Path>) -> Option<PathBuf> {
+	if let Some(p) = override_path {
+		return Some(p.to_path_buf());
+	}
+	if let Some(p) = find_in_path("kopia") {
+		return Some(p);
+	}
+	if cfg!(windows) {
+		return find_windows_kopia_binary();
+	}
+	None
+}
+
+fn find_in_path(name: &str) -> Option<PathBuf> {
+	let exe = if cfg!(windows) {
+		format!("{name}.exe")
+	} else {
+		name.to_string()
+	};
+	let path = std::env::var_os("PATH")?;
+	for dir in std::env::split_paths(&path) {
+		let candidate = dir.join(&exe);
+		if candidate.is_file() {
+			return Some(candidate);
+		}
+	}
+	None
+}
+
+/// Look for the kopia binary bundled with KopiaUI on Windows.
+pub fn find_windows_kopia_binary() -> Option<PathBuf> {
+	let mut candidates: Vec<PathBuf> = Vec::new();
+	if let Ok(local) = std::env::var("LOCALAPPDATA") {
+		candidates.push(
+			Path::new(&local)
+				.join("Programs")
+				.join("KopiaUI")
+				.join("resources")
+				.join("server")
+				.join("kopia.exe"),
+		);
+	}
+	if let Ok(pf) = std::env::var("ProgramFiles") {
+		candidates.push(
+			Path::new(&pf)
+				.join("KopiaUI")
+				.join("resources")
+				.join("server")
+				.join("kopia.exe"),
+		);
+	}
+	if let Ok(pf86) = std::env::var("ProgramFiles(x86)") {
+		candidates.push(
+			Path::new(&pf86)
+				.join("KopiaUI")
+				.join("resources")
+				.join("server")
+				.join("kopia.exe"),
+		);
+	}
+	candidates.into_iter().find(|p| p.exists())
+}
+
+/// Standard per-user kopia repository config on Windows, used by KopiaUI.
+pub fn find_windows_kopia_config() -> Option<PathBuf> {
+	let appdata = std::env::var("APPDATA").ok()?;
+	let config = Path::new(&appdata).join("kopia").join("repository.config");
+	config.exists().then_some(config)
+}
+
+/// Current process's username (via `whoami`). `None` if `whoami` can't
+/// determine it (rare).
+pub fn current_username() -> Option<String> {
+	whoami::fallible::username().ok()
+}
+
+/// What to do about elevation on Linux when we want to run kopia.
+#[derive(Debug)]
+pub enum Elevation {
+	/// Run as the current user — either we're already the kopia user, or
+	/// there's no system kopia install (the operator's running their own).
+	Direct,
+	/// Wrap the kopia invocation in `sudo -u kopia --`. Used whenever we're
+	/// running as a different user and the system kopia install exists; if
+	/// `sudo` isn't allowed (no NOPASSWD rule, no TTY), the resulting kopia
+	/// invocation will fail and the caller surfaces that as a Skip.
+	Sudo,
+	/// We can't elevate. The caller should bail with a reason.
+	Skip(String),
+}
+
+/// Decide how to invoke kopia on Linux given the current user and whether
+/// the system kopia install is present (and accessible).
+///
+/// Logic:
+/// - If we're the kopia user, run directly.
+/// - Else, probe the system kopia config:
+///   - Not found (ENOENT): no system install. Run directly as current user;
+///     they're presumably running their own kopia under their own config.
+///   - Permission denied (EACCES): exists, owned by kopia user. Elevate via
+///     `sudo -u kopia`.
+///   - Readable: exists and we can read it (unusual mode). Run directly.
+#[cfg(target_os = "linux")]
+pub fn linux_elevation() -> Elevation {
+	let Some(user) = current_username() else {
+		return Elevation::Skip("could not determine current Unix username".into());
+	};
+
+	if user == LINUX_KOPIA_USER {
+		return Elevation::Direct;
+	}
+
+	match std::fs::metadata(LINUX_KOPIA_CONFIG) {
+		Ok(_) => Elevation::Direct,
+		Err(err) if err.kind() == std::io::ErrorKind::NotFound => Elevation::Direct,
+		Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => Elevation::Sudo,
+		Err(err) => Elevation::Skip(format!("checking {LINUX_KOPIA_CONFIG}: {err}")),
+	}
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn linux_elevation() -> Elevation {
+	Elevation::Direct
+}
+
+/// Build a `Command` that runs the kopia binary, elevated to the kopia user
+/// if the current platform/user requires it (Linux only).
+///
+/// On non-Linux platforms or when no elevation is needed, this is just
+/// `Command::new(kopia)`. On Linux with [`Elevation::Sudo`], it returns
+/// `sudo -u kopia -- <kopia>`. [`Elevation::Skip`] is propagated as an
+/// `Err` whose message is the Skip reason.
+pub fn build_kopia_command(kopia: &Path) -> Result<Command, String> {
+	if cfg!(target_os = "linux") {
+		match linux_elevation() {
+			Elevation::Direct => Ok(Command::new(kopia)),
+			Elevation::Sudo => {
+				let mut c = Command::new("sudo");
+				c.arg("-u").arg(LINUX_KOPIA_USER).arg("--").arg(kopia);
+				Ok(c)
+			}
+			Elevation::Skip(reason) => Err(reason),
+		}
+	} else {
+		Ok(Command::new(kopia))
+	}
+}
+
+/// A single kopia snapshot, as emitted by `kopia snapshot list --json`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Snapshot {
+	pub id: String,
+	pub source: SnapshotSource,
+	#[serde(default)]
+	pub description: String,
+	#[serde(default)]
+	pub start_time: Option<Timestamp>,
+	#[serde(default)]
+	pub end_time: Option<Timestamp>,
+	#[serde(default)]
+	pub tags: BTreeMap<String, String>,
+	#[serde(default)]
+	pub root_entry: Option<RootEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SnapshotSource {
+	#[serde(default)]
+	pub host: String,
+	#[serde(default, rename = "userName")]
+	pub user_name: String,
+	#[serde(default)]
+	pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RootEntry {
+	#[serde(default, rename = "summ")]
+	pub summary: Option<DirSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DirSummary {
+	#[serde(default, rename = "size")]
+	pub total_size: i64,
+	#[serde(default, rename = "files")]
+	pub total_files: i64,
+	#[serde(default, rename = "dirs")]
+	pub total_dirs: i64,
+}
+
+impl Snapshot {
+	/// Time at which the snapshot finished (or started, if `endTime` is missing).
+	pub fn taken_at(&self) -> Option<Timestamp> {
+		self.end_time.or(self.start_time)
+	}
+
+	/// Best-effort total size of the snapshot's contents.
+	pub fn total_size(&self) -> Option<i64> {
+		self.root_entry
+			.as_ref()
+			.and_then(|r| r.summary.as_ref())
+			.map(|s| s.total_size)
+	}
+}
+
+/// Filter criteria used by listing/restore/mount.
+#[derive(Debug, Default, Clone)]
+pub struct SnapshotFilter {
+	/// `None` means "any host". `Some(name)` filters source.host == name.
+	pub source_host: Option<String>,
+	/// All entries must match.
+	pub tags: BTreeMap<String, String>,
+	/// Source path must contain this substring (case-insensitive).
+	pub path_substr: Option<String>,
+	/// Snapshot's taken_at must be within this Span from now.
+	pub since: Option<Span>,
+	/// Cap to the N most recent snapshots after the other filters apply.
+	pub limit: Option<usize>,
+}
+
+impl SnapshotFilter {
+	/// Apply the filter to a list of snapshots, returning matches sorted
+	/// newest-first.
+	pub fn apply(&self, snapshots: &[Snapshot], now: Timestamp) -> Vec<Snapshot> {
+		let cutoff: Option<Timestamp> = self.since.and_then(|span| now.checked_sub(span).ok());
+
+		let path_substr_lc = self.path_substr.as_ref().map(|s| s.to_lowercase());
+
+		let mut matches: Vec<Snapshot> = snapshots
+			.iter()
+			.filter(|s| {
+				if let Some(host) = &self.source_host
+					&& s.source.host != *host
+				{
+					return false;
+				}
+				for (k, v) in &self.tags {
+					if s.tags.get(k) != Some(v) {
+						return false;
+					}
+				}
+				if let Some(needle) = &path_substr_lc
+					&& !s.source.path.to_lowercase().contains(needle)
+				{
+					return false;
+				}
+				if let Some(cutoff) = cutoff
+					&& s.taken_at().is_none_or(|t| t < cutoff)
+				{
+					return false;
+				}
+				true
+			})
+			.cloned()
+			.collect();
+
+		matches.sort_by_key(|s| std::cmp::Reverse(s.taken_at()));
+
+		if let Some(n) = self.limit {
+			matches.truncate(n);
+		}
+		matches
+	}
+}
+
+/// Parse a `key:value` tag spec from a `--tag` flag.
+pub fn parse_tag_kv(s: &str) -> Result<(String, String), String> {
+	s.split_once(':')
+		.map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+		.filter(|(k, v)| !k.is_empty() && !v.is_empty())
+		.ok_or_else(|| format!("expected KEY:VALUE, got `{s}`"))
+}
+
+/// Build a [`SnapshotFilter`] from CLI-shaped inputs. `all = true` drops any
+/// source-host filter.
+pub fn build_filter(
+	all: bool,
+	source_host: Option<String>,
+	default_host: Option<String>,
+	tags: &[String],
+	path: Option<String>,
+	since: Option<&str>,
+	limit: Option<usize>,
+) -> Result<SnapshotFilter> {
+	let source_host = if all {
+		None
+	} else {
+		source_host.or(default_host)
+	};
+
+	let mut tag_map = BTreeMap::new();
+	for raw in tags {
+		let (k, v) = parse_tag_kv(raw).map_err(|e| miette!("invalid --tag: {e}"))?;
+		tag_map.insert(k, v);
+	}
+
+	let since = since
+		.map(|s| {
+			s.parse::<Span>()
+				.map_err(|e| miette!("invalid --since duration `{s}`: {e}"))
+		})
+		.transpose()?;
+
+	Ok(SnapshotFilter {
+		source_host,
+		tags: tag_map,
+		path_substr: path,
+		since,
+		limit,
+	})
+}
+
+/// Run `kopia snapshot list --json --all` and parse the result.
+///
+/// `bin` is expected to already be wrapped by [`build_kopia_command`] if
+/// elevation was needed — callers typically run that first and pass the
+/// resulting binary path here.
+pub fn fetch_snapshots(bin: &Path) -> Result<Vec<Snapshot>> {
+	let output = Command::new(bin)
+		.args(["snapshot", "list", "--json", "--all"])
+		.env("KOPIA_CHECK_FOR_UPDATES", "false")
+		.output()
+		.into_diagnostic()
+		.wrap_err_with(|| format!("invoking {}", bin.display()))?;
+	if !output.status.success() {
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		return Err(miette!(
+			"kopia snapshot list exited {}: {}",
+			output.status,
+			stderr.trim()
+		));
+	}
+	serde_json::from_slice(&output.stdout)
+		.into_diagnostic()
+		.wrap_err("decoding kopia snapshot list JSON")
+}
+
+/// Kopia's manifest IDs are long hex. The short prefix is enough to identify
+/// a snapshot in a list; kopia restore/mount accept short prefixes too.
+pub fn short_id(id: &str) -> String {
+	const SHORT: usize = 16;
+	if id.len() <= SHORT {
+		id.to_string()
+	} else {
+		id.chars().take(SHORT).collect()
+	}
+}
+
+/// Format a snapshot timestamp for human display.
+pub fn format_taken(ts: Timestamp) -> String {
+	ts.strftime("%Y-%m-%d %H:%M").to_string()
+}
+
+/// Render a snapshot's tag map as a `k=v, k2=v2` string (sorted by key).
+pub fn format_tags(tags: &BTreeMap<String, String>) -> String {
+	tags.iter()
+		.map(|(k, v)| format!("{k}={v}"))
+		.collect::<Vec<_>>()
+		.join(", ")
+}
+
+/// One-line summary of a snapshot, suitable for an interactive picker.
+pub fn format_snapshot_line(snap: &Snapshot) -> String {
+	let taken = snap
+		.taken_at()
+		.map(format_taken)
+		.unwrap_or_else(|| "—".into());
+	let source = format!(
+		"{}@{}:{}",
+		snap.source.user_name, snap.source.host, snap.source.path
+	);
+	let size = snap
+		.total_size()
+		.map(human_bytes)
+		.unwrap_or_else(|| "—".into());
+	let tags = format_tags(&snap.tags);
+	if tags.is_empty() {
+		format!("{}  {taken}  {source}  {size}", short_id(&snap.id))
+	} else {
+		format!(
+			"{}  {taken}  {source}  {size}  [{tags}]",
+			short_id(&snap.id)
+		)
+	}
+}
+
+/// Human-readable size formatter.
+pub fn human_bytes(b: i64) -> String {
+	if b < 0 {
+		return "?".into();
+	}
+	const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB"];
+	let mut value = b as f64;
+	let mut unit = 0;
+	while value >= 1024.0 && unit < UNITS.len() - 1 {
+		value /= 1024.0;
+		unit += 1;
+	}
+	if unit == 0 {
+		format!("{}{}", b, UNITS[0])
+	} else {
+		format!("{value:.1}{}", UNITS[unit])
+	}
+}
+
+#[cfg(feature = "cli")]
+pub use cli::*;
+
+#[cfg(feature = "cli")]
+mod cli {
+	use clap::Args;
+	use dialoguer::Select;
+	use miette::{Context as _, IntoDiagnostic as _, Result, bail};
+
+	use super::*;
+
+	/// Shared snapshot-selection flags for commands that operate on a single
+	/// snapshot (`restore`, `mount`, …). Flatten into each command's args
+	/// struct via `#[command(flatten)]`.
+	#[derive(Debug, Clone, Args)]
+	pub struct SnapshotSelectorArgs {
+		/// Snapshot ID (full or short prefix). Without this or `--latest`,
+		/// the command opens an interactive picker.
+		#[arg(long, value_name = "ID")]
+		pub snapshot: Option<String>,
+
+		/// Use the newest matching snapshot without prompting.
+		///
+		/// Requires at least one of `--tag` or `--path` so the "newest" is
+		/// unambiguous — a kopia repo holds many kinds of snapshots and "the
+		/// latest one for this host" would otherwise pick whichever ran most
+		/// recently, regardless of what it was backing up.
+		#[arg(long, conflicts_with = "snapshot")]
+		pub latest: bool,
+
+		/// Filter: source host. Defaults to this host.
+		#[arg(long, value_name = "HOST", conflicts_with = "all")]
+		pub source_host: Option<String>,
+
+		/// Filter: list snapshots from every host.
+		#[arg(long, conflicts_with = "source_host")]
+		pub all: bool,
+
+		/// Filter: tag. Repeatable. Format: `key:value`.
+		#[arg(long = "tag", value_name = "KEY:VALUE", value_parser = parse_tag_arg)]
+		pub tags: Vec<String>,
+
+		/// Filter: source path substring (case-insensitive).
+		#[arg(long, value_name = "SUBSTR")]
+		pub path: Option<String>,
+
+		/// Filter: only snapshots within this duration (e.g. `24h`, `7d`).
+		#[arg(long, value_name = "DURATION")]
+		pub since: Option<String>,
+	}
+
+	fn parse_tag_arg(s: &str) -> Result<String, String> {
+		parse_tag_kv(s).map(|_| s.to_string())
+	}
+
+	impl SnapshotSelectorArgs {
+		/// Resolve to a single snapshot: explicit ID, `--latest` over
+		/// filters, or interactive picker over filters. `default_host` is
+		/// the host to filter on when neither `--source-host` nor `--all` is
+		/// given (typically the current hostname).
+		pub fn resolve(
+			&self,
+			bin: &std::path::Path,
+			default_host: Option<String>,
+			picker_prompt: &str,
+		) -> Result<Snapshot> {
+			use std::io::IsTerminal as _;
+
+			if let Some(id) = &self.snapshot {
+				return resolve_by_id(bin, id);
+			}
+
+			if self.latest && self.tags.is_empty() && self.path.is_none() {
+				bail!(
+					"--latest requires --tag or --path: a kopia repo has many kinds of snapshots, and the newest unfiltered one would pick an arbitrary type. Narrow with --tag (e.g. --tag area:postgres) or --path."
+				);
+			}
+
+			let snapshots = fetch_snapshots(bin)?;
+			let filter = build_filter(
+				self.all,
+				self.source_host.clone(),
+				default_host,
+				&self.tags,
+				self.path.clone(),
+				self.since.as_deref(),
+				None,
+			)?;
+			let matches = filter.apply(&snapshots, Timestamp::now());
+
+			if matches.is_empty() {
+				bail!("no snapshots match the given filters");
+			}
+
+			if self.latest {
+				return Ok(matches.into_iter().next().expect("non-empty"));
+			}
+
+			let interactive = std::io::stdout().is_terminal() && std::io::stdin().is_terminal();
+			if !interactive {
+				bail!(
+					"no snapshot specified and stdin/stdout isn't a TTY — pass --snapshot, or --latest (with --tag/--path) to pick the newest match"
+				);
+			}
+
+			select_snapshot(&matches, picker_prompt)
+		}
+	}
+
+	fn resolve_by_id(bin: &std::path::Path, id_query: &str) -> Result<Snapshot> {
+		let snapshots = fetch_snapshots(bin)?;
+		let matches: Vec<&Snapshot> = snapshots
+			.iter()
+			.filter(|s| s.id.starts_with(id_query))
+			.collect();
+		match matches.len() {
+			0 => bail!("no snapshot found with id starting `{id_query}`"),
+			1 => Ok(matches[0].clone()),
+			n => bail!("snapshot id `{id_query}` is ambiguous ({n} matches); use a longer prefix"),
+		}
+	}
+
+	/// Open an interactive picker over a list of snapshots, returning the
+	/// chosen one. Defaults to the first (newest) entry.
+	pub fn select_snapshot(snapshots: &[Snapshot], prompt: &str) -> Result<Snapshot> {
+		let items: Vec<String> = snapshots.iter().map(format_snapshot_line).collect();
+		let selection = Select::new()
+			.with_prompt(prompt)
+			.items(&items)
+			.default(0)
+			.interact()
+			.into_diagnostic()
+			.wrap_err("interactive picker failed")?;
+		Ok(snapshots[selection].clone())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use jiff::ToSpan;
+
+	use super::*;
+
+	fn snapshot(id: &str, host: &str, path: &str, taken: Timestamp) -> Snapshot {
+		Snapshot {
+			id: id.into(),
+			source: SnapshotSource {
+				host: host.into(),
+				user_name: "kopia".into(),
+				path: path.into(),
+			},
+			description: String::new(),
+			start_time: Some(taken),
+			end_time: Some(taken),
+			tags: BTreeMap::new(),
+			root_entry: None,
+		}
+	}
+
+	#[test]
+	fn filter_by_host() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let snaps = vec![
+			snapshot("a", "host-1", "/data", now),
+			snapshot("b", "host-2", "/data", now),
+		];
+		let filter = SnapshotFilter {
+			source_host: Some("host-1".into()),
+			..Default::default()
+		};
+		let got = filter.apply(&snaps, now);
+		assert_eq!(got.len(), 1);
+		assert_eq!(got[0].id, "a");
+	}
+
+	#[test]
+	fn filter_by_tags_requires_all_to_match() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let mut tagged = snapshot("t", "h", "/data", now);
+		tagged.tags.insert("area".into(), "postgres".into());
+		tagged.tags.insert("type".into(), "ext4".into());
+		let snaps = vec![tagged, snapshot("u", "h", "/data", now)];
+
+		let mut tags = BTreeMap::new();
+		tags.insert("area".into(), "postgres".into());
+		tags.insert("type".into(), "ext4".into());
+		let filter = SnapshotFilter {
+			tags,
+			..Default::default()
+		};
+		let got = filter.apply(&snaps, now);
+		assert_eq!(got.len(), 1);
+		assert_eq!(got[0].id, "t");
+	}
+
+	#[test]
+	fn filter_path_substr_case_insensitive() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let snaps = vec![
+			snapshot("a", "h", r"C:\Program Files\PostgreSQL\15", now),
+			snapshot("b", "h", "/var/log/something", now),
+		];
+		let filter = SnapshotFilter {
+			path_substr: Some("postgresql".into()),
+			..Default::default()
+		};
+		let got = filter.apply(&snaps, now);
+		assert_eq!(got.len(), 1);
+		assert_eq!(got[0].id, "a");
+	}
+
+	#[test]
+	fn filter_since_drops_old_snapshots() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let snaps = vec![
+			snapshot("recent", "h", "/data", now - 1.hour()),
+			snapshot("old", "h", "/data", now - 30.hours()),
+		];
+		let filter = SnapshotFilter {
+			since: Some(24.hours()),
+			..Default::default()
+		};
+		let got = filter.apply(&snaps, now);
+		assert_eq!(got.len(), 1);
+		assert_eq!(got[0].id, "recent");
+	}
+
+	#[test]
+	fn filter_sorts_newest_first() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let snaps = vec![
+			snapshot("older", "h", "/data", now - 2.hours()),
+			snapshot("newer", "h", "/data", now - 1.hour()),
+		];
+		let filter = SnapshotFilter::default();
+		let got = filter.apply(&snaps, now);
+		assert_eq!(got[0].id, "newer");
+		assert_eq!(got[1].id, "older");
+	}
+
+	#[test]
+	fn filter_limit_truncates_after_sort() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let snaps = vec![
+			snapshot("a", "h", "/data", now - 3.hours()),
+			snapshot("b", "h", "/data", now - 1.hour()),
+			snapshot("c", "h", "/data", now - 2.hours()),
+		];
+		let filter = SnapshotFilter {
+			limit: Some(2),
+			..Default::default()
+		};
+		let got = filter.apply(&snaps, now);
+		assert_eq!(got.len(), 2);
+		assert_eq!(got[0].id, "b");
+		assert_eq!(got[1].id, "c");
+	}
+
+	#[test]
+	fn parse_tag_kv_accepts_simple() {
+		assert_eq!(
+			parse_tag_kv("area:postgres").unwrap(),
+			("area".into(), "postgres".into())
+		);
+	}
+
+	#[test]
+	fn parse_tag_kv_rejects_no_colon() {
+		assert!(parse_tag_kv("area-postgres").is_err());
+	}
+
+	#[test]
+	fn parse_tag_kv_rejects_empty_sides() {
+		assert!(parse_tag_kv(":value").is_err());
+		assert!(parse_tag_kv("key:").is_err());
+	}
+
+	#[test]
+	fn build_filter_all_drops_host() {
+		let filter =
+			build_filter(true, None, Some("ignored".into()), &[], None, None, None).unwrap();
+		assert!(filter.source_host.is_none());
+	}
+
+	#[test]
+	fn build_filter_default_host_used_when_not_overridden() {
+		let filter = build_filter(
+			false,
+			None,
+			Some("default-host".into()),
+			&[],
+			None,
+			None,
+			None,
+		)
+		.unwrap();
+		assert_eq!(filter.source_host.as_deref(), Some("default-host"));
+	}
+
+	#[test]
+	fn build_filter_explicit_host_beats_default() {
+		let filter = build_filter(
+			false,
+			Some("explicit".into()),
+			Some("default".into()),
+			&[],
+			None,
+			None,
+			None,
+		)
+		.unwrap();
+		assert_eq!(filter.source_host.as_deref(), Some("explicit"));
+	}
+
+	#[test]
+	fn build_filter_parses_since() {
+		let filter = build_filter(false, None, None, &[], None, Some("24h"), None).unwrap();
+		assert!(filter.since.is_some());
+	}
+
+	#[test]
+	fn build_filter_rejects_bad_since() {
+		let err =
+			build_filter(false, None, None, &[], None, Some("not-a-duration"), None).unwrap_err();
+		assert!(format!("{err}").contains("--since"));
+	}
+
+	#[test]
+	fn human_bytes_formats_units() {
+		assert_eq!(human_bytes(500), "500B");
+		assert_eq!(human_bytes(2 * 1024), "2.0KB");
+		assert_eq!(human_bytes(3 * 1024 * 1024 + 512 * 1024), "3.5MB");
+		assert_eq!(human_bytes(-1), "?");
+	}
+
+	#[test]
+	fn snapshot_taken_at_falls_back_to_start() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let mut snap = snapshot("a", "h", "/data", now);
+		snap.end_time = None;
+		assert_eq!(snap.taken_at(), Some(now));
+	}
+
+	#[test]
+	fn short_id_truncates_long_ids() {
+		assert_eq!(
+			short_id("kabcdef0123456789aaaaaaaaaaaaaaaa"),
+			"kabcdef012345678"
+		);
+	}
+
+	#[test]
+	fn short_id_passes_short_through() {
+		assert_eq!(short_id("k0000"), "k0000");
+	}
+
+	#[test]
+	fn format_tags_renders_sorted_kv_pairs() {
+		let mut tags = BTreeMap::new();
+		tags.insert("z".into(), "last".into());
+		tags.insert("a".into(), "first".into());
+		assert_eq!(format_tags(&tags), "a=first, z=last");
+	}
+
+	#[test]
+	fn format_tags_empty() {
+		let tags = BTreeMap::new();
+		assert_eq!(format_tags(&tags), "");
+	}
+
+	#[test]
+	fn format_snapshot_line_includes_id_source_and_tags() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let mut s = snapshot("kabc", "host-1", "/data", now);
+		s.tags.insert("area".into(), "postgres".into());
+		let line = format_snapshot_line(&s);
+		assert!(line.contains("kabc"));
+		assert!(line.contains("host-1"));
+		assert!(line.contains("/data"));
+		assert!(line.contains("area=postgres"));
+	}
+
+	#[test]
+	fn format_snapshot_line_omits_brackets_when_no_tags() {
+		let now = Timestamp::from_second(10_000_000).unwrap();
+		let s = snapshot("kabc", "host-1", "/data", now);
+		let line = format_snapshot_line(&s);
+		assert!(!line.contains("[]"));
+	}
+}

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -1,0 +1,1 @@
+//! Placeholder crate. Real content lands in the next release.

--- a/crates/tamanu/Cargo.toml
+++ b/crates/tamanu/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [features]
 default = ["doctor"]
 doctor = [
+	"dep:bestool-kopia",
 	"dep:futures",
 	"dep:hickory-resolver",
 	"dep:owo-colors",
@@ -47,6 +48,7 @@ uuid = { version = "1.23.1", features = ["v4"] }
 p256 = { version = "0.13.2", features = ["pkcs8", "pem"], optional = true }
 
 # doctor-only
+bestool-kopia = { version = "0.1.0", path = "../kopia", optional = true }
 futures = { workspace = true, optional = true }
 hickory-resolver = { version = "0.26.1", optional = true }
 owo-colors = { version = "4.2.3", optional = true }

--- a/crates/tamanu/src/doctor/checks/kopia_backup.rs
+++ b/crates/tamanu/src/doctor/checks/kopia_backup.rs
@@ -10,31 +10,25 @@
 //!
 //! On Linux the kopia repository config lives in the `kopia` system user's
 //! home directory and isn't readable by other users (not even to check for
-//! existence), so we don't pre-flight that; instead we either run kopia as
-//! that user directly (when the doctor is invoked as `kopia`) or via
-//! `runuser -u kopia --` (when invoked as root). Other contexts (e.g. the
-//! alertd daemon running as `tamanu`) Skip with a reason — there's no safe
-//! way to query an arbitrary user's kopia repo. If kopia is installed but
-//! not connected to a repo, the snapshot-list invocation reports that and
-//! we Skip with the error.
+//! existence), so we don't pre-flight that; we ask
+//! `bestool_kopia::build_kopia_command` to elevate via `sudo -u kopia --`
+//! when we're a different user and the system kopia install is present, or
+//! run directly when we *are* the kopia user. If sudo isn't allowed (no
+//! NOPASSWD rule, no TTY in the alertd context), the resulting kopia
+//! invocation fails and we Skip with the error.
 //!
-//! On Windows the backup is set up via KopiaUI under a desktop user (typically
-//! Administrator); we locate the bundled `kopia.exe` plus the user's
-//! `%APPDATA%\kopia\repository.config` and run it as the current user.
+//! On Windows the backup is set up via KopiaUI under a desktop user
+//! (typically Administrator); we locate the bundled `kopia.exe` plus the
+//! user's `%APPDATA%\kopia\repository.config` and run it as the current
+//! user.
 
-use std::{
-	path::{Path, PathBuf},
-	process::Command,
-};
-
+use bestool_kopia::{Elevation, Snapshot};
 use jiff::Timestamp;
-use serde::Deserialize;
 
 use super::CheckContext;
 use crate::doctor::check::Check;
 
 const CHECK_NAME: &str = "kopia_backup";
-const LINUX_KOPIA_USER: &str = "kopia";
 const FAIL_AGE_SECS: i64 = 24 * 60 * 60;
 
 pub async fn run(_ctx: CheckContext) -> Check {
@@ -52,24 +46,24 @@ pub async fn run(_ctx: CheckContext) -> Check {
 }
 
 fn run_linux() -> Check {
-	// The kopia repository config at /var/lib/kopia/.config/kopia/repository.config
-	// is only readable by the kopia user, so we can't pre-check for "kopia
-	// configured"; we discover that by trying. If kopia isn't connected to a
-	// repo, `kopia snapshot list` errors out and we Skip with the message.
-	let kopia_binary = match find_unix_kopia_binary() {
-		Some(b) => b,
-		None => {
-			return Check::skip(
-				CHECK_NAME,
-				"kopia binary not found",
-				"could not find `kopia` in PATH",
-			);
-		}
+	let Some(kopia_binary) = bestool_kopia::find_kopia_binary(None) else {
+		return Check::skip(
+			CHECK_NAME,
+			"kopia binary not found",
+			"could not find `kopia` in PATH",
+		);
 	};
 
-	let mut cmd = match build_linux_command(&kopia_binary) {
+	let elevation = bestool_kopia::linux_elevation();
+	if let Elevation::Skip(reason) = &elevation {
+		return Check::skip(CHECK_NAME, "need elevation to query kopia", reason.clone());
+	}
+
+	let mut cmd = match bestool_kopia::build_kopia_command(&kopia_binary) {
 		Ok(c) => c,
-		Err(skip) => return skip,
+		Err(reason) => {
+			return Check::skip(CHECK_NAME, "need elevation to query kopia", reason);
+		}
 	};
 
 	let output = match cmd
@@ -109,82 +103,34 @@ fn run_linux() -> Check {
 	evaluate(&snapshots, Timestamp::now())
 		.with_detail("platform", "linux")
 		.with_detail("kopia_binary", kopia_binary.display().to_string())
+		.with_detail("elevation", elevation_label(&elevation))
 }
 
-/// Build the kopia command, elevating to the kopia user if needed.
-///
-/// `Err(check)` carries a Skip result if we can't safely elevate (e.g. the
-/// doctor is running as `tamanu` and can't `runuser`).
-fn build_linux_command(kopia_binary: &Path) -> Result<Command, Check> {
-	let current = current_unix_username();
-	match current.as_deref() {
-		Some(u) if u == LINUX_KOPIA_USER => Ok(Command::new(kopia_binary)),
-		Some("root") => {
-			// `runuser -u kopia --` switches to the kopia user (only works when
-			// we're already root, since runuser usually isn't setuid). Falls
-			// back to the kopia binary as the executed program.
-			let mut c = Command::new("runuser");
-			c.arg("-u")
-				.arg(LINUX_KOPIA_USER)
-				.arg("--")
-				.arg(kopia_binary);
-			Ok(c)
-		}
-		Some(other) => Err(Check::skip(
-			CHECK_NAME,
-			"need elevation to query kopia",
-			format!(
-				"running as `{other}`, but the kopia config is owned by `{LINUX_KOPIA_USER}`; re-run as root or as the kopia user",
-			),
-		)),
-		None => Err(Check::skip(
-			CHECK_NAME,
-			"current user unknown",
-			"could not determine current Unix username via `id -un`",
-		)),
+fn elevation_label(e: &Elevation) -> &'static str {
+	match e {
+		Elevation::Direct => "direct",
+		Elevation::Sudo => "sudo",
+		Elevation::Skip(_) => "skip",
 	}
-}
-
-/// Returns the current process's username via `id -un`. Returns `None` on
-/// non-Unix platforms or if `id` is unavailable.
-#[cfg(unix)]
-fn current_unix_username() -> Option<String> {
-	let output = Command::new("id").arg("-un").output().ok()?;
-	if !output.status.success() {
-		return None;
-	}
-	let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
-	if name.is_empty() { None } else { Some(name) }
-}
-
-#[cfg(not(unix))]
-fn current_unix_username() -> Option<String> {
-	None
-}
-
-/// Locate the kopia binary on Linux. Prefers PATH (kopia is installed at
-/// `/usr/bin/kopia` on our servers via the kopia apt repo).
-fn find_unix_kopia_binary() -> Option<PathBuf> {
-	let path = std::env::var_os("PATH")?;
-	for dir in std::env::split_paths(&path) {
-		let candidate = dir.join("kopia");
-		if candidate.is_file() {
-			return Some(candidate);
-		}
-	}
-	None
 }
 
 fn run_windows() -> Check {
-	let Some(KopiaWindows { binary, config }) = locate_windows_kopia() else {
+	let Some(binary) = bestool_kopia::find_kopia_binary(None) else {
 		return Check::skip(
 			CHECK_NAME,
 			"kopia not configured",
-			"no KopiaUI install or repository config found for the current user",
+			"no KopiaUI install found",
+		);
+	};
+	let Some(config) = bestool_kopia::find_windows_kopia_config() else {
+		return Check::skip(
+			CHECK_NAME,
+			"kopia not configured",
+			"no kopia repository config found for the current user",
 		);
 	};
 
-	let output = match Command::new(&binary)
+	let output = match std::process::Command::new(&binary)
 		.args(["snapshot", "list", "--json", "--no-all"])
 		.env("KOPIA_CONFIG_PATH", &config)
 		.env("KOPIA_CHECK_FOR_UPDATES", "false")
@@ -225,32 +171,7 @@ fn run_windows() -> Check {
 		.with_detail("kopia_config", config.display().to_string())
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Snapshot {
-	source: SnapshotSource,
-	#[serde(default)]
-	end_time: Option<Timestamp>,
-	#[serde(default)]
-	start_time: Option<Timestamp>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SnapshotSource {
-	#[serde(default)]
-	path: String,
-}
-
-impl Snapshot {
-	fn taken_at(&self) -> Option<Timestamp> {
-		self.end_time.or(self.start_time)
-	}
-}
-
 fn evaluate(snapshots: &[Snapshot], now: Timestamp) -> Check {
-	// Host filtering is delegated to kopia via `--no-all`; everything in
-	// `snapshots` is already scoped to this host's source identity. We only
-	// need to pick the postgres-shaped one.
 	let candidates: Vec<&Snapshot> = snapshots
 		.iter()
 		.filter(|s| is_postgres_path(&s.source.path))
@@ -298,61 +219,11 @@ fn evaluate(snapshots: &[Snapshot], now: Timestamp) -> Check {
 
 /// Heuristic match for "this snapshot is of PostgreSQL data". Standard
 /// installs put data under `/var/lib/postgresql/...` on Linux and
-/// `C:\Program Files\PostgreSQL` on Windows; we tolerate variations
-/// (different drive, custom install dir) by just looking for the directory
-/// name anywhere in the path.
+/// `C:\Program Files\PostgreSQL` on Windows; tolerate variations (different
+/// drive, custom install dir) by looking for the directory name anywhere in
+/// the path.
 fn is_postgres_path(path: &str) -> bool {
 	path.to_lowercase().contains("postgresql")
-}
-
-struct KopiaWindows {
-	binary: PathBuf,
-	config: PathBuf,
-}
-
-fn locate_windows_kopia() -> Option<KopiaWindows> {
-	let binary = locate_windows_kopia_binary()?;
-	let config = locate_windows_kopia_config()?;
-	Some(KopiaWindows { binary, config })
-}
-
-fn locate_windows_kopia_binary() -> Option<PathBuf> {
-	let mut candidates: Vec<PathBuf> = Vec::new();
-	if let Ok(local) = std::env::var("LOCALAPPDATA") {
-		candidates.push(
-			Path::new(&local)
-				.join("Programs")
-				.join("KopiaUI")
-				.join("resources")
-				.join("server")
-				.join("kopia.exe"),
-		);
-	}
-	if let Ok(pf) = std::env::var("ProgramFiles") {
-		candidates.push(
-			Path::new(&pf)
-				.join("KopiaUI")
-				.join("resources")
-				.join("server")
-				.join("kopia.exe"),
-		);
-	}
-	if let Ok(pf86) = std::env::var("ProgramFiles(x86)") {
-		candidates.push(
-			Path::new(&pf86)
-				.join("KopiaUI")
-				.join("resources")
-				.join("server")
-				.join("kopia.exe"),
-		);
-	}
-	candidates.into_iter().find(|p| p.exists())
-}
-
-fn locate_windows_kopia_config() -> Option<PathBuf> {
-	let appdata = std::env::var("APPDATA").ok()?;
-	let config = Path::new(&appdata).join("kopia").join("repository.config");
-	config.exists().then_some(config)
 }
 
 fn humanise_age(secs: i64) -> String {
@@ -370,10 +241,29 @@ fn humanise_age(secs: i64) -> String {
 
 #[cfg(test)]
 mod tests {
+	use std::collections::BTreeMap;
+
+	use bestool_kopia::SnapshotSource;
 	use jiff::ToSpan;
 
 	use super::*;
 	use crate::doctor::check::CheckStatus;
+
+	fn snapshot(path: &str, end: Option<Timestamp>, start: Option<Timestamp>) -> Snapshot {
+		Snapshot {
+			id: "kabc".into(),
+			source: SnapshotSource {
+				host: "host-1".into(),
+				user_name: "kopia".into(),
+				path: path.into(),
+			},
+			description: String::new(),
+			end_time: end,
+			start_time: start,
+			tags: BTreeMap::new(),
+			root_entry: None,
+		}
+	}
 
 	#[test]
 	fn is_postgres_path_matches_program_files() {
@@ -386,14 +276,6 @@ mod tests {
 	fn is_postgres_path_rejects_unrelated() {
 		assert!(!is_postgres_path(r"C:\Users\admin\Documents"));
 		assert!(!is_postgres_path(r"C:\Program Files\KopiaUI"));
-	}
-
-	fn snapshot(path: &str, end: Option<Timestamp>, start: Option<Timestamp>) -> Snapshot {
-		Snapshot {
-			source: SnapshotSource { path: path.into() },
-			end_time: end,
-			start_time: start,
-		}
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Extracts a new `bestool-kopia` library crate (`crates/kopia`) with the shared infrastructure for interacting with the kopia CLI. The doctor `kopia_backup` check (already in main from #384) is rewritten to use it.

Two commits:

1. `feat(kopia): add bestool-kopia stub crate at 0.0.0` — empty placeholder so the crate name can be reserved on crates.io and trusted publishing set up before the real content ships. **Suggested workflow: check out this commit, publish `0.0.0` manually, set up trusted publishing for the crate, then merge the PR (which lands `0.1.0` with the real content).**
2. `refactor(kopia): extract bestool-kopia crate, reroute doctor check through it` — bumps to `0.1.0` and fills the crate.

## What `bestool-kopia` owns

- binary location (Linux PATH lookup, Windows KopiaUI install probing)
- `whoami`-based current-user detection
- Linux `sudo -u kopia` elevation decision (`Direct` / `Sudo` / `Skip` based on current user and access to the system config — using `fs::metadata` to distinguish EACCES from ENOENT)
- `Snapshot` / `SnapshotSource` deserialisation matching `kopia snapshot list --json`
- `fetch_snapshots`, `SnapshotFilter` + `build_filter`
- Formatters: `short_id`, `format_taken`, `format_tags`, `format_snapshot_line`, `human_bytes`

Behind a `cli` feature: `SnapshotSelectorArgs` (a `clap::Args` flatten-friendly struct with the `--latest` safety gate) and `select_snapshot` (dialoguer picker).

Nothing Tamanu-specific. Both `bestool-tamanu` (for the doctor check) and `bestool` (for the `bestool kopia` subcommand suite) depend on it, sharing one implementation.
