### PR TITLE
feat(tamanu): detect instanced patient portal layout

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -18,7 +18,7 @@ use bestool_tamanu::{
 	config::load_config,
 	pm2,
 	server_info::query_patient_portal_enabled,
-	services::{self, Expectation, Supervisor, parse_systemd_unit},
+	services::{self, Expectation, Supervisor, parse_systemd_unit, systemd_patient_portal_instanced},
 };
 
 use super::{TamanuArgs, find_tamanu};
@@ -74,7 +74,17 @@ pub async fn config_and_expectations(
 			false
 		};
 
-	let expectations = services::expected(supervisor, kind, &config, patient_portal_enabled);
+	let patient_portal_instanced = matches!(supervisor, Supervisor::Systemd)
+		&& matches!(kind, ApiServerKind::Central)
+		&& systemd_patient_portal_instanced();
+
+	let expectations = services::expected(
+		supervisor,
+		kind,
+		&config,
+		patient_portal_enabled,
+		patient_portal_instanced,
+	);
 	Ok((supervisor, expectations))
 }
 

--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -172,7 +172,16 @@ pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
 			false
 		};
 
-	let all_expectations = services::expected(supervisor, kind, &config, patient_portal_enabled);
+	let patient_portal_instanced = matches!(supervisor, Supervisor::Systemd)
+		&& matches!(kind, ApiServerKind::Central)
+		&& services::systemd_patient_portal_instanced();
+	let all_expectations = services::expected(
+		supervisor,
+		kind,
+		&config,
+		patient_portal_enabled,
+		patient_portal_instanced,
+	);
 	let up_expectations: Vec<&Expectation> = all_expectations
 		.iter()
 		.filter(|e| e.state == ExpectedState::Up)
@@ -940,7 +949,13 @@ mod tests {
 
 	#[test]
 	fn journalctl_pattern_handles_each_instance_kind() {
-		let exps = services::expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg(true, false), false);
+		let exps = services::expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg(true, false),
+			false,
+			false,
+		);
 		let tasks = exps.iter().find(|e| e.name == "tamanu-facility-tasks").unwrap();
 		assert_eq!(journalctl_pattern(tasks), "tamanu-facility-tasks.service");
 

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -78,11 +78,12 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 		bulk_restart(supervisor, &bulk)?;
 		lifecycle::wait_running(supervisor, &bulk)?;
 		// One reload after the bulk covers every behind-caddy service in
-		// the batch (currently just patient-portal). Per-service rolling
-		// reloads aren't needed here because singleton services don't have
-		// a "keep one up" availability constraint — the bulk restart
-		// already drops them all briefly, so a single trailing reload is
-		// enough to flush Caddy's stale upstream IPs.
+		// the batch — relevant for older deployments whose patient-portal
+		// is a singleton (the frontend always rolls, and on newer
+		// deployments the patient-portal does too). Per-service rolling
+		// reloads aren't needed for singletons: bulk-restart already
+		// drops them all briefly, so a single trailing reload is enough
+		// to flush Caddy's stale upstream IPs.
 		if bulk_behind_caddy {
 			lifecycle::reload_caddy().await;
 		}
@@ -142,16 +143,16 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 ///
 /// "Rolling-eligible" comes from [`Expectation::rolling_restart`]:
 /// `min_count >= 2`, i.e. the expectation has enough instances that
-/// rolling can keep one available while the next swaps. Singletons (even
-/// behind-caddy ones like patient-portal) bulk-restart because there's no
-/// second instance to take traffic during the roll.
+/// rolling can keep one available while the next swaps. Singletons bulk-
+/// restart because there's no second instance to take traffic during the
+/// roll.
 struct Partitioned {
 	/// Supervisor-native identifiers to bulk-restart.
 	bulk: Vec<String>,
 	/// True if any bulk entry's expectation has `behind_caddy: true` —
 	/// drives a single trailing `reload_caddy` after the bulk completes so
-	/// Caddy sees the new container IPs (currently relevant for
-	/// patient-portal).
+	/// Caddy sees the new container IPs (relevant on older deployments
+	/// where the patient-portal is still a singleton).
 	bulk_behind_caddy: bool,
 	/// Instances to roll one-at-a-time, paired with their expectation's
 	/// `behind_caddy` flag so each iteration knows whether to reload Caddy
@@ -330,10 +331,29 @@ mod tests {
 	}
 
 	#[test]
-	fn partition_flags_bulk_behind_caddy_when_portal_runs() {
-		// Patient portal is single-instance (so bulk-restartable) but behind
-		// Caddy — a bulk restart must still trigger a Caddy reload at the
-		// end so Caddy picks up the new container IP.
+	fn partition_rolls_patient_portal_a_b() {
+		// Patient portal is multi-instance (@a/@b) and behind Caddy — like
+		// the frontend, it should roll one instance at a time so there's
+		// always one up to take traffic.
+		let portal = up_exp("tamanu-patientportal", Instances::Named(&["a", "b"]), true);
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&portal,
+			vec![
+				inst("tamanu-patientportal", Some("a"), true),
+				inst("tamanu-patientportal", Some("b"), true),
+			],
+		)];
+		let p = partition(Supervisor::Systemd, &groups);
+		assert!(p.bulk.is_empty());
+		assert_eq!(p.rolling.len(), 2);
+		assert!(p.rolling.iter().all(|(_, behind_caddy)| *behind_caddy));
+	}
+
+	#[test]
+	fn partition_flags_bulk_behind_caddy_when_singleton_portal_runs() {
+		// Older deployments still run patient-portal as a singleton, so a
+		// bulk restart must trigger a Caddy reload at the end to flush
+		// the stale container IP.
 		let portal = up_exp("tamanu-patientportal", Instances::Single, true);
 		let tasks = up_exp("tamanu-central-tasks", Instances::Single, false);
 		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![
@@ -378,10 +398,10 @@ mod tests {
 	}
 
 	#[test]
-	fn partition_singleton_behind_caddy_is_bulk_not_rolling() {
-		// Patient portal: single-instance, behind caddy. The user-facing
-		// "kind of critical" case — should bulk-restart (only one
-		// instance), but still trigger caddy reload.
+	fn partition_singleton_portal_is_bulk_not_rolling() {
+		// Singleton patient-portal (older deployments): rolling needs ≥2
+		// instances to keep one up while the other swaps, so a singleton
+		// bulk-restarts but still triggers a caddy reload.
 		let portal = up_exp("tamanu-patientportal", Instances::Single, true);
 		let groups: Vec<(&Expectation, Vec<Instance>)> =
 			vec![(&portal, vec![inst("tamanu-patientportal", None, true)])];

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -554,7 +554,7 @@ mod tests {
 	fn down_exp() -> Expectation {
 		Expectation {
 			name: "tamanu-patientportal",
-			instances: Instances::Single,
+			instances: Instances::Named(&["a", "b"]),
 			state: ExpectedState::Down,
 			reason: "test".into(),
 			legacy: false,
@@ -609,12 +609,17 @@ mod tests {
 	#[test]
 	fn drop_disabled_down_removes_stopped_and_disabled() {
 		let exp = down_exp();
-		let mut groups: Vec<(&Expectation, Vec<Instance>)> =
-			vec![(&exp, vec![inst("tamanu-patientportal", None, false)])];
+		let mut groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&exp,
+			vec![
+				inst("tamanu-patientportal", Some("a"), false),
+				inst("tamanu-patientportal", Some("b"), false),
+			],
+		)];
 		drop_disabled_down(&mut groups, |_| false);
 		assert!(
 			groups[0].1.is_empty(),
-			"stopped+disabled Down unit should be dropped",
+			"stopped+disabled Down units should all be dropped",
 		);
 		let report = build_report(&groups, &empty_probe());
 		assert!(!report.any_short, "should be ABSENT/OK now");
@@ -624,10 +629,15 @@ mod tests {
 	#[test]
 	fn drop_disabled_down_keeps_stopped_but_enabled() {
 		let exp = down_exp();
-		let mut groups: Vec<(&Expectation, Vec<Instance>)> =
-			vec![(&exp, vec![inst("tamanu-patientportal", None, false)])];
+		let mut groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&exp,
+			vec![
+				inst("tamanu-patientportal", Some("a"), false),
+				inst("tamanu-patientportal", Some("b"), false),
+			],
+		)];
 		drop_disabled_down(&mut groups, |_| true);
-		assert_eq!(groups[0].1.len(), 1);
+		assert_eq!(groups[0].1.len(), 2);
 		let report = build_report(&groups, &empty_probe());
 		assert!(report.any_short, "stopped+enabled is still FORBIDDEN");
 		assert_eq!(report.expectations[0].status, "forbidden");
@@ -662,7 +672,7 @@ mod tests {
 		};
 		let portal = Expectation {
 			name: "tamanu-patientportal",
-			instances: Instances::Single,
+			instances: Instances::Named(&["a", "b"]),
 			state: ExpectedState::Down,
 			reason: "DB setting features.patientPortal is false".into(),
 			legacy: false,
@@ -678,7 +688,13 @@ mod tests {
 				],
 			),
 			(&absent_down, vec![]),
-			(&portal, vec![inst("tamanu-patientportal", None, false)]),
+			(
+				&portal,
+				vec![
+					inst("tamanu-patientportal", Some("a"), false),
+					inst("tamanu-patientportal", Some("b"), false),
+				],
+			),
 		];
 		let (table, any_short) = render_table(&groups, &empty_probe(), false);
 		assert!(any_short, "stopped+enabled Down expectation should bail");

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -8,7 +8,7 @@ use crate::{
 	pm2,
 	services::{
 		Expectation, ExpectedState, Instances, Supervisor, expected, parse_systemd_unit,
-		systemd_is_enabled,
+		systemd_is_enabled, systemd_patient_portal_instanced,
 	},
 };
 
@@ -29,8 +29,16 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Some(client) => crate::server_info::query_patient_portal_enabled(client).await,
 		None => false,
 	};
+	let patient_portal_instanced =
+		matches!(supervisor, Supervisor::Systemd) && systemd_patient_portal_instanced();
 
-	let expectations = expected(supervisor, ctx.kind, &ctx.config, patient_portal_enabled);
+	let expectations = expected(
+		supervisor,
+		ctx.kind,
+		&ctx.config,
+		patient_portal_enabled,
+		patient_portal_instanced,
+	);
 
 	let mut pm2_source: Option<pm2::Source> = None;
 	let mut discovered = match supervisor {
@@ -534,7 +542,13 @@ mod tests {
 	#[test]
 	fn happy_facility_systemd() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -550,7 +564,13 @@ mod tests {
 	#[test]
 	fn fails_when_tasks_missing() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-frontend", Some("a"), true),
 			d("tamanu-frontend", Some("b"), true),
@@ -571,7 +591,13 @@ mod tests {
 	#[test]
 	fn fails_on_api_shortfall() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -591,7 +617,13 @@ mod tests {
 	#[test]
 	fn fails_on_frontend_named_missing() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -615,7 +647,13 @@ mod tests {
 	#[test]
 	fn fails_when_forbidden_facility_singleton_present() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -711,7 +749,13 @@ mod tests {
 	#[test]
 	fn extras_recorded_but_dont_fail() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let mut discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -738,7 +782,13 @@ mod tests {
 	#[test]
 	fn central_with_fhir_requires_workers() {
 		let cfg = central_cfg(true);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-central-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -769,7 +819,13 @@ mod tests {
 		// expects `tamanu-patientportal` Down — i.e. absent from `discovered`
 		// is the pass case.
 		let cfg = central_cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-central-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -784,7 +840,7 @@ mod tests {
 	#[test]
 	fn pm2_facility_happy() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg, false, false);
 		let discovered = vec![
 			Discovered {
 				name: "tamanu-tasks".into(),
@@ -879,7 +935,13 @@ mod tests {
 	#[test]
 	fn not_running_listed_as_diagnosis() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, false), // not running
 			d("tamanu-frontend", Some("a"), true),
@@ -909,7 +971,13 @@ mod tests {
 		// false), got up (tamanu-patientportal.service)" rather than parsing
 		// expectations + services arrays.
 		let cfg = central_cfg(true);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Central, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-central-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -952,7 +1020,13 @@ mod tests {
 		// raw inventory is still in the top-level payload under `services`
 		// for anyone who wants to audit what was checked.
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),
@@ -980,7 +1054,13 @@ mod tests {
 		// `payload_extras["services"]`, not under per-check `details`. Keeps
 		// the `health[]` entry focused on human-readable diagnostics.
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Systemd, ApiServerKind::Facility, &cfg, false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Facility,
+			&cfg,
+			false,
+			false,
+		);
 		let discovered = vec![
 			d("tamanu-facility-tasks", None, true),
 			d("tamanu-frontend", Some("a"), true),

--- a/crates/tamanu/src/doctor/checks/version_drift.rs
+++ b/crates/tamanu/src/doctor/checks/version_drift.rs
@@ -10,7 +10,7 @@ use serde_json::{Value, json};
 use super::CheckContext;
 use crate::{
 	doctor::check::Check,
-	services::{Supervisor, expected, parse_systemd_unit},
+	services::{Supervisor, expected, parse_systemd_unit, systemd_patient_portal_instanced},
 	versions,
 };
 
@@ -52,7 +52,15 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Some(client) => crate::server_info::query_patient_portal_enabled(client).await,
 		None => false,
 	};
-	let expectations = expected(supervisor, ctx.kind, &ctx.config, patient_portal_enabled);
+	let patient_portal_instanced =
+		matches!(supervisor, Supervisor::Systemd) && systemd_patient_portal_instanced();
+	let expectations = expected(
+		supervisor,
+		ctx.kind,
+		&ctx.config,
+		patient_portal_enabled,
+		patient_portal_instanced,
+	);
 
 	let mut rows: Vec<Value> = Vec::new();
 	let mut drifted: Vec<String> = Vec::new();

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -13,6 +13,11 @@
 //!   exposed as template suffixes `@1`, `@2`, … Exceptions:
 //!   - `frontend` lives at `tamanu-frontend` (no kind prefix) with named
 //!     instances `@a` and `@b`.
+//!   - `patientportal` lives at `tamanu-patientportal` (no kind prefix). On
+//!     older deployments it's a singleton; newer ones (and rolling forward)
+//!     use a frontend-style template with `@a` and `@b` instances. Which
+//!     layout is installed is detected at runtime by
+//!     [`systemd_patient_portal_instanced`].
 //!   - `tamanu-facility` is a literal singleton unit (no kind prefix, no
 //!     `${thing}` segment) that's a leftover from older deployments and must
 //!     not be active or enabled on current ones.
@@ -139,11 +144,19 @@ impl Instances {
 /// because Tamanu's central-server code reads the setting (not the unused
 /// `patientPortal.portalUrl` config field) to decide whether to mount the
 /// portal API.
+///
+/// `patient_portal_instanced` decides the patient portal's unit shape: when
+/// true, expect a frontend-style `Named(["a", "b"])` template; when false,
+/// expect the historical singleton. Callers should source this from
+/// [`systemd_patient_portal_instanced`] on systemd hosts and pass `false`
+/// otherwise (the singleton default has no false-positive impact when the
+/// expectation is Down anyway).
 pub fn expected(
 	supervisor: Supervisor,
 	kind: ApiServerKind,
 	config: &TamanuConfig,
 	patient_portal_enabled: bool,
+	patient_portal_instanced: bool,
 ) -> Vec<Expectation> {
 	let mut out = Vec::new();
 
@@ -235,20 +248,28 @@ pub fn expected(
 				behind_caddy: false,
 			});
 
-			// The patient portal quadlet (`tamanu-patientportal.service`) is
-			// expected Up iff the Tamanu DB setting `features.patientPortal`
-			// is true. If the flag is on but the container isn't running,
-			// that's an ops misalignment worth flagging — exactly the case
-			// the doctor exists to catch.
+			// Patient portal layout depends on what the host actually
+			// ships. The frontend-style A/B template (new + rolling
+			// forward) lets rolling restart keep one instance up while
+			// the other swaps; older deployments still ship a singleton
+			// and bulk-restart. Expected Up iff the Tamanu DB setting
+			// `features.patientPortal` is true — if the flag is on but
+			// nothing's running, that's an ops misalignment worth
+			// flagging.
 			if matches!(supervisor, Supervisor::Systemd) {
 				let portal_state = if patient_portal_enabled {
 					ExpectedState::Up
 				} else {
 					ExpectedState::Down
 				};
+				let portal_instances = if patient_portal_instanced {
+					Instances::Named(&["a", "b"])
+				} else {
+					Instances::Single
+				};
 				out.push(Expectation {
 					name: "tamanu-patientportal",
-					instances: Instances::Single,
+					instances: portal_instances,
 					state: portal_state,
 					reason: format!(
 						"DB setting features.patientPortal is {patient_portal_enabled}"
@@ -316,6 +337,34 @@ pub fn match_names<'a>(
 	Ok(matched)
 }
 
+/// Whether the patient portal is deployed as a templated multi-instance unit
+/// (`tamanu-patientportal@.service`). Older deployments still ship the
+/// singleton `tamanu-patientportal.service`; we detect which is installed by
+/// asking systemd for the template's unit file.
+///
+/// Returns `false` on any systemctl error, on hosts where the template isn't
+/// installed, or on non-Linux systems — callers map `false` to the singleton
+/// layout, which is the historical default and a safe fallback when the
+/// expectation is Down anyway.
+pub fn systemd_patient_portal_instanced() -> bool {
+	let output = std::process::Command::new("systemctl")
+		.args([
+			"list-unit-files",
+			"--no-legend",
+			"--no-pager",
+			"tamanu-patientportal@.service",
+		])
+		.output();
+	let Ok(o) = output else { return false };
+	if !o.status.success() {
+		return false;
+	}
+	let stdout = String::from_utf8_lossy(&o.stdout);
+	stdout
+		.lines()
+		.any(|l| l.trim_start().starts_with("tamanu-patientportal@.service"))
+}
+
 /// Ask systemd whether a unit is enabled (will auto-start at boot).
 ///
 /// Returns `true` only for `enabled` / `enabled-runtime`. Treats
@@ -367,7 +416,13 @@ mod tests {
 
 	#[test]
 	fn facility_pm2_no_fhir() {
-		let es = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false), false);
+		let es = expected(
+			Supervisor::Pm2,
+			ApiServerKind::Facility,
+			&cfg(false),
+			false,
+			false,
+		);
 		assert_eq!(
 			names(&es),
 			vec!["tamanu-tasks", "tamanu-api", "tamanu-sync"]
@@ -382,7 +437,13 @@ mod tests {
 		// alert if the corresponding services are still running — that's
 		// usually a deploy that's flipped the toggle without taking the
 		// units down. So the expectations exist, but with state Down.
-		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(false), false);
+		let es = expected(
+			Supervisor::Pm2,
+			ApiServerKind::Central,
+			&cfg(false),
+			false,
+			false,
+		);
 		assert_eq!(
 			names(&es),
 			vec![
@@ -404,7 +465,13 @@ mod tests {
 
 	#[test]
 	fn central_pm2_with_fhir_adds_resolve_and_refresh() {
-		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(true), false);
+		let es = expected(
+			Supervisor::Pm2,
+			ApiServerKind::Central,
+			&cfg(true),
+			false,
+			false,
+		);
 		assert_eq!(
 			names(&es),
 			vec![
@@ -422,6 +489,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
+			false,
 			false,
 		);
 		assert_eq!(
@@ -448,6 +516,7 @@ mod tests {
 			ApiServerKind::Central,
 			&cfg(true),
 			true,
+			true,
 		);
 		assert_eq!(
 			names(&es),
@@ -464,14 +533,34 @@ mod tests {
 	}
 
 	#[test]
-	fn central_systemd_expects_patient_portal_up_when_db_flag_on() {
-		// `features.patientPortal = true` in the central DB means Tamanu has
-		// mounted the portal API; the doctor expects the matching unit running.
+	fn central_systemd_expects_patient_portal_instanced_when_template_installed() {
+		// `features.patientPortal = true` + the templated unit file is
+		// installed → expect a frontend-style A/B template.
 		let es = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
 			true,
+			true,
+		);
+		let pp = es
+			.iter()
+			.find(|e| e.name == "tamanu-patientportal")
+			.expect("patient portal expectation should be present");
+		assert_eq!(pp.state, ExpectedState::Up);
+		assert_eq!(pp.instances, Instances::Named(&["a", "b"]));
+	}
+
+	#[test]
+	fn central_systemd_expects_patient_portal_singleton_on_older_deployments() {
+		// `features.patientPortal = true` but the templated unit file isn't
+		// installed → fall back to the historical singleton layout.
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			true,
+			false,
 		);
 		let pp = es
 			.iter()
@@ -485,11 +574,13 @@ mod tests {
 	fn central_systemd_expects_patient_portal_down_when_db_flag_off() {
 		// `features.patientPortal = false` → Tamanu's portal API is unmounted.
 		// If the container's still running we want to know (stale install),
-		// so the expectation stays in the list but with state Down.
+		// so the expectation stays in the list but with state Down. The
+		// detected layout still drives which units we check for absence.
 		let es = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
+			false,
 			false,
 		);
 		let pp = es
@@ -506,6 +597,7 @@ mod tests {
 			ApiServerKind::Facility,
 			&cfg(false),
 			true,
+			true,
 		);
 		assert!(es.iter().all(|e| e.name != "tamanu-patientportal"));
 	}
@@ -515,7 +607,13 @@ mod tests {
 		// pm2 is Windows-only; tamanu-patientportal is a systemd-managed unit
 		// in our Linux deployments, so the pm2 expectation list shouldn't
 		// include it regardless of the DB flag.
-		let es = expected(Supervisor::Pm2, ApiServerKind::Central, &cfg(true), true);
+		let es = expected(
+			Supervisor::Pm2,
+			ApiServerKind::Central,
+			&cfg(true),
+			true,
+			true,
+		);
 		assert!(es.iter().all(|e| e.name != "tamanu-patientportal"));
 	}
 
@@ -525,6 +623,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
+			false,
 			false,
 		);
 		let fe = es.iter().find(|e| e.name == "tamanu-frontend").unwrap();
@@ -538,6 +637,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
+			false,
 			false,
 		);
 		let api = es.iter().find(|e| e.name == "tamanu-facility-api").unwrap();
@@ -584,34 +684,69 @@ mod tests {
 			ApiServerKind::Central,
 			&cfg(false),
 			false,
+			false,
 		);
 		assert!(rolling_for(&central, "tamanu-central-api"));
 		assert!(rolling_for(&central, "tamanu-frontend"));
 
-		let facility_pm2 = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg(false), false);
+		let facility_pm2 = expected(
+			Supervisor::Pm2,
+			ApiServerKind::Facility,
+			&cfg(false),
+			false,
+			false,
+		);
 		assert!(rolling_for(&facility_pm2, "tamanu-api"));
+	}
+
+	#[test]
+	fn instanced_patient_portal_is_rolling_restartable() {
+		// When the A/B template is installed the portal has two instances,
+		// so rolling restart can keep one up while the other swaps.
+		let central = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			true,
+			true,
+		);
+		assert!(rolling_for(&central, "tamanu-patientportal"));
+	}
+
+	#[test]
+	fn singleton_patient_portal_bulk_restarts() {
+		// Older deployments still ship the singleton; with only one instance
+		// rolling can't keep traffic up, so we bulk-restart.
+		let central = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			true,
+			false,
+		);
+		assert!(!rolling_for(&central, "tamanu-patientportal"));
 	}
 
 	#[test]
 	fn singletons_bulk_restart() {
 		// Single-instance services bulk-restart: there's no second instance
-		// to take traffic during a roll. This includes patient-portal,
-		// which is single-but-behind-caddy.
+		// to take traffic during a roll.
 		let central = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(true),
 			true,
+			true,
 		);
 		assert!(!rolling_for(&central, "tamanu-central-tasks"));
 		assert!(!rolling_for(&central, "tamanu-central-fhir-resolve"));
 		assert!(!rolling_for(&central, "tamanu-central-fhir-refresh"));
-		assert!(!rolling_for(&central, "tamanu-patientportal"));
 
 		let facility = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
+			false,
 			false,
 		);
 		assert!(!rolling_for(&facility, "tamanu-facility-sync"));


### PR DESCRIPTION
🤖 Some newer Linux deployments now ship the patient-portal service as a frontend-style A/B template (`tamanu-patientportal@a.service`, `tamanu-patientportal@b.service`) rather than the historical singleton. This change detects which layout is installed and adjusts expectations, start, and rolling-restart accordingly; older singleton deployments keep working unchanged.

## Summary

- `services::expected()` takes a new `patient_portal_instanced` flag and emits `Named(["a", "b"])` or `Single` for the portal.
- New `services::systemd_patient_portal_instanced()` probes `systemctl list-unit-files tamanu-patientportal@.service` and returns `false` on any error or non-systemd host (the safe singleton fallback).
- Detection is called from `lifecycle::config_and_expectations`, `logs`, `doctor::tamanu_service`, and `doctor::version_drift`.
- `tamanu start` enumerates `@a`/`@b` units, `tamanu restart` rolls them with per-instance Caddy reloads, and the doctor checks the right unit shape — all via the existing `Instances` plumbing.
- Tests cover both layouts (singleton bulk-restart, instanced rolling-restart, expectation shape under each flag combination).
