### PR TITLE
fix(tamanu/doctor): resolve server_id from file when DB is unreachable

### DIFF
--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -592,15 +592,15 @@ pub(super) async fn perform_sweep(
 	completed.sort_by_key(|(idx, _, _)| *idx);
 	let results: Vec<(Check, bool)> = completed.into_iter().map(|(_, c, w)| (c, w)).collect();
 
-	let server_id = match db.as_deref() {
-		Some(client) => match get_or_create_server_id(client).await {
-			Ok(id) => Some(id),
-			Err(err) => {
-				warn!("could not resolve metaServerId: {err}");
-				None
-			}
-		},
-		None => None,
+	// Resolve via the file path first so a doctor sweep can still report to
+	// canopy when the DB is down — that's exactly the moment canopy most
+	// needs to hear from us.
+	let server_id = match get_or_create_server_id(db.as_deref()).await {
+		Ok(id) => Some(id),
+		Err(err) => {
+			warn!("could not resolve metaServerId: {err}");
+			None
+		}
 	};
 
 	let facts = collect_server_facts(&config, db.as_deref(), cached_pg_version).await;

--- a/crates/bestool/src/actions/tamanu/meta_ticket.rs
+++ b/crates/bestool/src/actions/tamanu/meta_ticket.rs
@@ -58,7 +58,7 @@ pub async fn run(_args: MetaTicketArgs, ctx: Context) -> Result<()> {
 
 	let public_key_pem = derive_public_key_pem(&device_key_pem)?;
 
-	let server_id = get_or_create_server_id(&client).await?;
+	let server_id = get_or_create_server_id(Some(&client)).await?;
 
 	let (tailscale_ip, tailscale_name) = get_tailscale_info();
 	let hosting = detect_hosting();

--- a/crates/tamanu/src/doctor/checks/server_id.rs
+++ b/crates/tamanu/src/doctor/checks/server_id.rs
@@ -2,11 +2,10 @@ use super::CheckContext;
 use crate::{doctor::check::Check, server_info::get_or_create_server_id};
 
 pub async fn run(ctx: CheckContext) -> Check {
-	let Some(client) = ctx.db.as_deref() else {
-		return Check::fail("server_id", "no DB connection", "db_connect failed");
-	};
-
-	match get_or_create_server_id(client).await {
+	// Pass the DB through optionally: an already-provisioned host has the id
+	// cached at the standard file path and can answer without a DB, which is
+	// what lets the canopy push keep working when postgres is down.
+	match get_or_create_server_id(ctx.db.as_deref()).await {
 		Ok(id) => {
 			Check::pass("server_id", format!("metaServerId: {id}")).with_detail("server_id", id)
 		}

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -63,21 +63,44 @@ pub fn standard_tags_path() -> PathBuf {
 /// Resolve the `metaServerId` for this Tamanu server.
 ///
 /// Resolution order:
-/// 1. Read [`standard_server_id_path`] if present.
-/// 2. Read the legacy `local_system_facts.metaServerId` row; best-effort copy
-///    to the file path so subsequent runs don't need the DB.
-/// 3. Generate a fresh UUIDv4. Persist to the file path; if the file write
-///    fails, fall back to inserting into `local_system_facts` so the new ID
-///    isn't lost across runs.
-pub async fn get_or_create_server_id(client: &tokio_postgres::Client) -> Result<String> {
-	let path = standard_server_id_path();
+/// 1. Read [`standard_server_id_path`] if present. This is the only step that
+///    works without a DB connection; on already-provisioned hosts it always
+///    succeeds, so callers like the doctor daemon can report status to canopy
+///    even when postgres is down (which is precisely when canopy most needs
+///    to hear from us).
+/// 2. If `client` is `Some`, read the legacy `local_system_facts.metaServerId`
+///    row; best-effort copy to the file path so subsequent runs don't need
+///    the DB.
+/// 3. If `client` is `Some`, generate a fresh UUIDv4. Persist to the file
+///    path; if the file write fails, fall back to inserting into
+///    `local_system_facts` so the new ID isn't lost across runs.
+///
+/// Returns an error when `client` is `None` *and* the file isn't present —
+/// brand-new hosts have to reach the DB at least once to mint an ID.
+pub async fn get_or_create_server_id(client: Option<&tokio_postgres::Client>) -> Result<String> {
+	get_or_create_server_id_at(&standard_server_id_path(), client).await
+}
 
-	if let Some(id) = read_server_id_file(&path) {
+/// Test-shimmed core of [`get_or_create_server_id`] — same contract, with
+/// the file path injected so unit tests can drive it without touching
+/// `/etc/tamanu`.
+async fn get_or_create_server_id_at(
+	path: &Path,
+	client: Option<&tokio_postgres::Client>,
+) -> Result<String> {
+	if let Some(id) = read_server_id_file(path) {
 		return Ok(id);
 	}
 
+	let Some(client) = client else {
+		miette::bail!(
+			"no server-id file at {} and no DB connection to mint one from",
+			path.display()
+		);
+	};
+
 	if let Some(id) = query_server_id_row(client).await? {
-		match write_server_id_file(&path, &id) {
+		match write_server_id_file(path, &id) {
 			Ok(()) => info!(
 				path = %path.display(),
 				"copied metaServerId from Tamanu DB to standard path"
@@ -94,7 +117,7 @@ pub async fn get_or_create_server_id(client: &tokio_postgres::Client) -> Result<
 	let id = Uuid::new_v4().to_string();
 	info!(server_id = %id, "generating new metaServerId");
 
-	match write_server_id_file(&path, &id) {
+	match write_server_id_file(path, &id) {
 		Ok(()) => Ok(id),
 		Err(err) => {
 			debug!(
@@ -540,7 +563,7 @@ mod tests {
 		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
-		let id = get_or_create_server_id(&client).await.unwrap();
+		let id = get_or_create_server_id(Some(&client)).await.unwrap();
 		assert!(!id.is_empty());
 		uuid::Uuid::parse_str(&id).expect("should be a valid UUID");
 
@@ -568,7 +591,7 @@ mod tests {
 			.await
 			.unwrap();
 
-		let id = get_or_create_server_id(&client).await.unwrap();
+		let id = get_or_create_server_id(Some(&client)).await.unwrap();
 		assert_eq!(id, "existing-id-123");
 	}
 
@@ -577,9 +600,37 @@ mod tests {
 		let _lock = DB_TEST_MUTEX.lock().await;
 		let client = test_db_client().await;
 
-		let id1 = get_or_create_server_id(&client).await.unwrap();
-		let id2 = get_or_create_server_id(&client).await.unwrap();
+		let id1 = get_or_create_server_id(Some(&client)).await.unwrap();
+		let id2 = get_or_create_server_id(Some(&client)).await.unwrap();
 		assert_eq!(id1, id2);
+	}
+
+	#[tokio::test]
+	async fn server_id_resolves_from_file_without_db() {
+		// The boot-time canopy push case: postgres isn't reachable yet, but
+		// the host's been provisioned so the standard file path has an id.
+		// Resolution must succeed without consulting the DB at all.
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("server-id");
+		let cached = uuid::Uuid::new_v4().to_string();
+		std::fs::write(&path, &cached).unwrap();
+
+		let id = get_or_create_server_id_at(&path, None).await.unwrap();
+		assert_eq!(id, cached);
+	}
+
+	#[tokio::test]
+	async fn server_id_errors_without_db_and_without_file() {
+		// Brand-new host with no DB connection: there's no id to find, and
+		// no way to mint one — must surface as an error so the caller knows
+		// the cause.
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("server-id");
+		let err = get_or_create_server_id_at(&path, None)
+			.await
+			.expect_err("no file, no db → must error");
+		let msg = format!("{err}");
+		assert!(msg.contains("server-id"), "{msg}");
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 `alertd` started while postgres is down was silently dropping every healthcheck on the floor: the doctor sweep gates `get_or_create_server_id` on `db.is_some()` (`doctor.rs:595`), so even though the server-id file at `/etc/tamanu/server-id` would resolve fine on its own, no DB → no `server_id` → `tick` short-circuits with `no metaServerId available; skipping canopy status push`. That means the one moment canopy most needs to hear from the host — DB down — is the moment it hears nothing.

Stacked on #416.

## Summary

- `get_or_create_server_id` now takes `Option<&Client>`. The file path is tried first regardless; the DB fallback only runs when a client is provided. Returns an error only on the brand-new-host case (no file *and* no client).
- The doctor sweep passes `db.as_deref()` through directly — already-provisioned hosts answer from the file even when postgres is unreachable, so `server_id` is `Some(...)` and the canopy push happens with the `db_connect` failure (and all the other DB-dependent checks skipping) visible in the payload.
- The `server_id` doctor check no longer hard-fails when the DB is down; if the file resolves it reports the cached id.
- `meta_ticket` keeps its DB-only call shape via `Some(&client)`.
- Internal `get_or_create_server_id_at(path, client)` shim lets unit tests drive the file-only path against a tempdir; covers both "file present, no DB → returns cached id" and "no file, no DB → errors".
