### PR TITLE
feat(kopia): add bestool-kopia stub crate at 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bestool-kopia"
+version = "0.0.0"
+
+[[package]]
 name = "bestool-postgres"
 version = "1.0.10"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"crates/bestool",
 	"crates/canopy",
 	"crates/improv-wifi",
+	"crates/kopia",
 	"crates/postgres",
 	"crates/psql",
 	"crates/rpi-st7789v2-driver",

--- a/crates/kopia/Cargo.toml
+++ b/crates/kopia/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bestool-kopia"
+version = "0.0.0"
+edition = "2024"
+authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes.au>"]
+license = "GPL-3.0-or-later"
+description = "(Internal) BES tooling: shared library for interacting with the kopia CLI"
+repository = "https://github.com/beyondessential/bestool/tree/main/crates/kopia"
+exclude.workspace = true
+
+[lints]
+workspace = true

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -1,0 +1,1 @@
+//! Placeholder crate. Real content lands in the next release.


### PR DESCRIPTION
🤖 Adds an empty `bestool-kopia` crate at version `0.0.0` so the name can be reserved on crates.io and trusted publishing set up before the real content ships.

The real content arrives in the follow-up PR (#397) which bumps to `0.1.0` and fills the crate with the shared kopia infrastructure used by the doctor check and the `bestool kopia` subcommand suite.

Suggested merge order:
1. Merge this PR.
2. Manually publish `bestool-kopia 0.0.0` to crates.io.
3. Set up trusted publishing on crates.io for the crate.
4. Merge #397 (and the rest of the stack on top).
