### PR TITLE
feat(tamanu/start): also stop and disable services with Down expectations

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -248,6 +248,73 @@ pub fn wait_stopped(supervisor: Supervisor, targets: &[String]) -> Result<()> {
 	wait_for(supervisor, targets, false, "inactive")
 }
 
+/// Issue a stop call to the right supervisor for every target.
+///
+/// `targets` are supervisor-native identifiers — systemd unit names
+/// (`tamanu-foo.service`, `tamanu-foo@1.service`) or pm2 process names.
+/// No-op for an empty slice. Bails non-zero on supervisor failure; doesn't
+/// itself wait for the stop to complete (use `wait_stopped` afterwards).
+pub fn stop_targets(supervisor: Supervisor, targets: &[String]) -> Result<()> {
+	if targets.is_empty() {
+		return Ok(());
+	}
+	let (cmd, verb) = match supervisor {
+		Supervisor::Systemd => ("systemctl", "stop"),
+		Supervisor::Pm2 => ("pm2", "stop"),
+	};
+	let status = Command::new(cmd)
+		.arg(verb)
+		.args(targets)
+		.status()
+		.into_diagnostic()?;
+	if !status.success() {
+		bail!("{cmd} {verb} failed: exit {status}");
+	}
+	Ok(())
+}
+
+/// Delete (i.e. unregister) a batch of pm2 processes. pm2's analogue of
+/// `systemctl disable`: removes the process entry from pm2's list entirely,
+/// so it won't be picked up by `pm2 resurrect` after the next pm2 restart
+/// and won't show up in `pm2 list`. Implies stopping the process if it was
+/// running. No-op for an empty slice.
+///
+/// More aggressive than systemd's `disable`: there's no plain "don't
+/// auto-start" toggle on pm2, so re-bringing-up requires the ops setup
+/// playbook to re-register the process via the ecosystem file.
+pub fn delete_pm2(names: &[String]) -> Result<()> {
+	if names.is_empty() {
+		return Ok(());
+	}
+	let status = Command::new("pm2")
+		.arg("delete")
+		.args(names)
+		.status()
+		.into_diagnostic()?;
+	if !status.success() {
+		bail!("pm2 delete failed: exit {status}");
+	}
+	Ok(())
+}
+
+/// Disable a batch of systemd units. No-op for an empty slice. Errors
+/// bubble up — callers that want best-effort behaviour should filter the
+/// list with `systemd_is_enabled` first (the typical pattern).
+pub fn disable_systemd_units(units: &[String]) -> Result<()> {
+	if units.is_empty() {
+		return Ok(());
+	}
+	let status = Command::new("systemctl")
+		.arg("disable")
+		.args(units)
+		.status()
+		.into_diagnostic()?;
+	if !status.success() {
+		bail!("systemctl disable failed: exit {status}");
+	}
+	Ok(())
+}
+
 fn wait_for(
 	supervisor: Supervisor,
 	targets: &[String],

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use clap::Parser;
 use miette::{IntoDiagnostic, Result, bail};
 
-use bestool_tamanu::services::{self, Criticality, ExpectedState, Expectation, Supervisor};
+use bestool_tamanu::services::{
+	self, Criticality, ExpectedState, Expectation, Supervisor, systemd_is_enabled,
+};
 
 use crate::actions::{
 	Context,
@@ -13,16 +15,29 @@ use crate::actions::{
 	},
 };
 
-/// Bring up any expected tamanu services that aren't running.
+/// Normalise tamanu services to the expected running state.
 ///
-/// Idempotent: services already up are left alone. Use `tamanu status`
-/// first if you want to see what's missing.
+/// Default mode does both halves: stops (and disables, on systemd) any
+/// service we expect to be `Down` that's currently running or enabled,
+/// then starts any `Up` service that's currently missing or short. With
+/// `--up-only` it behaves like the previous `start`-only version: just
+/// brings up missing services without touching anything else.
+///
+/// Idempotent: services already in the expected state are left alone.
+/// Use `tamanu status` first to see what's drifted.
 #[derive(Debug, Clone, Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct StartArgs {
 	/// Limit to expectations whose name contains any of these substrings.
-	/// No names = start every Up expectation that's currently short.
+	/// No names = consider every expectation.
 	pub names: Vec<String>,
+
+	/// Skip the stop/disable phase: only bring up missing Up services,
+	/// leave any drifted Down services as-is. Useful when you want to
+	/// avoid touching a service that's running but shouldn't be (e.g.
+	/// because you're mid-investigation).
+	#[arg(long)]
+	pub up_only: bool,
 }
 
 pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
@@ -34,24 +49,34 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 	let discovered = lifecycle::discover(supervisor)?;
 	let groups = lifecycle::group_by_expectation(&matched, &discovered);
 
+	let stop_plan = if args.up_only {
+		StopPlan::default()
+	} else {
+		plan_stop(supervisor, &groups, systemd_is_enabled)
+	};
 	let Plan {
 		targets,
 		started_critical,
 	} = plan_start(supervisor, &groups)?;
-	if targets.is_empty() {
-		tracing::info!("nothing to start; everything expected is already up");
+	if stop_plan.is_empty() && targets.is_empty() {
+		tracing::info!("nothing to do; everything matches expected state");
 		return Ok(());
 	}
 
 	lifecycle::ensure_root_or_reexec(supervisor)?;
 
-	tracing::info!(?targets, "starting");
-	match supervisor {
-		Supervisor::Systemd => systemctl_start(&targets)?,
-		Supervisor::Pm2 => pm2_start(&targets)?,
+	if !stop_plan.is_empty() {
+		execute_stop(supervisor, &stop_plan)?;
 	}
 
-	lifecycle::wait_running(supervisor, &targets)?;
+	if !targets.is_empty() {
+		tracing::info!(?targets, "starting");
+		match supervisor {
+			Supervisor::Systemd => systemctl_start(&targets)?,
+			Supervisor::Pm2 => pm2_start(&targets)?,
+		}
+		lifecycle::wait_running(supervisor, &targets)?;
+	}
 
 	// Critical services are the API and frontend, whose containers Caddy
 	// reaches by hostname. When one of those comes up fresh, Caddy's
@@ -63,6 +88,110 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 		lifecycle::reload_caddy();
 	}
 
+	Ok(())
+}
+
+/// What `plan_stop` decided to do for the Down-side normalisation phase.
+///
+/// Three lists because the two supervisors normalise to "absent" via
+/// different verbs:
+///
+/// - systemd: `stop` for running units (keep `disable` empty if the unit
+///   was already disabled), `disable` for enabled units (keep `stop` empty
+///   if the unit was already inactive), or both.
+/// - pm2: `delete` for any registered process — pm2 has no "stop but stay
+///   registered" + "disable from list" split, so the only way to clear a
+///   Down expectation is to unregister entirely.
+#[derive(Default, Debug)]
+struct StopPlan {
+	/// systemd units to `systemctl stop`. Empty on pm2.
+	stop: Vec<String>,
+	/// systemd units to `systemctl disable`. Empty on pm2.
+	disable: Vec<String>,
+	/// pm2 process names to `pm2 delete`. Empty on systemd.
+	delete: Vec<String>,
+}
+
+impl StopPlan {
+	fn is_empty(&self) -> bool {
+		self.stop.is_empty() && self.disable.is_empty() && self.delete.is_empty()
+	}
+}
+
+/// Compute the stop+disable list for every `Down` expectation in `groups`.
+///
+/// - Running discovered instances get added to `stop`.
+/// - Enabled units (whether discovered or not — we also probe each
+///   expectation's required units to catch the `enabled-but-not-loaded`
+///   edge case) get added to `disable`.
+///
+/// The `is_enabled` probe is taken as a parameter so the test suite can
+/// drive the planner without shelling out to `systemctl`.
+fn plan_stop(
+	supervisor: Supervisor,
+	groups: &[(&Expectation, Vec<Instance>)],
+	is_enabled: impl Fn(&str) -> bool,
+) -> StopPlan {
+	let mut plan = StopPlan::default();
+	for (exp, instances) in groups {
+		if exp.state != ExpectedState::Down {
+			continue;
+		}
+		match supervisor {
+			Supervisor::Systemd => {
+				for inst in instances {
+					if inst.running {
+						plan.stop.push(inst.unit());
+					}
+				}
+				// Probe is-enabled for every required unit and any
+				// discovered instance, deduping. Catches both the
+				// stopped-but-enabled case (discovered, not running, will
+				// auto-start) and the enabled-but-not-loaded case (not in
+				// `list-units` output but `is-enabled` says yes).
+				let mut to_probe: Vec<String> = exp.instances.required_systemd_units(exp.name);
+				for inst in instances {
+					let u = inst.unit();
+					if !to_probe.contains(&u) {
+						to_probe.push(u);
+					}
+				}
+				for unit in to_probe {
+					if is_enabled(&unit) {
+						plan.disable.push(unit);
+					}
+				}
+			}
+			Supervisor::Pm2 => {
+				// `pm2 delete` is sufficient on its own: it stops the process
+				// if running, then unregisters it. Dedupe by name because pm2
+				// clustering produces multiple entries sharing one name and
+				// `pm2 delete <name>` removes them all in a single call.
+				for inst in instances {
+					if !plan.delete.contains(&inst.name) {
+						plan.delete.push(inst.name.clone());
+					}
+				}
+			}
+		}
+	}
+	plan
+}
+
+fn execute_stop(supervisor: Supervisor, plan: &StopPlan) -> Result<()> {
+	if !plan.stop.is_empty() {
+		tracing::info!(targets = ?plan.stop, "stopping services expected down");
+		lifecycle::stop_targets(supervisor, &plan.stop)?;
+		lifecycle::wait_stopped(supervisor, &plan.stop)?;
+	}
+	if !plan.disable.is_empty() {
+		tracing::info!(units = ?plan.disable, "disabling units expected down");
+		lifecycle::disable_systemd_units(&plan.disable)?;
+	}
+	if !plan.delete.is_empty() {
+		tracing::info!(processes = ?plan.delete, "deleting pm2 processes expected down");
+		lifecycle::delete_pm2(&plan.delete)?;
+	}
 	Ok(())
 }
 
@@ -214,5 +343,147 @@ mod tests {
 		];
 		let plan = plan_start(Supervisor::Systemd, &groups).unwrap();
 		assert!(plan.started_critical);
+	}
+
+	fn down_exp(name: &'static str) -> Expectation {
+		Expectation {
+			name,
+			instances: Instances::Single,
+			state: ExpectedState::Down,
+			criticality: Criticality::Background,
+			reason: "test".into(),
+			legacy: false,
+		}
+	}
+
+	#[test]
+	fn plan_stop_collects_running_down_instances() {
+		// Running Down unit → systemd stop list, plus disable if enabled.
+		let portal = down_exp("tamanu-patientportal");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&portal,
+			vec![Instance {
+				name: "tamanu-patientportal".into(),
+				instance: None,
+				pm_id: None,
+				running: true,
+			}],
+		)];
+		let plan = plan_stop(Supervisor::Systemd, &groups, |_| true);
+		assert_eq!(plan.stop, vec!["tamanu-patientportal.service"]);
+		assert_eq!(plan.disable, vec!["tamanu-patientportal.service"]);
+	}
+
+	#[test]
+	fn plan_stop_disables_stopped_but_enabled_down_unit() {
+		// Not running but `is_enabled` says yes → no stop call (already
+		// stopped) but still disable it so it doesn't come back at boot.
+		let portal = down_exp("tamanu-patientportal");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&portal,
+			vec![Instance {
+				name: "tamanu-patientportal".into(),
+				instance: None,
+				pm_id: None,
+				running: false,
+			}],
+		)];
+		let plan = plan_stop(Supervisor::Systemd, &groups, |_| true);
+		assert!(plan.stop.is_empty());
+		assert_eq!(plan.disable, vec!["tamanu-patientportal.service"]);
+	}
+
+	#[test]
+	fn plan_stop_handles_enabled_but_not_loaded_down_unit() {
+		// No matching instances at all, but `is_enabled` says yes — we still
+		// want to disable so the unit doesn't sneak back at next boot.
+		let portal = down_exp("tamanu-patientportal");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(&portal, vec![])];
+		let plan = plan_stop(Supervisor::Systemd, &groups, |_| true);
+		assert!(plan.stop.is_empty());
+		assert_eq!(plan.disable, vec!["tamanu-patientportal.service"]);
+	}
+
+	#[test]
+	fn plan_stop_noop_when_down_unit_fully_absent() {
+		// Already in the expected state: not running, not enabled, not
+		// loaded. plan_stop should produce nothing.
+		let portal = down_exp("tamanu-patientportal");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(&portal, vec![])];
+		let plan = plan_stop(Supervisor::Systemd, &groups, |_| false);
+		assert!(plan.is_empty());
+	}
+
+	#[test]
+	fn plan_stop_ignores_up_expectations() {
+		// An Up expectation with a (transiently) stopped instance must not
+		// be added to the stop/disable list — the start phase will bring it
+		// back, not normalise it away.
+		let api = exp("tamanu-central-api", Criticality::Critical);
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&api,
+			vec![Instance {
+				name: "tamanu-central-api".into(),
+				instance: None,
+				pm_id: None,
+				running: false,
+			}],
+		)];
+		let plan = plan_stop(Supervisor::Systemd, &groups, |unit| {
+			panic!("is_enabled probe must not fire for Up expectations, got {unit}")
+		});
+		assert!(plan.is_empty());
+	}
+
+	#[test]
+	fn plan_stop_pm2_deletes_registered_down_regardless_of_run_state() {
+		// pm2 has no plain disable; the only way to clear a Down expectation
+		// is to delete (unregister) the process. Running or stopped doesn't
+		// matter — both register as "present" in pm2's list and would still
+		// be flagged by `tamanu status`.
+		let fhir = down_exp("tamanu-fhir-resolve");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&fhir,
+			vec![Instance {
+				name: "tamanu-fhir-resolve".into(),
+				instance: None,
+				pm_id: Some(3),
+				running: false,
+			}],
+		)];
+		let plan = plan_stop(Supervisor::Pm2, &groups, |unit| {
+			panic!("is_enabled probe is meaningless on pm2, got {unit}")
+		});
+		assert!(plan.stop.is_empty());
+		assert!(plan.disable.is_empty());
+		assert_eq!(plan.delete, vec!["tamanu-fhir-resolve"]);
+	}
+
+	#[test]
+	fn plan_stop_pm2_dedupes_cluster_instances_by_name() {
+		// Pm2 clustering registers N processes sharing one name.
+		// `pm2 delete <name>` removes all of them in a single call, so the
+		// plan should only carry the name once even when discovery returns
+		// multiple entries.
+		let fhir = down_exp("tamanu-fhir-resolve");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&fhir,
+			vec![
+				Instance {
+					name: "tamanu-fhir-resolve".into(),
+					instance: None,
+					pm_id: Some(3),
+					running: true,
+				},
+				Instance {
+					name: "tamanu-fhir-resolve".into(),
+					instance: None,
+					pm_id: Some(4),
+					running: true,
+				},
+			],
+		)];
+		let plan = plan_stop(Supervisor::Pm2, &groups, |_| false);
+		assert_eq!(plan.delete, vec!["tamanu-fhir-resolve"]);
 	}
 }

--- a/crates/bestool/src/actions/tamanu/stop.rs
+++ b/crates/bestool/src/actions/tamanu/stop.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use miette::{IntoDiagnostic, Result, bail};
+use miette::Result;
 
 use bestool_tamanu::services::{self, ExpectedState, Expectation, Supervisor};
 
@@ -42,11 +42,7 @@ pub async fn run(args: StopArgs, ctx: Context) -> Result<()> {
 	lifecycle::ensure_root_or_reexec(supervisor)?;
 
 	tracing::info!(?targets, "stopping");
-	match supervisor {
-		Supervisor::Systemd => systemctl_stop(&targets)?,
-		Supervisor::Pm2 => pm2_stop(&targets)?,
-	}
-
+	lifecycle::stop_targets(supervisor, &targets)?;
 	lifecycle::wait_stopped(supervisor, &targets)?;
 	Ok(())
 }
@@ -74,26 +70,3 @@ fn plan_stop(
 	targets
 }
 
-fn systemctl_stop(units: &[String]) -> Result<()> {
-	let status = std::process::Command::new("systemctl")
-		.arg("stop")
-		.args(units)
-		.status()
-		.into_diagnostic()?;
-	if !status.success() {
-		bail!("systemctl stop failed: exit {status}");
-	}
-	Ok(())
-}
-
-fn pm2_stop(names: &[String]) -> Result<()> {
-	let status = std::process::Command::new("pm2")
-		.arg("stop")
-		.args(names)
-		.status()
-		.into_diagnostic()?;
-	if !status.success() {
-		bail!("pm2 stop failed: exit {status}");
-	}
-	Ok(())
-}


### PR DESCRIPTION
🤖 Reframes `bestool tamanu start` as a "normalise to the expected state" operation rather than a pure start. In addition to bringing up any `Up` service that's missing or short, it now also tears down anything that shouldn't be there:

- **systemd**: stops any `Down` unit that's currently running, and disables any `Down` unit that's currently enabled — including the rare "enabled-but-not-loaded" case (probed via `systemctl is-enabled` on every `Down` expectation's required units, not just the ones that showed up in `list-units`). Just stopping wouldn't suffice: a stopped+enabled unit comes back at next boot, and the recent `tamanu status` fix deliberately keeps flagging that state.

- **pm2**: `pm2 delete` any registered process (running or stopped) for a `Down` expectation. Pm2 has no plain "don't auto-start" toggle; the only way to clear a `Down` match is to unregister entirely. Dedupes by name to handle clustering where N processes share one name.

The new `--up-only` flag opts out of the tear-down phase, restoring the previous start-only behaviour for operators mid-investigation.

Factors the supervisor primitives into shared `lifecycle::stop_targets` / `disable_systemd_units` / `delete_pm2` helpers so `tamanu stop` and the new normalise phase share one source of truth.

> Stacked on #404 — review/merge that first.
