### PR TITLE
refactor(tamanu): consolidate DB connection opening through bestool-postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "base64 0.22.1",
  "bestool-alertd",
  "bestool-canopy",
+ "bestool-postgres",
  "bestool-psql",
  "bestool-tamanu",
  "binstalk-downloader",

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -100,10 +100,7 @@ pub async fn run_with_shutdown_and_reload(
 	metrics::init_metrics();
 	metrics::record_activity();
 
-	debug!(database_url = %daemon_config.database_url, "creating database connection pool");
-
-	let pool =
-		bestool_postgres::pool::create_pool(&daemon_config.database_url, "bestool-alertd").await?;
+	let pool = daemon_config.pg_pool.clone();
 
 	let canopy_client = match CanopyClient::new(
 		daemon_config.tamanu_version.clone(),

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -51,7 +51,16 @@ pub struct DaemonConfig {
 	/// On occasion, patterns are re-evaluated to pick up newly created paths.
 	pub alert_globs: Vec<String>,
 
-	/// Database connection URL
+	/// Database connection pool, opened by the caller.
+	///
+	/// Centralising pool creation at the caller lets `bestool tamanu alertd`
+	/// reuse the pool for one-off setup queries (kind detection, device key
+	/// lookup) instead of opening additional short-lived connections.
+	pub pg_pool: bestool_postgres::pool::PgPool,
+
+	/// Database connection URL, retained for redacted display and as a
+	/// substitution variable in alert templates (e.g. the `DatabaseDown`
+	/// event context).
 	pub database_url: String,
 
 	/// Email server configuration
@@ -126,9 +135,15 @@ impl fmt::Debug for DaemonConfig {
 }
 
 impl DaemonConfig {
-	pub fn new(alert_globs: Vec<String>, database_url: String, tamanu_version: String) -> Self {
+	pub fn new(
+		alert_globs: Vec<String>,
+		pg_pool: bestool_postgres::pool::PgPool,
+		database_url: String,
+		tamanu_version: String,
+	) -> Self {
 		Self {
 			alert_globs,
+			pg_pool,
 			database_url,
 			email: None,
 			device_key_pem: None,

--- a/crates/alertd/src/main.rs
+++ b/crates/alertd/src/main.rs
@@ -248,7 +248,7 @@ fn get_args() -> Result<(Args, WorkerGuard)> {
 	Ok((args, log_guard))
 }
 
-fn build_daemon_config(daemon: DaemonArgs) -> Result<bestool_alertd::DaemonConfig> {
+async fn build_daemon_config(daemon: DaemonArgs) -> Result<bestool_alertd::DaemonConfig> {
 	let database_url = daemon
 		.database_url
 		.ok_or_else(|| miette!("--database-url is required"))?;
@@ -290,12 +290,18 @@ fn build_daemon_config(daemon: DaemonArgs) -> Result<bestool_alertd::DaemonConfi
 		None
 	};
 
-	let mut daemon_config =
-		bestool_alertd::DaemonConfig::new(daemon.glob, database_url, daemon.tamanu_version)
-			.with_dry_run(daemon.dry_run)
-			.with_no_server(daemon.no_server)
-			.with_server_addrs(daemon.server_addr)
-			.with_watchdog_timeout(watchdog_timeout);
+	let pg_pool = bestool_postgres::pool::create_pool(&database_url, "bestool-alertd").await?;
+
+	let mut daemon_config = bestool_alertd::DaemonConfig::new(
+		daemon.glob,
+		pg_pool,
+		database_url,
+		daemon.tamanu_version,
+	)
+	.with_dry_run(daemon.dry_run)
+	.with_no_server(daemon.no_server)
+	.with_server_addrs(daemon.server_addr)
+	.with_watchdog_timeout(watchdog_timeout);
 
 	if let Some(email) = email {
 		daemon_config = daemon_config.with_email(email);
@@ -309,7 +315,7 @@ fn build_daemon_config(daemon: DaemonArgs) -> Result<bestool_alertd::DaemonConfi
 }
 
 async fn run_daemon(daemon: DaemonArgs) -> Result<()> {
-	let daemon_config = build_daemon_config(daemon)?;
+	let daemon_config = build_daemon_config(daemon).await?;
 	bestool_alertd::run(daemon_config).await
 }
 
@@ -374,7 +380,7 @@ async fn main() -> Result<()> {
 		Command::ConfigureRecovery => bestool_alertd::windows_service::configure_recovery(),
 		#[cfg(windows)]
 		Command::Service { daemon } => {
-			let daemon_config = build_daemon_config(daemon)?;
+			let daemon_config = build_daemon_config(daemon).await?;
 			bestool_alertd::windows_service::run_service(daemon_config)
 		}
 		Command::Docs => {

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 algae-cli = { version = "1.0.20", path = "../algae-cli", optional = true }
 bestool-alertd = { version = "5.0.0", path = "../alertd", default-features = false, optional = true }
 bestool-canopy = { version = "0.1.1", path = "../canopy", optional = true }
+bestool-postgres = { version = "1.0.9", path = "../postgres", optional = true }
 bestool-psql = { version = "1.5.4", path = "../psql", default-features = false, optional = true }
 bestool-tamanu = { version = "0.4.1", path = "../tamanu", default-features = false, optional = true }
 binstalk-downloader = { version = "0.13.38", optional = true, features = ["hickory-dns"] }
@@ -147,7 +148,7 @@ tamanu-alerts = [
 	"dep:tokio-postgres",
 	"dep:walkdir",
 ]
-tamanu-alertd = ["__tamanu", "tamanu-config", "bestool-tamanu/doctor", "dep:bestool-alertd", "dep:p256", "dep:serde_path_to_error", "dep:serde_yaml", "dep:tokio-postgres", "dep:tokio-stream", "dep:walkdir"]
+tamanu-alertd = ["__tamanu", "tamanu-config", "bestool-tamanu/doctor", "dep:bestool-alertd", "dep:bestool-postgres", "dep:p256", "dep:serde_path_to_error", "dep:serde_yaml", "dep:tokio-postgres", "dep:tokio-stream", "dep:walkdir"]
 tamanu-artifacts = ["__tamanu", "dep:comfy-table", "dep:detect-targets", "dep:target-tuples"]
 tamanu-backup = ["__tamanu", "file", "tamanu-config", "dep:bestool-psql", "dep:algae-cli", "dep:duct"]
 tamanu-backup-configs = ["__tamanu", "tamanu-backup", "dep:walkdir", "dep:zip"]

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -158,6 +158,7 @@ tamanu-doctor = [
 	"tamanu-config",
 	"bestool-tamanu/doctor",
 	"dep:bestool-canopy",
+	"dep:bestool-postgres",
 	"dep:bestool-psql",
 	"dep:owo-colors",
 	"dep:p256",

--- a/crates/bestool/src/actions/tamanu/alertd.rs
+++ b/crates/bestool/src/actions/tamanu/alertd.rs
@@ -10,7 +10,6 @@ use tracing::{debug, info};
 
 use bestool_tamanu::{
 	config::{TamanuConfig, load_config},
-	connection_url::ConnectionUrlBuilder,
 	server_info::fetch_device_key,
 };
 
@@ -318,19 +317,7 @@ async fn build_config(
 
 	info!("starting alertd daemon");
 
-	let database_url = ConnectionUrlBuilder {
-		username: config.db.username.clone(),
-		password: Some(config.db.password.clone()),
-		host: config
-			.db
-			.host
-			.clone()
-			.unwrap_or_else(|| "localhost".to_string()),
-		port: config.db.port,
-		database: config.db.name.clone(),
-		ssl_mode: None,
-	}
-	.build();
+	let database_url = config.database_url();
 
 	let email = config
 		.mailgun

--- a/crates/bestool/src/actions/tamanu/alertd.rs
+++ b/crates/bestool/src/actions/tamanu/alertd.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info};
 
 use bestool_tamanu::{
 	config::{TamanuConfig, load_config},
-	server_info::fetch_device_key,
+	server_info::{fetch_device_key_with, query_device_key_row},
 };
 
 use super::{TamanuArgs, find_tamanu};
@@ -318,6 +318,7 @@ async fn build_config(
 	info!("starting alertd daemon");
 
 	let database_url = config.database_url();
+	let pg_pool = bestool_postgres::pool::create_pool(&database_url, "bestool-alertd").await?;
 
 	let email = config
 		.mailgun
@@ -334,17 +335,32 @@ async fn build_config(
 		Some(std::time::Duration::from_secs(watchdog_timeout))
 	};
 
-	let device_key_pem = fetch_device_key(&database_url).await;
+	let device_key_pem = fetch_device_key_with(|| async {
+		match pg_pool.get().await {
+			Ok(conn) => query_device_key_row(&conn).await,
+			Err(err) => {
+				tracing::warn!(%err, "could not get DB conn for deviceKey fetch");
+				None
+			}
+		}
+	})
+	.await;
 
 	let config = Arc::new(config);
 
-	let mut daemon_config =
-		bestool_alertd::DaemonConfig::new(dirs, database_url.clone(), tamanu_version.to_string())
-			.with_dry_run(dry_run)
-			.with_no_server(no_server)
-			.with_server_addrs(server_addr)
-			.with_watchdog_timeout(watchdog)
-			.with_server_kind(detect_server_kind(&config, &database_url).await);
+	let server_kind = detect_server_kind(&config, &pg_pool).await;
+
+	let mut daemon_config = bestool_alertd::DaemonConfig::new(
+		dirs,
+		pg_pool.clone(),
+		database_url.clone(),
+		tamanu_version.to_string(),
+	)
+	.with_dry_run(dry_run)
+	.with_no_server(no_server)
+	.with_server_addrs(server_addr)
+	.with_watchdog_timeout(watchdog)
+	.with_server_kind(server_kind);
 
 	if !no_healthchecks {
 		daemon_config = daemon_config.with_task(Arc::new(DoctorTask::new(
@@ -368,31 +384,24 @@ async fn build_config(
 
 /// Resolve the Tamanu server kind for alertd's alert-definition filter.
 ///
-/// Opens a short-lived DB connection so [`bestool_tamanu::detect_kind`] can
-/// check `local_system_facts`; the daemon itself uses a fresh pool later.
-/// Alertd is plugin-agnostic — it takes the kind as an opaque string and
-/// compares against alert YAML `server-kind:` values by equality. The Tamanu
+/// Borrows a connection from the daemon pool so
+/// [`bestool_tamanu::detect_kind`] can check `local_system_facts`. Alertd is
+/// plugin-agnostic — it takes the kind as an opaque string and compares
+/// against alert YAML `server-kind:` values by equality. The Tamanu
 /// vocabulary (`central` / `facility`) is decided here, at the integration
 /// boundary, not by alertd.
 async fn detect_server_kind(
 	config: &bestool_tamanu::config::TamanuConfig,
-	database_url: &str,
+	pg_pool: &bestool_postgres::pool::PgPool,
 ) -> &'static str {
-	let db = match tokio_postgres::connect(database_url, tokio_postgres::NoTls).await {
-		Ok((client, conn)) => {
-			tokio::spawn(async move {
-				if let Err(err) = conn.await {
-					tracing::warn!("kind-detection connection error: {err}");
-				}
-			});
-			Some(client)
-		}
+	let conn = match pg_pool.get().await {
+		Ok(c) => Some(c),
 		Err(err) => {
 			tracing::debug!(%err, "no DB for kind detection; falling back to config-only");
 			None
 		}
 	};
-	match bestool_tamanu::detect_kind(config, db.as_ref()).await {
+	match bestool_tamanu::detect_kind(config, conn.as_deref()).await {
 		bestool_tamanu::ApiServerKind::Central => "central",
 		bestool_tamanu::ApiServerKind::Facility => "facility",
 	}

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -521,16 +521,15 @@ pub(super) async fn perform_sweep(
 ) -> Result<SweepResult> {
 	// Open a single connection up-front. Checks that need the DB share it; the
 	// `db_connect` check separately measures the open latency for reporting.
-	let db = match tokio_postgres::connect(database_url, tokio_postgres::NoTls).await {
-		Ok((client, conn)) => {
-			tokio::spawn(async move {
-				if let Err(err) = conn.await {
-					warn!("doctor db connection error: {err}");
-				}
-			});
-			Some(Arc::new(client))
+	// Goes through `bestool_postgres::pool::connect_one` so all DB opens in
+	// the project share one SSL fallback / auth retry / app-name path.
+	let db = match bestool_postgres::pool::connect_one(database_url, "bestool-tamanu-doctor").await
+	{
+		Ok(client) => Some(Arc::new(client)),
+		Err(err) => {
+			warn!(%err, "doctor could not open Tamanu DB; DB-dependent checks will skip");
+			None
 		}
-		Err(_) => None,
 	};
 
 	let kind = bestool_tamanu::detect_kind(&config, db.as_deref()).await;

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -15,7 +15,6 @@ use tracing::{debug, warn};
 
 use bestool_tamanu::{
 	config::{TamanuConfig, load_config},
-	connection_url::ConnectionUrlBuilder,
 	doctor::{
 		check::{Check, CheckStatus, OverallResult},
 		checks::{self, CheckContext},
@@ -85,7 +84,7 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	let (version, root) = find_tamanu(tamanu)?;
 	let config = Arc::new(load_config(&root, None)?);
 
-	let database_url = build_database_url(&config);
+	let database_url = config.database_url();
 	let http_client = reqwest::Client::new();
 
 	let (sweep, source) = if args.no_daemon {
@@ -503,22 +502,6 @@ pub(super) struct SweepResult {
 	/// callers (e.g. the daemon plugin) can cache it across ticks instead of
 	/// re-querying every minute.
 	pub pg_version: Option<String>,
-}
-
-pub(super) fn build_database_url(config: &TamanuConfig) -> String {
-	ConnectionUrlBuilder {
-		username: config.db.username.clone(),
-		password: Some(config.db.password.clone()),
-		host: config
-			.db
-			.host
-			.clone()
-			.unwrap_or_else(|| "localhost".to_string()),
-		port: config.db.port,
-		database: config.db.name.clone(),
-		ssl_mode: None,
-	}
-	.build()
 }
 
 #[expect(

--- a/crates/bestool/src/actions/tamanu/meta_ticket.rs
+++ b/crates/bestool/src/actions/tamanu/meta_ticket.rs
@@ -8,7 +8,6 @@ use tracing::debug;
 
 use bestool_tamanu::{
 	config::load_config,
-	connection_url::ConnectionUrlBuilder,
 	server_info::{
 		detect_virtualisation, get_or_create_device_key, get_or_create_server_id,
 		get_tailscale_info,
@@ -49,19 +48,7 @@ pub async fn run(_args: MetaTicketArgs, ctx: Context) -> Result<()> {
 	let (_, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 	let config = load_config(&root, None)?;
 
-	let builder = ConnectionUrlBuilder {
-		username: config.db.username.clone(),
-		password: Some(config.db.password.clone()),
-		host: config
-			.db
-			.host
-			.clone()
-			.unwrap_or_else(|| "localhost".to_string()),
-		port: config.db.port,
-		database: config.db.name.clone(),
-		ssl_mode: None,
-	};
-	let url = builder.build();
+	let url = config.database_url();
 
 	debug!(url, "connecting to database");
 	let pool = bestool_psql::create_pool(&url).await?;

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -455,9 +455,9 @@ pub async fn run(args: PsqlArgs, ctx: Context) -> Result<()> {
 
 /// Read the Tamanu device key from the standard on-disk path.
 ///
-/// Tries the file-based source only. `bestool-tamanu`'s full `fetch_device_key`
-/// also falls back to the Tamanu DB, but pulling in that path here would drag
-/// the doctor-only tokio runtime into the psql feature for what's a small
+/// Tries the file-based source only. `bestool-tamanu::fetch_device_key_with`
+/// also falls back to the Tamanu DB if a connection is available, but
+/// reaching for it here would add an extra DB round-trip for what's a small
 /// best-effort lookup — psql's canopy use degrades cleanly to direct fetches
 /// when the device key isn't readable.
 fn read_device_key() -> Option<String> {

--- a/crates/postgres/src/pool.rs
+++ b/crates/postgres/src/pool.rs
@@ -164,6 +164,21 @@ pub async fn create_pool(url: &str, application_name: &str) -> Result<PgPool> {
 	Ok(pool)
 }
 
+/// Open a single connection using the same SSL fallback, auth retry, and
+/// application-name path as [`create_pool`].
+///
+/// For one-shot commands that open exactly one connection and exit (doctor
+/// sweeps, the patient-portal flag lookup in lifecycle subcommands, etc.).
+/// Internally builds a pool, takes one client out, then drops the pool. The
+/// returned client owns its connection driver task — it remains usable after
+/// the pool is gone.
+pub async fn connect_one(url: &str, application_name: &str) -> Result<tokio_postgres::Client> {
+	use mobc::Manager as _;
+
+	let pool = create_pool(url, application_name).await?;
+	pool.manager.connect().await.into_diagnostic()
+}
+
 /// Check if we can actually establish a connection
 async fn check_pool(pool: &PgPool) -> Result<()> {
 	let conn = match pool.get().await {

--- a/crates/tamanu/Cargo.toml
+++ b/crates/tamanu/Cargo.toml
@@ -18,7 +18,6 @@ doctor = [
 	"dep:hickory-resolver",
 	"dep:owo-colors",
 	"dep:reqwest",
-	"dep:tokio",
 ]
 meta-ticket = ["dep:p256"]
 
@@ -38,6 +37,7 @@ regex = "1.11.2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 sysinfo = { workspace = true }
+tokio = { workspace = true, features = ["process", "time", "sync", "rt", "net", "macros"] }
 tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-serde_json-1", "with-uuid-1"] }
 tracing = { workspace = true }
 url = { version = "2.5.8", features = ["serde"] }
@@ -51,7 +51,6 @@ futures = { workspace = true, optional = true }
 hickory-resolver = { version = "0.26.1", optional = true }
 owo-colors = { version = "4.2.3", optional = true }
 reqwest = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["process", "time", "sync", "rt", "net", "macros"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.21.0"

--- a/crates/tamanu/src/config/structure.rs
+++ b/crates/tamanu/src/config/structure.rs
@@ -63,6 +63,28 @@ impl TamanuConfig {
 	pub fn fhir_worker_enabled(&self) -> bool {
 		self.integrations.fhir.worker.enabled
 	}
+
+	/// Build the `postgresql://` URL from `db` for the canonical
+	/// username/password the local Tamanu install uses. Hosts default to
+	/// `localhost`, port defers to the URL's libpq default when unset.
+	///
+	/// Subcommands that need a different role (e.g. psql's report-schema
+	/// connections) build their own `ConnectionUrlBuilder` instead.
+	pub fn database_url(&self) -> String {
+		crate::connection_url::ConnectionUrlBuilder {
+			username: self.db.username.clone(),
+			password: Some(self.db.password.clone()),
+			host: self
+				.db
+				.host
+				.clone()
+				.unwrap_or_else(|| "localhost".to_string()),
+			port: self.db.port,
+			database: self.db.name.clone(),
+			ssl_mode: None,
+		}
+		.build()
+	}
 }
 
 /// The `integrations` block of the Tamanu config.

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -276,27 +276,16 @@ fn generate_device_key_pem() -> Result<String> {
 
 /// Best-effort load of the Tamanu deviceKey PEM.
 ///
-/// Tries the standard file path first ([`standard_device_key_path`]). If that
-/// isn't readable, falls back to the legacy `local_system_facts.deviceKey`
-/// row in the Tamanu DB by opening a fresh connection to `database_url`. When
-/// the fallback succeeds and the standard path doesn't already exist,
-/// attempts a best-effort copy so subsequent runs don't need the DB.
+/// Tries the standard file path first ([`standard_device_key_path`]). If
+/// that isn't readable, falls back to the legacy
+/// `local_system_facts.deviceKey` row via the caller-supplied closure (which
+/// receives the chance to use a pre-existing DB client). When the fallback
+/// succeeds and the standard path doesn't already exist, attempts a
+/// best-effort copy so subsequent runs don't need the DB.
 ///
-/// Callers that already have a Tamanu DB client should use
-/// [`fetch_device_key_with`] instead to avoid opening a second connection.
-///
-/// Returns `None` if neither source yields a key. Logging is the only signal:
-/// callers without a device key continue to work (canopy tailscale path is
-/// still available).
-pub async fn fetch_device_key(database_url: &str) -> Option<String> {
-	fetch_device_key_with(|| fetch_device_key_from_db(database_url)).await
-}
-
-/// Like [`fetch_device_key`] but with a caller-supplied DB-fallback fetcher.
-///
-/// Use this from contexts that already hold a `tokio_postgres::Client` so we
-/// don't open a second connection. The closure is invoked only if the file at
-/// the standard path is missing/unreadable.
+/// Returns `None` if neither source yields a key. Logging is the only
+/// signal: callers without a device key continue to work (canopy tailscale
+/// path is still available).
 pub async fn fetch_device_key_with<F, Fut>(db_fetch: F) -> Option<String>
 where
 	F: FnOnce() -> Fut,
@@ -449,24 +438,6 @@ fn write_device_key_file(path: &Path, pem: &str) -> std::io::Result<()> {
 		f.sync_all()?;
 	}
 	std::fs::rename(&tmp, path)
-}
-
-async fn fetch_device_key_from_db(database_url: &str) -> Option<String> {
-	let (client, connection) =
-		match tokio_postgres::connect(database_url, tokio_postgres::NoTls).await {
-			Ok(c) => c,
-			Err(err) => {
-				warn!("failed to connect for deviceKey fetch: {err}");
-				return None;
-			}
-		};
-	tokio::spawn(async move {
-		if let Err(err) = connection.await {
-			warn!("deviceKey-fetch connection error: {err}");
-		}
-	});
-
-	query_device_key_row(&client).await
 }
 
 /// Read the tailscale Self node's first IP and DNS name, if tailscale is


### PR DESCRIPTION
🤖 Funnel every DB open in the workspace through `bestool_postgres::pool` so all the SSL fallback, auth retry, and `application_name` handling lives in one path. Sits underneath #400 (patient portal flag fix), no behaviour change on its own.

## What changed

- **`TamanuConfig::database_url()`** in bestool-tamanu — replaces the inline `ConnectionUrlBuilder { ... }` blocks in `actions/tamanu/doctor.rs`, `alertd.rs`, and `meta_ticket.rs` (4 copies → 1).
- **tokio promoted to a hard dep on bestool-tamanu**. `tokio_postgres` already requires a runtime, and every consumer enabled the implicit transitive `doctor` feature anyway, so the existing `optional = true` was a footgun (`server_info::fetch_device_key_from_db` and `external_users` wouldn't compile if you ever asked for a non-`doctor` feature set).
- **`bestool_postgres::pool::connect_one(url, app_name)`** — new helper for one-shot opens. Wraps `create_pool` so the caller gets back a single `tokio_postgres::Client` after the unified setup, then drops the pool. mobc adds ~1 round-trip on localhost (`SELECT 1` check) vs raw `tokio_postgres::connect`; trade is worth it to consolidate the SSL fallback / auth retry / app-name handling.
- **alertd's `DaemonConfig` takes a `PgPool` from the caller** instead of opening one internally. `bestool tamanu alertd` builds the pool once and reuses it for `detect_server_kind` (via `detect_kind`) and the device-key lookup (via `fetch_device_key_with`) — was opening two extra raw connections on top of the daemon's pool. Standalone `bestool-alertd` binary creates the pool itself in `main.rs`.
- **doctor `perform_sweep`** uses `connect_one` instead of raw `tokio_postgres::connect`. `CheckContext` shape unchanged (still `Option<Arc<PgClient>>`) so checks didn't need touching.
- Dropped now-unreachable `fetch_device_key(url)` and its private `_from_db(url)` fallback from bestool-tamanu — the only remaining caller (alertd) moved to `fetch_device_key_with` with a pool connection.
