### PR TITLE
feat(tamanu): reload caddy after patient-portal restart (and on Windows)

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1093,7 +1093,7 @@ Alias: t
 * `psql` — Connect to Tamanu's database
 * `tags` — Fetch this device's tags from canopy.
 * `restart` — Rolling-restart all running tamanu services.
-* `start` — Bring up any expected tamanu services that aren't running.
+* `start` — Normalise tamanu services to the expected running state.
 * `status` — Report on tamanu services: what's expected vs what's actually running.
 * `stop` — Stop running tamanu services.
 
@@ -1851,16 +1851,26 @@ instance up to take traffic.
 
 ## `bestool tamanu start`
 
-Bring up any expected tamanu services that aren't running.
+Normalise tamanu services to the expected running state.
 
-Idempotent: services already up are left alone. Use `tamanu status`
-first if you want to see what's missing.
+Default mode does both halves: stops (and disables, on systemd) any
+service we expect to be `Down` that's currently running or enabled,
+then starts any `Up` service that's currently missing or short. With
+`--up-only` it behaves like the previous `start`-only version: just
+brings up missing services without touching anything else.
 
-**Usage:** `bestool tamanu start [NAMES]...`
+Idempotent: services already in the expected state are left alone.
+Use `tamanu status` first to see what's drifted.
+
+**Usage:** `bestool tamanu start [OPTIONS] [NAMES]...`
 
 ###### **Arguments:**
 
-* `<NAMES>` — Limit to expectations whose name contains any of these substrings. No names = start every Up expectation that's currently short
+* `<NAMES>` — Limit to expectations whose name contains any of these substrings. No names = consider every expectation
+
+###### **Options:**
+
+* `--up-only` — Skip the stop/disable phase: only bring up missing Up services, leave any drifted Down services as-is. Useful when you want to avoid touching a service that's running but shouldn't be (e.g. because you're mid-investigation)
 
 
 
@@ -1881,6 +1891,7 @@ check, or before/after a `tamanu start` / `restart` to see the impact.
 ###### **Options:**
 
 * `--json` — Emit the wire-shape JSON instead of the human-readable render
+* `--all` — Include compliant legacy expectations (e.g. `tamanu-facility`) in the output. Without this flag, legacy rows are hidden when they're in their expected state — they only show up if they fail, so the 90% of deployments that never had the leftover unit don't see a permanent OK row for it. Implied when name filters are supplied
 
 
 

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -530,14 +530,13 @@ fn is_running(supervisor: Supervisor, target: &str) -> bool {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bestool_tamanu::services::{Criticality, ExpectedState, Instances};
+	use bestool_tamanu::services::{ExpectedState, Instances};
 
 	fn exp(name: &'static str) -> Expectation {
 		Expectation {
 			name,
 			instances: Instances::Single,
 			state: ExpectedState::Up,
-			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,
@@ -549,7 +548,6 @@ mod tests {
 			name,
 			instances: Instances::NumericAtLeast(2),
 			state: ExpectedState::Up,
-			criticality: Criticality::Critical,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -410,16 +410,34 @@ fn is_pm2_pm_id_online(pm_id: Option<i64>) -> bool {
 	}
 }
 
-/// Reload caddy + flush systemd-resolved. Needed after restarting a
-/// containerised tamanu service: caddy's upstream list is by hostname,
-/// resolved caches IPs, and the restarted container has a new IP. Both
-/// calls are best-effort: failures are logged but don't bail.
+/// Reload caddy (Linux: + flush systemd-resolved). Needed after
+/// restarting a containerised tamanu service: caddy's upstream list is by
+/// hostname, resolved caches IPs, and the restarted container has a new
+/// IP. All calls are best-effort: failures are logged but don't bail.
+///
+/// Uses the platform-native path that reads the on-disk Caddyfile:
+///
+/// - Linux: `systemctl reload caddy`. We deliberately don't POST the
+///   Caddyfile to the admin API here even though it'd work for a
+///   single-file config — production deployments split their Caddyfile
+///   across `/etc/caddy/conf.d/*` includes, and the safest way to pick
+///   up every fragment is to let caddy re-read from disk the same way
+///   it did at startup.
+/// - Windows: tries the admin API first (`POST localhost:2019/load`
+///   with the Caddyfile content) since it's the most reliable when
+///   available; falls back to `caddy reload --config <path> --adapter
+///   caddyfile` if the admin endpoint is unreachable.
+///
+/// On Linux, also runs `resolvectl flush-caches` regardless of which
+/// reload path actually fired — systemd-resolved caches DNS independently
+/// of caddy's upstream list.
 ///
 /// Mirror of the ansible "Reload caddy" handler from #313.
-pub fn reload_caddy() {
+#[cfg(target_os = "linux")]
+pub async fn reload_caddy() {
 	let status = Command::new("systemctl").args(["reload", "caddy"]).status();
 	match status {
-		Ok(s) if s.success() => debug!("caddy reloaded"),
+		Ok(s) if s.success() => debug!("caddy reloaded via systemctl"),
 		Ok(s) => warn!("systemctl reload caddy exited with {s}"),
 		Err(e) => warn!("could not reload caddy: {e}"),
 	}
@@ -429,6 +447,63 @@ pub fn reload_caddy() {
 		Ok(s) => warn!("resolvectl flush-caches exited with {s}"),
 		Err(e) => debug!("resolvectl not available: {e}"),
 	}
+}
+
+#[cfg(target_os = "windows")]
+pub async fn reload_caddy() {
+	let path = r"C:\Caddy\Caddyfile";
+	match reload_caddy_via_admin_api(path).await {
+		Ok(()) => {
+			debug!("caddy reloaded via admin API");
+			return;
+		}
+		Err(err) => debug!(%err, "caddy admin API unreachable, falling back to CLI"),
+	}
+	// `caddy reload` reads the file, adapts it, and POSTs to the admin
+	// API on the caddy process's behalf. Same end-state as the admin-API
+	// path above; this fallback handles the case where caddy is running
+	// but the admin endpoint is locked down or relocated.
+	let status = Command::new("caddy")
+		.args(["reload", "--config", path, "--adapter", "caddyfile"])
+		.status();
+	match status {
+		Ok(s) if s.success() => debug!("caddy reloaded via CLI"),
+		Ok(s) => warn!("caddy reload exited with {s}"),
+		Err(e) => warn!("could not run caddy reload: {e}"),
+	}
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub async fn reload_caddy() {
+	debug!("caddy reload is unsupported on this OS");
+}
+
+/// POST the Caddyfile content to Caddy's admin API at the default
+/// `localhost:2019/load` endpoint with `Content-Type: text/caddyfile`,
+/// telling Caddy to adapt + load it in-process. Returns an error string
+/// (with enough context to debug) if the file can't be read, the API
+/// doesn't respond, or it returns a non-2xx — the caller logs at debug
+/// and falls back to the platform CLI.
+#[cfg(target_os = "windows")]
+async fn reload_caddy_via_admin_api(path: &str) -> std::result::Result<(), String> {
+	let content = std::fs::read(path).map_err(|e| format!("read {path}: {e}"))?;
+	let client = reqwest::Client::builder()
+		.timeout(Duration::from_secs(5))
+		.build()
+		.map_err(|e| format!("build client: {e}"))?;
+	let resp = client
+		.post("http://localhost:2019/load")
+		.header("Content-Type", "text/caddyfile")
+		.body(content)
+		.send()
+		.await
+		.map_err(|e| format!("POST localhost:2019/load: {e}"))?;
+	if !resp.status().is_success() {
+		let status = resp.status();
+		let body = resp.text().await.unwrap_or_default();
+		return Err(format!("admin API returned {status}: {body}"));
+	}
+	Ok(())
 }
 
 /// Look up the netavark IP of the podman container backing a systemd

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -273,6 +273,41 @@ pub fn stop_targets(supervisor: Supervisor, targets: &[String]) -> Result<()> {
 	Ok(())
 }
 
+/// Restart a batch of pm2 targets by stop-then-start with a short pause
+/// between, rather than `pm2 restart`. `targets` are pm2-acceptable
+/// identifiers (process names, or pm_ids stringified).
+///
+/// `pm2 restart` has been observed to occasionally leak the previous
+/// node process — it shows up as no longer owned by pm2 (and no longer in
+/// `pm2 list`) but still holding the TCP port, causing the freshly
+/// started replacement to either fail to bind or sit alongside the
+/// zombie. Splitting into explicit stop and start with ~1s in between
+/// gives the old process time to exit and release its handles before pm2
+/// hands them to the new one. No-op for an empty slice.
+pub fn pm2_restart_targets(targets: &[String]) -> Result<()> {
+	if targets.is_empty() {
+		return Ok(());
+	}
+	let stop = Command::new("pm2")
+		.arg("stop")
+		.args(targets)
+		.status()
+		.into_diagnostic()?;
+	if !stop.success() {
+		bail!("pm2 stop failed: exit {stop}");
+	}
+	sleep(Duration::from_secs(1));
+	let start = Command::new("pm2")
+		.arg("start")
+		.args(targets)
+		.status()
+		.into_diagnostic()?;
+	if !start.success() {
+		bail!("pm2 start failed: exit {start}");
+	}
+	Ok(())
+}
+
 /// Delete (i.e. unregister) a batch of pm2 processes. pm2's analogue of
 /// `systemctl disable`: removes the process entry from pm2's list entirely,
 /// so it won't be picked up by `pm2 resurrect` after the next pm2 restart
@@ -363,14 +398,7 @@ pub fn restart_one(supervisor: Supervisor, instance: &Instance) -> Result<()> {
 			let id = instance
 				.pm_id
 				.ok_or_else(|| miette::miette!("pm2 instance {} has no pm_id", instance.name))?;
-			let status = Command::new("pm2")
-				.args(["restart", &id.to_string()])
-				.status()
-				.into_diagnostic()?;
-			if !status.success() {
-				bail!("pm2 restart {id} failed: {status}");
-			}
-			Ok(())
+			pm2_restart_targets(&[id.to_string()])
 		}
 	}
 }

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -540,6 +540,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 
@@ -551,6 +552,7 @@ mod tests {
 			criticality: Criticality::Critical,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -83,8 +83,8 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 		// a "keep one up" availability constraint — the bulk restart
 		// already drops them all briefly, so a single trailing reload is
 		// enough to flush Caddy's stale upstream IPs.
-		if bulk_behind_caddy && matches!(supervisor, Supervisor::Systemd) {
-			lifecycle::reload_caddy();
+		if bulk_behind_caddy {
+			lifecycle::reload_caddy().await;
 		}
 	} else {
 		debug!("no bulk-restart services");
@@ -113,8 +113,8 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 			false
 		};
 
-		if *behind_caddy && matches!(supervisor, Supervisor::Systemd) {
-			lifecycle::reload_caddy();
+		if *behind_caddy {
+			lifecycle::reload_caddy().await;
 		}
 
 		// Cooldown only applies when we have no readiness signal at all —

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -6,7 +6,7 @@ use miette::{IntoDiagnostic, Result, bail};
 use reqwest::{Client, Url};
 use tracing::{debug, info, warn};
 
-use bestool_tamanu::services::{self, Criticality, ExpectedState, Expectation, Supervisor};
+use bestool_tamanu::services::{self, ExpectedState, Expectation, Supervisor};
 
 use crate::actions::{
 	Context,
@@ -67,34 +67,34 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 	lifecycle::ensure_root_or_reexec(supervisor)?;
 
 	let Partitioned {
-		background,
-		background_behind_caddy,
-		critical,
+		bulk,
+		bulk_behind_caddy,
+		rolling,
 	} = partition(supervisor, &groups);
 	let client = http_client()?;
 
-	if !background.is_empty() {
-		info!(targets = ?background, "restarting background services");
-		bulk_restart(supervisor, &background)?;
-		lifecycle::wait_running(supervisor, &background)?;
-		// One reload after the bulk covers every behind-caddy background
-		// service in the batch (currently just patient-portal). Per-service
-		// rolling reloads aren't needed here because background services
-		// don't have a "keep one up" availability constraint — the bulk
-		// restart already drops them all briefly, so a single trailing
-		// reload is enough to flush Caddy's stale upstream IPs.
-		if background_behind_caddy && matches!(supervisor, Supervisor::Systemd) {
+	if !bulk.is_empty() {
+		info!(targets = ?bulk, "bulk-restarting non-rolling services");
+		bulk_restart(supervisor, &bulk)?;
+		lifecycle::wait_running(supervisor, &bulk)?;
+		// One reload after the bulk covers every behind-caddy service in
+		// the batch (currently just patient-portal). Per-service rolling
+		// reloads aren't needed here because singleton services don't have
+		// a "keep one up" availability constraint — the bulk restart
+		// already drops them all briefly, so a single trailing reload is
+		// enough to flush Caddy's stale upstream IPs.
+		if bulk_behind_caddy && matches!(supervisor, Supervisor::Systemd) {
 			lifecycle::reload_caddy();
 		}
 	} else {
-		debug!("no background services to restart");
+		debug!("no bulk-restart services");
 	}
 
-	for (i, (instance, behind_caddy)) in critical.iter().enumerate() {
+	for (i, (instance, behind_caddy)) in rolling.iter().enumerate() {
 		info!(
 			"rolling restart {}/{}: {}",
 			i + 1,
-			critical.len(),
+			rolling.len(),
 			instance.display(),
 		);
 		lifecycle::restart_one(supervisor, instance)?;
@@ -121,7 +121,7 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 		// either probing is disabled (`--no-probe-http`) or we couldn't
 		// construct a probe URL. A failed probe is impossible here: the
 		// probe loop retries forever until it succeeds.
-		if i + 1 < critical.len() && !probed_ready {
+		if i + 1 < rolling.len() && !probed_ready {
 			debug!(seconds = args.cooldown.as_secs(), "cooldown");
 			tokio::time::sleep(args.cooldown).await;
 		}
@@ -135,28 +135,34 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 	Ok(())
 }
 
-/// Output of [`partition`]: background services are restarted in bulk,
-/// critical services one-at-a-time with a per-instance readiness probe
-/// between each. `Down` expectations are dropped entirely (they wouldn't
-/// be running, so there's nothing to restart).
+/// Output of [`partition`]: rolling-eligible services restart one
+/// instance at a time with a per-instance readiness probe between each;
+/// everything else bulk-restarts. `Down` expectations are dropped entirely
+/// (they wouldn't be running, so there's nothing to restart).
+///
+/// "Rolling-eligible" comes from [`Expectation::rolling_restart`]:
+/// `min_count >= 2`, i.e. the expectation has enough instances that
+/// rolling can keep one available while the next swaps. Singletons (even
+/// behind-caddy ones like patient-portal) bulk-restart because there's no
+/// second instance to take traffic during the roll.
 struct Partitioned {
 	/// Supervisor-native identifiers to bulk-restart.
-	background: Vec<String>,
-	/// True if any background entry's expectation has `behind_caddy: true`
-	/// — drives a single trailing `reload_caddy` after the bulk completes
-	/// so Caddy sees the new container IPs (currently relevant for
+	bulk: Vec<String>,
+	/// True if any bulk entry's expectation has `behind_caddy: true` —
+	/// drives a single trailing `reload_caddy` after the bulk completes so
+	/// Caddy sees the new container IPs (currently relevant for
 	/// patient-portal).
-	background_behind_caddy: bool,
-	/// Instances to roll one-at-a-time, paired with their
-	/// expectation's `behind_caddy` flag so each iteration knows whether
-	/// to reload Caddy after the restart settles.
-	critical: Vec<(Instance, bool)>,
+	bulk_behind_caddy: bool,
+	/// Instances to roll one-at-a-time, paired with their expectation's
+	/// `behind_caddy` flag so each iteration knows whether to reload Caddy
+	/// after the restart settles.
+	rolling: Vec<(Instance, bool)>,
 }
 
 fn partition(supervisor: Supervisor, groups: &[(&Expectation, Vec<Instance>)]) -> Partitioned {
-	let mut background = Vec::new();
-	let mut background_behind_caddy = false;
-	let mut critical = Vec::new();
+	let mut bulk = Vec::new();
+	let mut bulk_behind_caddy = false;
+	let mut rolling = Vec::new();
 	for (exp, instances) in groups {
 		if exp.state != ExpectedState::Up {
 			continue;
@@ -165,24 +171,23 @@ fn partition(supervisor: Supervisor, groups: &[(&Expectation, Vec<Instance>)]) -
 			if !inst.running {
 				continue;
 			}
-			match exp.criticality {
-				Criticality::Background => {
-					background.push(match supervisor {
-						Supervisor::Systemd => inst.unit(),
-						Supervisor::Pm2 => inst.name.clone(),
-					});
-					if exp.behind_caddy {
-						background_behind_caddy = true;
-					}
+			if exp.rolling_restart() {
+				rolling.push((inst.clone(), exp.behind_caddy));
+			} else {
+				bulk.push(match supervisor {
+					Supervisor::Systemd => inst.unit(),
+					Supervisor::Pm2 => inst.name.clone(),
+				});
+				if exp.behind_caddy {
+					bulk_behind_caddy = true;
 				}
-				Criticality::Critical => critical.push((inst.clone(), exp.behind_caddy)),
 			}
 		}
 	}
 	Partitioned {
-		background,
-		background_behind_caddy,
-		critical,
+		bulk,
+		bulk_behind_caddy,
+		rolling,
 	}
 }
 
@@ -303,66 +308,85 @@ mod tests {
 	use super::*;
 	use bestool_tamanu::services::Instances;
 
-	fn up_exp(name: &'static str, crit: Criticality, behind_caddy: bool) -> Expectation {
+	fn up_exp(name: &'static str, instances: Instances, behind_caddy: bool) -> Expectation {
 		Expectation {
 			name,
-			instances: Instances::Single,
+			instances,
 			state: ExpectedState::Up,
-			criticality: crit,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy,
 		}
 	}
 
-	fn inst(name: &str, running: bool) -> Instance {
+	fn inst(name: &str, instance: Option<&str>, running: bool) -> Instance {
 		Instance {
 			name: name.into(),
-			instance: None,
+			instance: instance.map(Into::into),
 			pm_id: None,
 			running,
 		}
 	}
 
 	#[test]
-	fn partition_flags_background_behind_caddy_when_portal_runs() {
-		// Patient portal is Background but behind Caddy — a bulk restart of
-		// it must still trigger a Caddy reload at the end so Caddy picks up
-		// the new container IP.
-		let portal = up_exp("tamanu-patientportal", Criticality::Background, true);
-		let tasks = up_exp("tamanu-central-tasks", Criticality::Background, false);
+	fn partition_flags_bulk_behind_caddy_when_portal_runs() {
+		// Patient portal is single-instance (so bulk-restartable) but behind
+		// Caddy — a bulk restart must still trigger a Caddy reload at the
+		// end so Caddy picks up the new container IP.
+		let portal = up_exp("tamanu-patientportal", Instances::Single, true);
+		let tasks = up_exp("tamanu-central-tasks", Instances::Single, false);
 		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![
-			(&portal, vec![inst("tamanu-patientportal", true)]),
-			(&tasks, vec![inst("tamanu-central-tasks", true)]),
+			(&portal, vec![inst("tamanu-patientportal", None, true)]),
+			(&tasks, vec![inst("tamanu-central-tasks", None, true)]),
 		];
 		let p = partition(Supervisor::Systemd, &groups);
-		assert!(p.background_behind_caddy);
-		assert_eq!(p.background.len(), 2);
+		assert!(p.bulk_behind_caddy);
+		assert_eq!(p.bulk.len(), 2);
+		assert!(p.rolling.is_empty());
 	}
 
 	#[test]
-	fn partition_no_background_behind_caddy_when_no_caddy_service_in_background() {
-		// All-internal background batch — no caddy reload should fire.
-		let tasks = up_exp("tamanu-central-tasks", Criticality::Background, false);
-		let sync = up_exp("tamanu-facility-sync", Criticality::Background, false);
+	fn partition_no_bulk_behind_caddy_when_no_caddy_service_in_bulk() {
+		// All-internal bulk batch — no caddy reload should fire.
+		let tasks = up_exp("tamanu-central-tasks", Instances::Single, false);
+		let sync = up_exp("tamanu-facility-sync", Instances::Single, false);
 		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![
-			(&tasks, vec![inst("tamanu-central-tasks", true)]),
-			(&sync, vec![inst("tamanu-facility-sync", true)]),
+			(&tasks, vec![inst("tamanu-central-tasks", None, true)]),
+			(&sync, vec![inst("tamanu-facility-sync", None, true)]),
 		];
 		let p = partition(Supervisor::Systemd, &groups);
-		assert!(!p.background_behind_caddy);
+		assert!(!p.bulk_behind_caddy);
 	}
 
 	#[test]
-	fn partition_carries_behind_caddy_per_critical_instance() {
-		let api = up_exp("tamanu-central-api", Criticality::Critical, true);
+	fn partition_carries_behind_caddy_per_rolling_instance() {
+		// Multi-instance API is rolling-eligible; each rolling entry carries
+		// the behind_caddy flag so the loop can reload caddy per swap.
+		let api = up_exp("tamanu-central-api", Instances::NumericAtLeast(2), true);
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&api,
+			vec![
+				inst("tamanu-central-api", Some("1"), true),
+				inst("tamanu-central-api", Some("2"), true),
+			],
+		)];
+		let p = partition(Supervisor::Systemd, &groups);
+		assert_eq!(p.rolling.len(), 2);
+		assert!(p.rolling.iter().all(|(_, behind_caddy)| *behind_caddy));
+		assert!(p.bulk.is_empty());
+	}
+
+	#[test]
+	fn partition_singleton_behind_caddy_is_bulk_not_rolling() {
+		// Patient portal: single-instance, behind caddy. The user-facing
+		// "kind of critical" case — should bulk-restart (only one
+		// instance), but still trigger caddy reload.
+		let portal = up_exp("tamanu-patientportal", Instances::Single, true);
 		let groups: Vec<(&Expectation, Vec<Instance>)> =
-			vec![(&api, vec![inst("tamanu-central-api", true)])];
+			vec![(&portal, vec![inst("tamanu-patientportal", None, true)])];
 		let p = partition(Supervisor::Systemd, &groups);
-		assert_eq!(p.critical.len(), 1);
-		assert!(
-			p.critical[0].1,
-			"behind_caddy flag should ride along on each critical instance"
-		);
+		assert!(p.rolling.is_empty(), "singleton must not roll");
+		assert_eq!(p.bulk.len(), 1);
+		assert!(p.bulk_behind_caddy);
 	}
 }

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -66,18 +66,31 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 
 	lifecycle::ensure_root_or_reexec(supervisor)?;
 
-	let (background, critical) = partition(supervisor, &groups);
+	let Partitioned {
+		background,
+		background_behind_caddy,
+		critical,
+	} = partition(supervisor, &groups);
 	let client = http_client()?;
 
 	if !background.is_empty() {
 		info!(targets = ?background, "restarting background services");
 		bulk_restart(supervisor, &background)?;
 		lifecycle::wait_running(supervisor, &background)?;
+		// One reload after the bulk covers every behind-caddy background
+		// service in the batch (currently just patient-portal). Per-service
+		// rolling reloads aren't needed here because background services
+		// don't have a "keep one up" availability constraint — the bulk
+		// restart already drops them all briefly, so a single trailing
+		// reload is enough to flush Caddy's stale upstream IPs.
+		if background_behind_caddy && matches!(supervisor, Supervisor::Systemd) {
+			lifecycle::reload_caddy();
+		}
 	} else {
 		debug!("no background services to restart");
 	}
 
-	for (i, instance) in critical.iter().enumerate() {
+	for (i, (instance, behind_caddy)) in critical.iter().enumerate() {
 		info!(
 			"rolling restart {}/{}: {}",
 			i + 1,
@@ -100,7 +113,7 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 			false
 		};
 
-		if matches!(supervisor, Supervisor::Systemd) {
+		if *behind_caddy && matches!(supervisor, Supervisor::Systemd) {
 			lifecycle::reload_caddy();
 		}
 
@@ -122,13 +135,27 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 	Ok(())
 }
 
-/// Split discovered instances into (background, critical), keeping only
-/// what's currently running. Drops `Down` expectations.
-fn partition(
-	supervisor: Supervisor,
-	groups: &[(&Expectation, Vec<Instance>)],
-) -> (Vec<String>, Vec<Instance>) {
+/// Output of [`partition`]: background services are restarted in bulk,
+/// critical services one-at-a-time with a per-instance readiness probe
+/// between each. `Down` expectations are dropped entirely (they wouldn't
+/// be running, so there's nothing to restart).
+struct Partitioned {
+	/// Supervisor-native identifiers to bulk-restart.
+	background: Vec<String>,
+	/// True if any background entry's expectation has `behind_caddy: true`
+	/// — drives a single trailing `reload_caddy` after the bulk completes
+	/// so Caddy sees the new container IPs (currently relevant for
+	/// patient-portal).
+	background_behind_caddy: bool,
+	/// Instances to roll one-at-a-time, paired with their
+	/// expectation's `behind_caddy` flag so each iteration knows whether
+	/// to reload Caddy after the restart settles.
+	critical: Vec<(Instance, bool)>,
+}
+
+fn partition(supervisor: Supervisor, groups: &[(&Expectation, Vec<Instance>)]) -> Partitioned {
 	let mut background = Vec::new();
+	let mut background_behind_caddy = false;
 	let mut critical = Vec::new();
 	for (exp, instances) in groups {
 		if exp.state != ExpectedState::Up {
@@ -139,15 +166,24 @@ fn partition(
 				continue;
 			}
 			match exp.criticality {
-				Criticality::Background => background.push(match supervisor {
-					Supervisor::Systemd => inst.unit(),
-					Supervisor::Pm2 => inst.name.clone(),
-				}),
-				Criticality::Critical => critical.push(inst.clone()),
+				Criticality::Background => {
+					background.push(match supervisor {
+						Supervisor::Systemd => inst.unit(),
+						Supervisor::Pm2 => inst.name.clone(),
+					});
+					if exp.behind_caddy {
+						background_behind_caddy = true;
+					}
+				}
+				Criticality::Critical => critical.push((inst.clone(), exp.behind_caddy)),
 			}
 		}
 	}
-	(background, critical)
+	Partitioned {
+		background,
+		background_behind_caddy,
+		critical,
+	}
 }
 
 fn bulk_restart(supervisor: Supervisor, targets: &[String]) -> Result<()> {
@@ -259,5 +295,74 @@ async fn probe_once(client: &Client, url: &Url) -> std::result::Result<(), Strin
 		Ok(resp) if !resp.status().is_server_error() => Ok(()),
 		Ok(resp) => Err(format!("HTTP {}", resp.status())),
 		Err(e) => Err(e.to_string()),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bestool_tamanu::services::Instances;
+
+	fn up_exp(name: &'static str, crit: Criticality, behind_caddy: bool) -> Expectation {
+		Expectation {
+			name,
+			instances: Instances::Single,
+			state: ExpectedState::Up,
+			criticality: crit,
+			reason: "test".into(),
+			legacy: false,
+			behind_caddy,
+		}
+	}
+
+	fn inst(name: &str, running: bool) -> Instance {
+		Instance {
+			name: name.into(),
+			instance: None,
+			pm_id: None,
+			running,
+		}
+	}
+
+	#[test]
+	fn partition_flags_background_behind_caddy_when_portal_runs() {
+		// Patient portal is Background but behind Caddy — a bulk restart of
+		// it must still trigger a Caddy reload at the end so Caddy picks up
+		// the new container IP.
+		let portal = up_exp("tamanu-patientportal", Criticality::Background, true);
+		let tasks = up_exp("tamanu-central-tasks", Criticality::Background, false);
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![
+			(&portal, vec![inst("tamanu-patientportal", true)]),
+			(&tasks, vec![inst("tamanu-central-tasks", true)]),
+		];
+		let p = partition(Supervisor::Systemd, &groups);
+		assert!(p.background_behind_caddy);
+		assert_eq!(p.background.len(), 2);
+	}
+
+	#[test]
+	fn partition_no_background_behind_caddy_when_no_caddy_service_in_background() {
+		// All-internal background batch — no caddy reload should fire.
+		let tasks = up_exp("tamanu-central-tasks", Criticality::Background, false);
+		let sync = up_exp("tamanu-facility-sync", Criticality::Background, false);
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![
+			(&tasks, vec![inst("tamanu-central-tasks", true)]),
+			(&sync, vec![inst("tamanu-facility-sync", true)]),
+		];
+		let p = partition(Supervisor::Systemd, &groups);
+		assert!(!p.background_behind_caddy);
+	}
+
+	#[test]
+	fn partition_carries_behind_caddy_per_critical_instance() {
+		let api = up_exp("tamanu-central-api", Criticality::Critical, true);
+		let groups: Vec<(&Expectation, Vec<Instance>)> =
+			vec![(&api, vec![inst("tamanu-central-api", true)])];
+		let p = partition(Supervisor::Systemd, &groups);
+		assert_eq!(p.critical.len(), 1);
+		assert!(
+			p.critical[0].1,
+			"behind_caddy flag should ride along on each critical instance"
+		);
 	}
 }

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -192,19 +192,20 @@ fn partition(supervisor: Supervisor, groups: &[(&Expectation, Vec<Instance>)]) -
 }
 
 fn bulk_restart(supervisor: Supervisor, targets: &[String]) -> Result<()> {
-	let (cmd, verb) = match supervisor {
-		Supervisor::Systemd => ("systemctl", "restart"),
-		Supervisor::Pm2 => ("pm2", "restart"),
-	};
-	let status = std::process::Command::new(cmd)
-		.arg(verb)
-		.args(targets)
-		.status()
-		.into_diagnostic()?;
-	if !status.success() {
-		bail!("{cmd} {verb} failed: {status}");
+	match supervisor {
+		Supervisor::Systemd => {
+			let status = std::process::Command::new("systemctl")
+				.arg("restart")
+				.args(targets)
+				.status()
+				.into_diagnostic()?;
+			if !status.success() {
+				bail!("systemctl restart failed: {status}");
+			}
+			Ok(())
+		}
+		Supervisor::Pm2 => lifecycle::pm2_restart_targets(targets),
 	}
-	Ok(())
 }
 
 fn http_client() -> Result<Client> {

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -85,8 +85,8 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 	// a stale upstream. `restart` reloads per-instance for critical
 	// services; `start` brings everything up in one batch, so a single
 	// reload at the end covers them all.
-	if started_behind_caddy && matches!(supervisor, Supervisor::Systemd) {
-		lifecycle::reload_caddy();
+	if started_behind_caddy {
+		lifecycle::reload_caddy().await;
 	}
 
 	Ok(())

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use miette::{IntoDiagnostic, Result, bail};
 
 use bestool_tamanu::services::{
-	self, Criticality, ExpectedState, Expectation, Supervisor, systemd_is_enabled,
+	self, ExpectedState, Expectation, Supervisor, systemd_is_enabled,
 };
 
 use crate::actions::{
@@ -56,7 +56,7 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 	};
 	let Plan {
 		targets,
-		started_critical,
+		started_behind_caddy,
 	} = plan_start(supervisor, &groups)?;
 	if stop_plan.is_empty() && targets.is_empty() {
 		tracing::info!("nothing to do; everything matches expected state");
@@ -78,13 +78,14 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 		lifecycle::wait_running(supervisor, &targets)?;
 	}
 
-	// Critical services are the API and frontend, whose containers Caddy
-	// reaches by hostname. When one of those comes up fresh, Caddy's
-	// upstream DNS cache may still hold a stale (NXDOMAIN) entry from
-	// before the container existed — `restart` handles this per-instance,
-	// but `start` brings up a batch in one go, so a single reload at the
-	// end covers all of them.
-	if started_critical && matches!(supervisor, Supervisor::Systemd) {
+	// Behind-caddy services (API, frontend, patient portal) reach Caddy by
+	// container hostname. When one of those comes up fresh its podman
+	// container has a brand-new netavark IP, but Caddy and systemd-resolved
+	// still hold the previous one — without a reload the next request hits
+	// a stale upstream. `restart` reloads per-instance for critical
+	// services; `start` brings everything up in one batch, so a single
+	// reload at the end covers them all.
+	if started_behind_caddy && matches!(supervisor, Supervisor::Systemd) {
 		lifecycle::reload_caddy();
 	}
 
@@ -198,9 +199,10 @@ fn execute_stop(supervisor: Supervisor, plan: &StopPlan) -> Result<()> {
 /// What `plan_start` decided to do.
 struct Plan {
 	targets: Vec<String>,
-	/// Whether any of the planned starts was for a `Criticality::Critical`
-	/// expectation — drives the post-start caddy reload.
-	started_critical: bool,
+	/// Whether any of the planned starts was for a `behind_caddy: true`
+	/// expectation — drives the post-start caddy reload so Caddy sees the
+	/// fresh container IPs of the services that just came up.
+	started_behind_caddy: bool,
 }
 
 /// Compute the list of supervisor identifiers to start.
@@ -214,7 +216,7 @@ fn plan_start(
 	groups: &[(&Expectation, Vec<Instance>)],
 ) -> Result<Plan> {
 	let mut targets = Vec::new();
-	let mut started_critical = false;
+	let mut started_behind_caddy = false;
 	for (exp, instances) in groups {
 		if exp.state != ExpectedState::Up {
 			continue;
@@ -249,13 +251,13 @@ fn plan_start(
 				}
 			}
 		}
-		if targets.len() > before && exp.criticality == Criticality::Critical {
-			started_critical = true;
+		if targets.len() > before && exp.behind_caddy {
+			started_behind_caddy = true;
 		}
 	}
 	Ok(Plan {
 		targets,
-		started_critical,
+		started_behind_caddy,
 	})
 }
 
@@ -286,41 +288,44 @@ fn pm2_start(names: &[String]) -> Result<()> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bestool_tamanu::services::Instances;
+	use bestool_tamanu::services::{Criticality, Instances};
 
-	fn exp(name: &'static str, crit: Criticality) -> Expectation {
+	fn exp(name: &'static str, behind_caddy: bool) -> Expectation {
 		Expectation {
 			name,
 			instances: Instances::Single,
 			state: ExpectedState::Up,
-			criticality: crit,
+			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy,
 		}
 	}
 
 	#[test]
-	fn started_critical_set_when_a_critical_unit_is_planned() {
-		let api = exp("tamanu-central-api", Criticality::Critical);
+	fn started_behind_caddy_set_when_a_behind_caddy_unit_is_planned() {
+		let api = exp("tamanu-central-api", true);
 		let groups = vec![(&api, Vec::<Instance>::new())];
 		let plan = plan_start(Supervisor::Systemd, &groups).unwrap();
 		assert!(!plan.targets.is_empty());
-		assert!(plan.started_critical);
+		assert!(plan.started_behind_caddy);
 	}
 
 	#[test]
-	fn started_critical_unset_when_only_background_planned() {
-		let tasks = exp("tamanu-central-tasks", Criticality::Background);
+	fn started_behind_caddy_unset_when_only_internal_planned() {
+		// Internal-only services (tasks, workers) trigger no caddy reload —
+		// caddy doesn't route to them.
+		let tasks = exp("tamanu-central-tasks", false);
 		let groups = vec![(&tasks, Vec::<Instance>::new())];
 		let plan = plan_start(Supervisor::Systemd, &groups).unwrap();
 		assert!(!plan.targets.is_empty());
-		assert!(!plan.started_critical);
+		assert!(!plan.started_behind_caddy);
 	}
 
 	#[test]
-	fn started_critical_unset_when_critical_already_running() {
-		// Critical expectation is fully satisfied — no targets, no caddy reload.
-		let api = exp("tamanu-central-api", Criticality::Critical);
+	fn started_behind_caddy_unset_when_behind_caddy_already_running() {
+		// behind-caddy expectation is fully satisfied — no targets, no caddy reload.
+		let api = exp("tamanu-central-api", true);
 		let already_running = vec![Instance {
 			name: "tamanu-central-api".into(),
 			instance: None,
@@ -330,19 +335,19 @@ mod tests {
 		let groups = vec![(&api, already_running)];
 		let plan = plan_start(Supervisor::Systemd, &groups).unwrap();
 		assert!(plan.targets.is_empty());
-		assert!(!plan.started_critical);
+		assert!(!plan.started_behind_caddy);
 	}
 
 	#[test]
-	fn started_critical_tracks_any_critical_in_a_mixed_batch() {
-		let tasks = exp("tamanu-central-tasks", Criticality::Background);
-		let api = exp("tamanu-central-api", Criticality::Critical);
+	fn started_behind_caddy_tracks_any_behind_caddy_in_a_mixed_batch() {
+		let tasks = exp("tamanu-central-tasks", false);
+		let api = exp("tamanu-central-api", true);
 		let groups = vec![
 			(&tasks, Vec::<Instance>::new()),
 			(&api, Vec::<Instance>::new()),
 		];
 		let plan = plan_start(Supervisor::Systemd, &groups).unwrap();
-		assert!(plan.started_critical);
+		assert!(plan.started_behind_caddy);
 	}
 
 	fn down_exp(name: &'static str) -> Expectation {
@@ -353,6 +358,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 
@@ -419,7 +425,7 @@ mod tests {
 		// An Up expectation with a (transiently) stopped instance must not
 		// be added to the stop/disable list — the start phase will bring it
 		// back, not normalise it away.
-		let api = exp("tamanu-central-api", Criticality::Critical);
+		let api = exp("tamanu-central-api", true);
 		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
 			&api,
 			vec![Instance {

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -288,14 +288,13 @@ fn pm2_start(names: &[String]) -> Result<()> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bestool_tamanu::services::{Criticality, Instances};
+	use bestool_tamanu::services::Instances;
 
 	fn exp(name: &'static str, behind_caddy: bool) -> Expectation {
 		Expectation {
 			name,
 			instances: Instances::Single,
 			state: ExpectedState::Up,
-			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy,
@@ -355,7 +354,6 @@ mod tests {
 			name,
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -4,7 +4,7 @@ use miette::{IntoDiagnostic, Result, bail};
 use serde::Serialize;
 
 use bestool_tamanu::services::{
-	self, Criticality, ExpectedState, Expectation, Supervisor, systemd_is_enabled,
+	self, ExpectedState, Expectation, Supervisor, systemd_is_enabled,
 };
 
 use crate::actions::{
@@ -87,12 +87,12 @@ struct Report {
 struct ExpectationReport {
 	name: &'static str,
 	expected_state: &'static str,
-	criticality: &'static str,
 	running: usize,
 	min_count: usize,
 	status: &'static str,
 	reason: String,
 	legacy: bool,
+	behind_caddy: bool,
 	instances: Vec<InstanceReport>,
 }
 
@@ -164,15 +164,12 @@ fn build_report(groups: &[(&Expectation, Vec<Instance>)]) -> Report {
 					ExpectedState::Up => "up",
 					ExpectedState::Down => "down",
 				},
-				criticality: match exp.criticality {
-					Criticality::Critical => "critical",
-					Criticality::Background => "background",
-				},
 				running,
 				min_count: exp.instances.min_count(),
 				status,
 				reason: exp.reason.clone(),
 				legacy: exp.legacy,
+				behind_caddy: exp.behind_caddy,
 				instances: instances
 					.iter()
 					.map(|i| InstanceReport {
@@ -288,11 +285,7 @@ fn header_cells(use_colours: bool) -> Vec<Cell> {
 }
 
 fn service_cell(exp: &Expectation) -> Cell {
-	let suffix = match (exp.state, exp.criticality) {
-		(ExpectedState::Up, Criticality::Critical) => " (critical)",
-		_ => "",
-	};
-	Cell::new(format!("{}{suffix}", exp.name))
+	Cell::new(exp.name)
 }
 
 fn expected_cell(exp: &Expectation) -> Cell {
@@ -403,14 +396,13 @@ fn reason_cell(reason: &str, use_colours: bool) -> Cell {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bestool_tamanu::services::{Criticality, Instances};
+	use bestool_tamanu::services::Instances;
 
 	fn down_exp() -> Expectation {
 		Expectation {
 			name: "tamanu-patientportal",
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,
@@ -422,7 +414,6 @@ mod tests {
 			name: "tamanu-frontend",
 			instances: Instances::Named(&["a", "b"]),
 			state: ExpectedState::Up,
-			criticality: Criticality::Critical,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,
@@ -470,7 +461,6 @@ mod tests {
 			name: "tamanu-central-tasks",
 			instances: Instances::Single,
 			state: ExpectedState::Up,
-			criticality: Criticality::Background,
 			reason: "always required".into(),
 			legacy: false,
 			behind_caddy: false,
@@ -489,7 +479,6 @@ mod tests {
 			name: "tamanu-facility",
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
 			behind_caddy: false,
@@ -498,7 +487,6 @@ mod tests {
 			name: "tamanu-patientportal",
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: Criticality::Background,
 			reason: "DB setting features.patientPortal is false".into(),
 			legacy: false,
 			behind_caddy: false,
@@ -519,7 +507,7 @@ mod tests {
 		assert!(any_short, "stopped+enabled Down expectation should bail");
 		let rendered = table.to_string();
 		assert!(rendered.contains("tamanu-central-tasks"));
-		assert!(rendered.contains("tamanu-frontend (critical)"));
+		assert!(rendered.contains("tamanu-frontend"));
 		assert!(rendered.contains("up \u{00d7}2"));
 		assert!(rendered.contains("tamanu-facility"));
 		assert!(rendered.contains("absent"));
@@ -559,7 +547,6 @@ mod tests {
 			name: "tamanu-facility",
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
 			behind_caddy: false,
@@ -582,7 +569,6 @@ mod tests {
 			name: "tamanu-facility",
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
 			behind_caddy: false,

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -413,6 +413,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 
@@ -424,6 +425,7 @@ mod tests {
 			criticality: Criticality::Critical,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 
@@ -471,6 +473,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "always required".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 
@@ -489,6 +492,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
+			behind_caddy: false,
 		};
 		let portal = Expectation {
 			name: "tamanu-patientportal",
@@ -497,6 +501,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "DB setting features.patientPortal is false".into(),
 			legacy: false,
+			behind_caddy: false,
 		};
 		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![
 			(&tasks, vec![inst("tamanu-central-tasks", None, true)]),
@@ -557,6 +562,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
+			behind_caddy: false,
 		};
 		let tasks = ok_up_exp();
 		let mut groups: Vec<(&Expectation, Vec<Instance>)> = vec![
@@ -579,6 +585,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
+			behind_caddy: false,
 		};
 		let mut groups: Vec<(&Expectation, Vec<Instance>)> =
 			vec![(&legacy, vec![inst("tamanu-facility", None, true)])];

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -338,6 +338,7 @@ fn evaluate(
 			"outcome": outcome_to_json(&outcome),
 			"reason": exp.reason,
 			"legacy": exp.legacy,
+			"behind_caddy": exp.behind_caddy,
 		}));
 
 		if !matches!(outcome, Outcome::Ok) {
@@ -647,6 +648,7 @@ mod tests {
 			criticality: crate::services::Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -645,7 +645,6 @@ mod tests {
 			name: "tamanu-patientportal",
 			instances: Instances::Single,
 			state: ExpectedState::Down,
-			criticality: crate::services::Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -49,6 +49,16 @@ pub struct Expectation {
 	/// that will always read OK. Non-compliant legacy rows still surface
 	/// (and fail the check) just like any other.
 	pub legacy: bool,
+	/// True for services Caddy reverse-proxies to by container hostname —
+	/// frontend, API, patient portal. Whenever one of these is started or
+	/// restarted its podman container gets a fresh netavark IP, but Caddy
+	/// and systemd-resolved still cache the previous one; without a reload
+	/// the next request hits a stale upstream. Lifecycle commands key off
+	/// this flag to decide when to call `lifecycle::reload_caddy` —
+	/// `Criticality::Critical` happens to currently mean the same thing,
+	/// but only because nothing background is behind Caddy *yet*; patient
+	/// portal is the first counterexample.
+	pub behind_caddy: bool,
 }
 
 /// Whether a service must keep at least one instance up at all times.
@@ -158,6 +168,7 @@ pub fn expected(
 		criticality: Criticality::Background,
 		reason: "always required".into(),
 		legacy: false,
+		behind_caddy: false,
 	});
 
 	if matches!(supervisor, Supervisor::Systemd) {
@@ -168,6 +179,7 @@ pub fn expected(
 			criticality: Criticality::Critical,
 			reason: "always required on systemd".into(),
 			legacy: false,
+			behind_caddy: true,
 		});
 		out.push(Expectation {
 			name: "tamanu-facility",
@@ -177,6 +189,7 @@ pub fn expected(
 			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
+			behind_caddy: false,
 		});
 	}
 
@@ -194,6 +207,7 @@ pub fn expected(
 		criticality: Criticality::Critical,
 		reason: "always required".into(),
 		legacy: false,
+		behind_caddy: true,
 	});
 
 	match kind {
@@ -222,6 +236,7 @@ pub fn expected(
 				criticality: Criticality::Background,
 				reason: fhir_reason.clone(),
 				legacy: false,
+				behind_caddy: false,
 			});
 			out.push(Expectation {
 				name: refresh,
@@ -230,6 +245,7 @@ pub fn expected(
 				criticality: Criticality::Background,
 				reason: fhir_reason,
 				legacy: false,
+				behind_caddy: false,
 			});
 
 			// The patient portal quadlet (`tamanu-patientportal.service`) is
@@ -252,6 +268,7 @@ pub fn expected(
 						"DB setting features.patientPortal is {patient_portal_enabled}"
 					),
 					legacy: false,
+					behind_caddy: true,
 				});
 			}
 		}
@@ -267,6 +284,7 @@ pub fn expected(
 				criticality: Criticality::Background,
 				reason: "kind is facility".into(),
 				legacy: false,
+				behind_caddy: false,
 			});
 		}
 	}
@@ -637,6 +655,7 @@ mod tests {
 			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
+			behind_caddy: false,
 		}
 	}
 

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -32,9 +32,6 @@ pub struct Expectation {
 	pub name: &'static str,
 	pub instances: Instances,
 	pub state: ExpectedState,
-	/// Availability constraint when restarting. Only meaningful for
-	/// `ExpectedState::Up` services.
-	pub criticality: Criticality,
 	/// Why this expectation has its current shape — surfaced in doctor
 	/// diagnostics so operators can see *why* a given service is expected up
 	/// or down. Examples: `"always required"`, `"kind is facility"`,
@@ -54,23 +51,19 @@ pub struct Expectation {
 	/// restarted its podman container gets a fresh netavark IP, but Caddy
 	/// and systemd-resolved still cache the previous one; without a reload
 	/// the next request hits a stale upstream. Lifecycle commands key off
-	/// this flag to decide when to call `lifecycle::reload_caddy` —
-	/// `Criticality::Critical` happens to currently mean the same thing,
-	/// but only because nothing background is behind Caddy *yet*; patient
-	/// portal is the first counterexample.
+	/// this flag to decide when to call `lifecycle::reload_caddy`.
 	pub behind_caddy: bool,
 }
 
-/// Whether a service must keep at least one instance up at all times.
-///
-/// Drives the restart strategy: `Critical` rolls one instance at a time
-/// with a readiness probe between each; `Background` restarts in bulk.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Criticality {
-	/// Must always have at least one instance up. API and frontend.
-	Critical,
-	/// No availability constraint. Tasks, sync, fhir-*.
-	Background,
+impl Expectation {
+	/// Whether `bestool tamanu restart` should roll this service one
+	/// instance at a time (with a readiness probe between each) instead of
+	/// bulk-restarting. The criterion is purely technical: rolling needs at
+	/// least two instances to keep one available during the roll. Single
+	/// instances bulk-restart regardless of how user-facing they are.
+	pub fn rolling_restart(&self) -> bool {
+		self.instances.min_count() >= 2
+	}
 }
 
 /// How the instances of a logical service are arranged.
@@ -165,7 +158,6 @@ pub fn expected(
 		name: tasks_name,
 		instances: Instances::Single,
 		state: ExpectedState::Up,
-		criticality: Criticality::Background,
 		reason: "always required".into(),
 		legacy: false,
 		behind_caddy: false,
@@ -176,7 +168,6 @@ pub fn expected(
 			name: "tamanu-frontend",
 			instances: Instances::Named(&["a", "b"]),
 			state: ExpectedState::Up,
-			criticality: Criticality::Critical,
 			reason: "always required on systemd".into(),
 			legacy: false,
 			behind_caddy: true,
@@ -186,7 +177,6 @@ pub fn expected(
 			instances: Instances::Single,
 			state: ExpectedState::Down,
 			// criticality is unused for Down; Background is the harmless default.
-			criticality: Criticality::Background,
 			reason: "legacy singleton unit must not be present".into(),
 			legacy: true,
 			behind_caddy: false,
@@ -204,7 +194,6 @@ pub fn expected(
 		name: api_name,
 		instances: Instances::NumericAtLeast(2),
 		state: ExpectedState::Up,
-		criticality: Criticality::Critical,
 		reason: "always required".into(),
 		legacy: false,
 		behind_caddy: true,
@@ -233,7 +222,6 @@ pub fn expected(
 				name: resolve,
 				instances: Instances::Single,
 				state: fhir_state,
-				criticality: Criticality::Background,
 				reason: fhir_reason.clone(),
 				legacy: false,
 				behind_caddy: false,
@@ -242,7 +230,6 @@ pub fn expected(
 				name: refresh,
 				instances: Instances::Single,
 				state: fhir_state,
-				criticality: Criticality::Background,
 				reason: fhir_reason,
 				legacy: false,
 				behind_caddy: false,
@@ -263,7 +250,6 @@ pub fn expected(
 					name: "tamanu-patientportal",
 					instances: Instances::Single,
 					state: portal_state,
-					criticality: Criticality::Background,
 					reason: format!(
 						"DB setting features.patientPortal is {patient_portal_enabled}"
 					),
@@ -281,7 +267,6 @@ pub fn expected(
 				name: sync_name,
 				instances: Instances::Single,
 				state: ExpectedState::Up,
-				criticality: Criticality::Background,
 				reason: "kind is facility".into(),
 				legacy: false,
 				behind_caddy: false,
@@ -583,57 +568,45 @@ mod tests {
 		assert!(!Instances::Single.admits_instance(Some("1")));
 	}
 
-	fn criticality_for(es: &[Expectation], name: &str) -> Criticality {
+	fn rolling_for(es: &[Expectation], name: &str) -> bool {
 		es.iter()
 			.find(|e| e.name == name)
 			.unwrap_or_else(|| panic!("no expectation named {name}"))
-			.criticality
+			.rolling_restart()
 	}
 
 	#[test]
-	fn api_and_frontend_are_critical() {
+	fn api_and_frontend_are_rolling_restartable() {
+		// Both run as templated/clustered units; rolling restart can keep
+		// one instance live while the other swaps.
 		let central = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
 			false,
 		);
-		assert_eq!(
-			criticality_for(&central, "tamanu-central-api"),
-			Criticality::Critical
-		);
-		assert_eq!(
-			criticality_for(&central, "tamanu-frontend"),
-			Criticality::Critical
-		);
+		assert!(rolling_for(&central, "tamanu-central-api"));
+		assert!(rolling_for(&central, "tamanu-frontend"));
 
 		let facility_pm2 = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false), false);
-		assert_eq!(
-			criticality_for(&facility_pm2, "tamanu-api"),
-			Criticality::Critical
-		);
+		assert!(rolling_for(&facility_pm2, "tamanu-api"));
 	}
 
 	#[test]
-	fn tasks_sync_fhir_are_background() {
+	fn singletons_bulk_restart() {
+		// Single-instance services bulk-restart: there's no second instance
+		// to take traffic during a roll. This includes patient-portal,
+		// which is single-but-behind-caddy.
 		let central = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(true),
-			false,
+			true,
 		);
-		assert_eq!(
-			criticality_for(&central, "tamanu-central-tasks"),
-			Criticality::Background
-		);
-		assert_eq!(
-			criticality_for(&central, "tamanu-central-fhir-resolve"),
-			Criticality::Background
-		);
-		assert_eq!(
-			criticality_for(&central, "tamanu-central-fhir-refresh"),
-			Criticality::Background
-		);
+		assert!(!rolling_for(&central, "tamanu-central-tasks"));
+		assert!(!rolling_for(&central, "tamanu-central-fhir-resolve"));
+		assert!(!rolling_for(&central, "tamanu-central-fhir-refresh"));
+		assert!(!rolling_for(&central, "tamanu-patientportal"));
 
 		let facility = expected(
 			Supervisor::Systemd,
@@ -641,10 +614,7 @@ mod tests {
 			&cfg(false),
 			false,
 		);
-		assert_eq!(
-			criticality_for(&facility, "tamanu-facility-sync"),
-			Criticality::Background
-		);
+		assert!(!rolling_for(&facility, "tamanu-facility-sync"));
 	}
 
 	fn exp(name: &'static str) -> Expectation {
@@ -652,7 +622,6 @@ mod tests {
 			name,
 			instances: Instances::Single,
 			state: ExpectedState::Up,
-			criticality: Criticality::Background,
 			reason: "test".into(),
 			legacy: false,
 			behind_caddy: false,


### PR DESCRIPTION
🤖 Four related changes (now that #404 + #405 have landed, branched directly on main).

## 1. Mark behind-caddy services; reload caddy after patient-portal restart

Adds a `behind_caddy: bool` field to `Expectation` and marks the services Caddy reverse-proxies to: `tamanu-frontend`, `tamanu-{kind}-api`, and `tamanu-patientportal` (plus `tamanu-api` on pm2).

Patient portal was the motivating case: it's single-instance (so not roll-restartable) but user-facing and behind Caddy, so when `tamanu restart` bulk-restarts it the container gets a new netavark IP and Caddy needs a reload to flush its stale upstream. Previously bulk restart never triggered caddy reload — only the rolling loop for `Critical` services did.

- `bestool tamanu restart` now reloads caddy once after the bulk restart if any bulk entry was behind_caddy. The rolling loop's per-instance reload is now gated on the instance's `behind_caddy` flag rather than its criticality.
- `bestool tamanu start` reloads caddy after the start phase if any started service was behind_caddy.
- The doctor's per-expectation payload carries `behind_caddy` alongside `legacy`.

## 2. Drop the `Criticality` enum; derive rolling-eligibility from `Instances`

`Criticality` carried a value judgement ("this service is availability-critical") that *happened* to coincide with a technical property ("it has enough instances to support a rolling restart with one always live"). Patient portal broke the coincidence — user-facing, kind-of-critical, but single-instance.

Drops the enum entirely and derives the rolling decision from `Expectation::rolling_restart()` = `Instances::min_count() >= 2`. Same behaviour on every current service (frontend, api roll; everything else bulk-restarts).

Renames `restart.rs`'s `Partitioned` fields from `background`/`critical` to `bulk`/`rolling` to track the technical criterion. Status drops the ` (critical)` suffix on service names and the `criticality` JSON field; the doctor's payload likewise drops it. `behind_caddy` is the remaining semantic hint.

## 3. Reload caddy on Windows too

Tamanu Windows deployments do run Caddy (at `C:\Caddy\Caddyfile`) but the previous `reload_caddy` hardcoded `systemctl reload caddy` and all callers gated on the systemd supervisor — so Windows silently skipped the reload, leaving Caddy with stale upstreams after a restart.

Split `reload_caddy` per platform:

- **Linux**: unchanged — still `systemctl reload caddy` followed by `resolvectl flush-caches`. We deliberately don't POST to the admin API here because production Caddyfiles are split across `/etc/caddy/conf.d/*` includes, and the safest way to pick up every fragment is to let caddy re-read from disk the same way it did at startup.
- **Windows**: tries the admin API first (`POST localhost:2019/load` with the Caddyfile content); falls back to `caddy reload --config <path> --adapter caddyfile` if the admin endpoint is locked down or unreachable.

Stays best-effort: failures only log. Removes the `matches!(supervisor, Supervisor::Systemd)` gates from all callers — `reload_caddy()` handles platform dispatch internally.

## 4. Replace `pm2 restart` with stop+1s+start

`pm2 restart` has been observed to occasionally leak the previous node process — it shows up as no longer owned by pm2 (and no longer in `pm2 list`) but still holding the TCP port, causing the freshly started replacement to either fail to bind or sit alongside the zombie.

Both the bulk pm2 path (`restart.rs::bulk_restart`) and the single-instance path (`lifecycle::restart_one`) now go through a shared `lifecycle::pm2_restart_targets` helper that does `pm2 stop … ; sleep 1s ; pm2 start …`, giving the old process time to exit and release its handles before pm2 hands them to the new one. Systemd path unaffected.
