### PR TITLE
fix(tamanu): logs caddy alone no longer tails every service

### DIFF
--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -99,6 +99,11 @@ pub struct LogsArgs {
 struct Selection {
 	tamanu_names: Vec<String>,
 	include_caddy: bool,
+	/// Set when the user passed no NAMES at all. Tails every expected-Up
+	/// tamanu service. Distinct from `tamanu_names.is_empty()`, which is also
+	/// true when the user passed only `caddy` — in that case we must NOT
+	/// auto-include every tamanu service.
+	all_tamanu: bool,
 }
 
 fn select(names: &[String]) -> Selection {
@@ -106,6 +111,7 @@ fn select(names: &[String]) -> Selection {
 		return Selection {
 			tamanu_names: Vec::new(),
 			include_caddy: true,
+			all_tamanu: true,
 		};
 	}
 	let mut tamanu_names = Vec::new();
@@ -120,6 +126,7 @@ fn select(names: &[String]) -> Selection {
 	Selection {
 		tamanu_names,
 		include_caddy,
+		all_tamanu: false,
 	}
 }
 
@@ -172,22 +179,30 @@ pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
 		.collect();
 
 	// We use the same matcher as the lifecycle commands but only consider
-	// expected-Up services as candidates for the NAMES filter.
-	let tamanu_name_refs: Vec<&str> = selection
-		.tamanu_names
-		.iter()
-		.map(String::as_str)
-		.collect();
-	let matches: Vec<&Expectation> = {
+	// expected-Up services as candidates for the NAMES filter. When the user
+	// passed no NAMES we tail every up service; when they passed only `caddy`
+	// we tail no tamanu services at all (just caddy below).
+	let matches: Vec<&Expectation> = if selection.all_tamanu {
+		up_expectations.clone()
+	} else if selection.tamanu_names.is_empty() {
+		Vec::new()
+	} else {
+		let tamanu_name_refs: Vec<&str> = selection
+			.tamanu_names
+			.iter()
+			.map(String::as_str)
+			.collect();
 		let up_owned: Vec<Expectation> = up_expectations.iter().map(|e| (*e).clone()).collect();
 		let m = services::match_names(&up_owned, &tamanu_name_refs)?;
-		m.iter().map(|e| {
-			up_expectations
-				.iter()
-				.copied()
-				.find(|x| x.name == e.name)
-				.expect("match came from up_expectations")
-		}).collect()
+		m.iter()
+			.map(|e| {
+				up_expectations
+					.iter()
+					.copied()
+					.find(|x| x.name == e.name)
+					.expect("match came from up_expectations")
+			})
+			.collect()
 	};
 
 	debug!(
@@ -667,16 +682,20 @@ mod tests {
 	}
 
 	#[test]
-	fn select_empty_includes_caddy_and_no_tamanu_filter() {
+	fn select_empty_includes_caddy_and_all_tamanu() {
 		let s = select(&[]);
 		assert!(s.include_caddy);
+		assert!(s.all_tamanu);
 		assert!(s.tamanu_names.is_empty());
 	}
 
 	#[test]
-	fn select_caddy_alone() {
+	fn select_caddy_alone_does_not_imply_all_tamanu() {
+		// Regression: `bestool tamanu logs caddy` used to tail every service
+		// because empty `tamanu_names` was conflated with "no filter at all".
 		let s = select(&["caddy".to_string()]);
 		assert!(s.include_caddy);
+		assert!(!s.all_tamanu);
 		assert!(s.tamanu_names.is_empty());
 	}
 
@@ -684,6 +703,7 @@ mod tests {
 	fn select_caddy_with_others() {
 		let s = select(&["caddy".to_string(), "api".to_string()]);
 		assert!(s.include_caddy);
+		assert!(!s.all_tamanu);
 		assert_eq!(s.tamanu_names, vec!["api".to_string()]);
 	}
 
@@ -691,6 +711,7 @@ mod tests {
 	fn select_without_caddy_excludes_it() {
 		let s = select(&["api".to_string(), "tasks".to_string()]);
 		assert!(!s.include_caddy);
+		assert!(!s.all_tamanu);
 		assert_eq!(s.tamanu_names, vec!["api".to_string(), "tasks".to_string()]);
 	}
 


### PR DESCRIPTION
🤖 `bestool tamanu logs caddy` was tailing every tamanu service in addition to caddy, instead of just caddy.

## Root cause

In `crates/bestool/src/actions/tamanu/logs.rs`, `select(["caddy"])` produced `tamanu_names = []` with `include_caddy = true`. The downstream call `services::match_names(&up_expectations, &[])` treats an empty patterns slice as "no filter" and returns every expectation — so journalctl was invoked with `-u` for every up tamanu unit plus `caddy.service`.

The bug was a conflation in `Selection`: "user passed no NAMES at all" and "user passed only `caddy`" both ended up with empty `tamanu_names`, but they should behave differently.

## Fix

Added an `all_tamanu` flag on `Selection`, set only when zero NAMES were passed. `run` now distinguishes three cases:

- no NAMES → tail all up tamanu services + caddy (unchanged)
- only `caddy` → tail only caddy
- explicit tamanu names → match via `match_names` as before

New regression test `select_caddy_alone_does_not_imply_all_tamanu` locks this in. The existing `select_*` tests were updated to assert the new field.

## Scope

This bug is exclusive to `logs.rs`. The lifecycle commands (`start`, `stop`, `restart`, `status`) call `match_names` directly with `args.names` and have no `caddy` pseudo-service — passing `caddy` to them errors out via the typo-safety branch because no tamanu service name contains the substring "caddy".
