### PR TITLE
feat(tamanu): Unknown expectation state for DB-unreachable signals

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -87,12 +87,14 @@ pub async fn config_and_expectations(
 	};
 
 	// The patient-portal expectation is only emitted on Linux/central; skip
-	// the DB round-trip in any other shape.
+	// the DB round-trip in any other shape. On other deployment shapes
+	// there's no portal flag to read, so `Some(false)` is correct — not
+	// Unknown, which would falsely imply "we couldn't tell".
 	let patient_portal_enabled =
 		if matches!(supervisor, Supervisor::Systemd) && matches!(kind, ApiServerKind::Central) {
 			query_patient_portal_enabled_with_wait(&config.database_url(), wait_for_db).await
 		} else {
-			false
+			Some(false)
 		};
 
 	let patient_portal_instanced = matches!(supervisor, Supervisor::Systemd)
@@ -109,12 +111,21 @@ pub async fn config_and_expectations(
 	Ok((supervisor, expectations))
 }
 
-/// Connect to the DB and read `features.patientPortal`. With
-/// [`WaitForDb::No`], one attempt; on failure, warn and return `false`.
-/// With [`WaitForDb::Yes`], retry every [`DB_WAIT_INTERVAL`] for up to
-/// [`DB_WAIT_TIMEOUT`], warning on each failure so an operator running
-/// the command manually while the DB is down sees what's happening.
-async fn query_patient_portal_enabled_with_wait(database_url: &str, wait_for_db: WaitForDb) -> bool {
+/// Connect to the DB and read `features.patientPortal`. Returns
+/// `Some(value)` when the query succeeds (including the missing-row case,
+/// where Tamanu's default of `false` applies), `None` when the DB is
+/// unreachable — callers map `None` to the Unknown expectation state so
+/// lifecycle commands leave the portal alone rather than guessing.
+///
+/// With [`WaitForDb::No`], one attempt; on failure, warn and return
+/// `None`. With [`WaitForDb::Yes`], retry every [`DB_WAIT_INTERVAL`] for
+/// up to [`DB_WAIT_TIMEOUT`], warning on each failure so an operator
+/// running the command manually while the DB is down sees what's
+/// happening.
+async fn query_patient_portal_enabled_with_wait(
+	database_url: &str,
+	wait_for_db: WaitForDb,
+) -> Option<bool> {
 	query_patient_portal_enabled_with_wait_inner(
 		database_url,
 		wait_for_db,
@@ -132,7 +143,7 @@ async fn query_patient_portal_enabled_with_wait_inner(
 	wait_for_db: WaitForDb,
 	timeout: Duration,
 	interval: Duration,
-) -> bool {
+) -> Option<bool> {
 	let deadline = match wait_for_db {
 		WaitForDb::No => None,
 		WaitForDb::Yes => Some(Instant::now() + timeout),
@@ -143,16 +154,16 @@ async fn query_patient_portal_enabled_with_wait_inner(
 			Ok(client) => return query_patient_portal_enabled(&client).await,
 			Err(err) => match deadline {
 				None => {
-					warn!(%err, "could not query features.patientPortal; assuming false");
-					return false;
+					warn!(%err, "could not query features.patientPortal; expectation will be Unknown");
+					return None;
 				}
 				Some(deadline) if Instant::now() >= deadline => {
 					warn!(
 						%err,
-						"timed out after {}s waiting for the database; assuming features.patientPortal is false",
+						"timed out after {}s waiting for the database; features.patientPortal expectation will be Unknown",
 						timeout.as_secs(),
 					);
-					return false;
+					return None;
 				}
 				Some(_) => {
 					warn!(
@@ -277,6 +288,22 @@ fn discover_pm2() -> Result<(Vec<Instance>, pm2::Source)> {
 		});
 	}
 	Ok((out, source))
+}
+
+/// Warn-log every expectation whose state is Unknown — lifecycle commands
+/// silently skip Unknown services (we don't know what they should be doing,
+/// so we leave them alone), but operators running interactively should see
+/// what's been left out and why.
+pub fn warn_unknown_expectations(expectations: &[&Expectation]) {
+	for exp in expectations {
+		if matches!(exp.state, services::ExpectedState::Unknown) {
+			warn!(
+				name = exp.name,
+				reason = %exp.reason,
+				"leaving service alone: expected state is Unknown"
+			);
+		}
+	}
 }
 
 /// Group discovered instances under the expectation each belongs to.
@@ -800,7 +827,7 @@ mod tests {
 	const UNREACHABLE_DB_URL: &str = "postgres://localhost:1/x";
 
 	#[tokio::test]
-	async fn wait_for_db_no_returns_false_after_single_attempt() {
+	async fn wait_for_db_no_returns_none_after_single_attempt() {
 		let start = Instant::now();
 		let result = query_patient_portal_enabled_with_wait_inner(
 			UNREACHABLE_DB_URL,
@@ -809,7 +836,7 @@ mod tests {
 			Duration::from_millis(50),
 		)
 		.await;
-		assert!(!result);
+		assert_eq!(result, None, "DB unreachable must surface as Unknown, not a guess");
 		assert!(
 			start.elapsed() < Duration::from_secs(5),
 			"WaitForDb::No should not loop; took {:?}",
@@ -829,7 +856,7 @@ mod tests {
 			Duration::from_millis(50),
 		)
 		.await;
-		assert!(!result, "should default to false after timeout");
+		assert_eq!(result, None, "should surface as Unknown after timeout");
 		assert!(
 			start.elapsed() >= Duration::from_millis(300),
 			"should have waited at least the timeout; took {:?}",

--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -164,12 +164,15 @@ pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
 			{
 				Ok(client) => query_patient_portal_enabled(&client).await,
 				Err(err) => {
-					tracing::warn!(%err, "could not query features.patientPortal; assuming false");
-					false
+					tracing::warn!(
+						%err,
+						"could not query features.patientPortal; portal logs may be missing from output"
+					);
+					None
 				}
 			}
 		} else {
-			false
+			Some(false)
 		};
 
 	let patient_portal_instanced = matches!(supervisor, Supervisor::Systemd)
@@ -953,7 +956,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(true, false),
-			false,
+			Some(false),
 			false,
 		);
 		let tasks = exps.iter().find(|e| e.name == "tamanu-facility-tasks").unwrap();

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -62,6 +62,7 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 		lifecycle::config_and_expectations(tamanu, WaitForDb::No).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
 	let matched = services::match_names(&expectations, &names)?;
+	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor)?;
 	let groups = lifecycle::group_by_expectation(&matched, &discovered);
 

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -53,6 +53,7 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 		lifecycle::config_and_expectations(tamanu, WaitForDb::Yes).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
 	let matched = services::match_names(&expectations, &names)?;
+	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor)?;
 	let groups = lifecycle::group_by_expectation(&matched, &discovered);
 
@@ -306,6 +307,48 @@ mod tests {
 			legacy: false,
 			behind_caddy,
 		}
+	}
+
+	fn unknown_exp(name: &'static str) -> Expectation {
+		Expectation {
+			name,
+			instances: Instances::Single,
+			state: ExpectedState::Unknown,
+			reason: "test: DB unreachable".into(),
+			legacy: false,
+			behind_caddy: true,
+		}
+	}
+
+	#[test]
+	fn plan_start_skips_unknown_expectations() {
+		// Unknown means "we don't know what this should be" — start must
+		// not touch it.
+		let portal = unknown_exp("tamanu-patientportal");
+		let groups = vec![(&portal, Vec::<Instance>::new())];
+		let plan = plan_start(Supervisor::Systemd, &groups).unwrap();
+		assert!(plan.targets.is_empty(), "Unknown must not be started");
+		assert!(!plan.started_behind_caddy);
+	}
+
+	#[test]
+	fn plan_stop_skips_unknown_expectations() {
+		// Same on the stop side: even if a discovered instance is running,
+		// Unknown means hands-off.
+		let portal = unknown_exp("tamanu-patientportal");
+		let groups: Vec<(&Expectation, Vec<Instance>)> = vec![(
+			&portal,
+			vec![Instance {
+				name: "tamanu-patientportal".into(),
+				instance: None,
+				pm_id: None,
+				running: true,
+			}],
+		)];
+		let plan = plan_stop(Supervisor::Systemd, &groups, |unit| {
+			panic!("is_enabled must not be called for Unknown, got {unit}");
+		});
+		assert!(plan.is_empty(), "Unknown must not be stopped or disabled");
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -222,6 +222,12 @@ fn build_report(groups: &[(&Expectation, Vec<Instance>)], probe: &VersionProbe) 
 					any_short = true;
 					"forbidden"
 				}
+				// Unknown is *not* short: we deliberately don't know what the
+				// expectation should be (typically because the DB-derived
+				// signal was unreachable), so there's nothing to act on or
+				// alarm about. The row still appears in the table so
+				// operators see the gap.
+				ExpectedState::Unknown => "unknown",
 			};
 			let expected_version = probe.expected_for(exp.name).map(str::to_string);
 			ExpectationReport {
@@ -229,6 +235,7 @@ fn build_report(groups: &[(&Expectation, Vec<Instance>)], probe: &VersionProbe) 
 				expected_state: match exp.state {
 					ExpectedState::Up => "up",
 					ExpectedState::Down => "down",
+					ExpectedState::Unknown => "unknown",
 				},
 				running,
 				min_count: exp.instances.min_count(),
@@ -285,6 +292,10 @@ enum Outcome {
 	/// (running, or stopped+enabled). The matching units are surfaced in the
 	/// Actual cell.
 	Forbidden,
+	/// Expectation state was `Unknown` — the driving signal (e.g. a DB
+	/// flag) couldn't be read. We don't claim the actual state is anything
+	/// in particular; the row is rendered but isn't a failure.
+	Unknown,
 }
 
 impl Outcome {
@@ -297,6 +308,10 @@ impl Outcome {
 			Outcome::Up | Outcome::Absent => Color::Green,
 			Outcome::Short => Color::Yellow,
 			Outcome::Down | Outcome::Forbidden => Color::Red,
+			// Coloured Yellow rather than Red so the operator sees the row
+			// is worth attention but not a failure. The driving signal (DB
+			// flag) couldn't be read, so anything could be true.
+			Outcome::Unknown => Color::Yellow,
 		}
 	}
 }
@@ -321,6 +336,10 @@ fn classify(exp: &Expectation, instances: &[Instance]) -> Outcome {
 				Outcome::Forbidden
 			}
 		}
+		// We deliberately don't know what should be running — surface the
+		// row so operators see the gap, but classify it as Unknown rather
+		// than guessing Up/Down.
+		ExpectedState::Unknown => Outcome::Unknown,
 	}
 }
 
@@ -389,6 +408,7 @@ fn expected_cell(exp: &Expectation) -> Cell {
 			}
 		}
 		ExpectedState::Down => "absent".to_string(),
+		ExpectedState::Unknown => "unknown".to_string(),
 	};
 	Cell::new(text)
 }
@@ -420,6 +440,21 @@ fn actual_cell(
 		}
 		Outcome::Absent => "absent".to_string(),
 		Outcome::Forbidden => forbidden_summary(instances),
+		Outcome::Unknown => {
+			// Surface whatever's actually there, without claiming it
+			// matches an expectation. Bare "unknown" would hide useful
+			// detail; the running/stopped split is still real.
+			if instances.is_empty() {
+				"unknown (nothing present)".to_string()
+			} else if running == instances.len() {
+				format!("unknown ({running} running)")
+			} else if running == 0 {
+				format!("unknown ({} stopped)", instances.len())
+			} else {
+				let stopped = instances.len() - running;
+				format!("unknown ({running} running, {stopped} stopped)")
+			}
+		}
 	};
 
 	let mut lines = vec![summary];
@@ -471,6 +506,8 @@ fn instance_word(inst: &Instance, expected: ExpectedState) -> &'static str {
 		(true, _) => "running",
 		(false, ExpectedState::Down) => "stopped, but still enabled",
 		(false, ExpectedState::Up) => "stopped",
+		// We don't know whether stopped is right or wrong, so just say so.
+		(false, ExpectedState::Unknown) => "stopped",
 	}
 }
 

--- a/crates/bestool/src/actions/tamanu/stop.rs
+++ b/crates/bestool/src/actions/tamanu/stop.rs
@@ -31,6 +31,7 @@ pub async fn run(args: StopArgs, ctx: Context) -> Result<()> {
 		lifecycle::config_and_expectations(tamanu, WaitForDb::No).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
 	let matched = services::match_names(&expectations, &names)?;
+	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor)?;
 	let groups = lifecycle::group_by_expectation(&matched, &discovered);
 

--- a/crates/tamanu/src/doctor/checks/tamanu_service.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_service.rs
@@ -23,11 +23,11 @@ pub async fn run(ctx: CheckContext) -> Check {
 	};
 
 	// Patient-portal expectation is gated on Tamanu's own `features.patientPortal`
-	// DB setting. Without a DB client (e.g. unreachable), treat the flag as off
-	// — same as the `expected()` default for missing-config callers.
+	// DB setting. Without a DB client (e.g. unreachable), pass `None` so the
+	// expectation surfaces as Unknown rather than a false-negative Down.
 	let patient_portal_enabled = match ctx.db.as_deref() {
 		Some(client) => crate::server_info::query_patient_portal_enabled(client).await,
-		None => false,
+		None => None,
 	};
 	let patient_portal_instanced =
 		matches!(supervisor, Supervisor::Systemd) && systemd_patient_portal_instanced();
@@ -208,6 +208,12 @@ enum Outcome {
 	Forbidden {
 		units: Vec<String>,
 	},
+	/// Expectation is `Unknown` (the driving signal was unreachable). We
+	/// record what's there but neither pass nor fail; the row exists so
+	/// operators see that we couldn't decide for this service.
+	Indeterminate {
+		discovered: Vec<String>,
+	},
 }
 
 /// Cross-reference Down expectations against `is-enabled` to handle the two
@@ -265,6 +271,13 @@ fn match_expectation(exp: &Expectation, discovered: &[Discovered]) -> (Outcome, 
 		.collect();
 
 	match exp.state {
+		ExpectedState::Unknown => {
+			let units: Vec<String> = matched_idx
+				.iter()
+				.map(|i| discovered[*i].raw.clone())
+				.collect();
+			(Outcome::Indeterminate { discovered: units }, matched_idx)
+		}
 		ExpectedState::Down => {
 			if matched_idx.is_empty() {
 				(Outcome::Ok, matched_idx)
@@ -349,7 +362,24 @@ fn evaluate(
 			"behind_caddy": exp.behind_caddy,
 		}));
 
-		if !matches!(outcome, Outcome::Ok) {
+		// `Indeterminate` is the Unknown-expectation outcome: we couldn't
+		// decide what should be running. That's not a failure (we never
+		// claimed the actual state is wrong), so it doesn't go in the
+		// failures list — but it does land in `diagnostics` so operators
+		// see the row was deliberately not evaluated.
+		if matches!(outcome, Outcome::Indeterminate { .. }) {
+			let (actual, detail) = actual_for_outcome(exp, &outcome);
+			let mut diag = json!({
+				"name": exp.name,
+				"expected": expected_state_label(exp.state),
+				"reason": exp.reason,
+				"actual": actual,
+			});
+			if let Some(d) = detail {
+				diag["detail"] = Value::String(d);
+			}
+			diagnostics.push(diag);
+		} else if !matches!(outcome, Outcome::Ok) {
 			let (actual, detail) = actual_for_outcome(exp, &outcome);
 			let expected_label = expected_state_label(exp.state);
 			let mut diag = json!({
@@ -436,6 +466,7 @@ fn expected_state_label(s: ExpectedState) -> &'static str {
 	match s {
 		ExpectedState::Up => "up",
 		ExpectedState::Down => "down",
+		ExpectedState::Unknown => "unknown",
 	}
 }
 
@@ -459,6 +490,14 @@ fn actual_for_outcome(exp: &Expectation, outcome: &Outcome) -> (&'static str, Op
 			("partial", Some(parts.join("; ")))
 		}
 		Outcome::Forbidden { units } => ("up", Some(units.join(", "))),
+		Outcome::Indeterminate { discovered } => {
+			let detail = if discovered.is_empty() {
+				None
+			} else {
+				Some(discovered.join(", "))
+			};
+			("indeterminate", detail)
+		}
 	}
 }
 
@@ -500,6 +539,9 @@ fn outcome_to_json(o: &Outcome) -> Value {
 			"missing_named": missing_named,
 		}),
 		Outcome::Forbidden { units } => json!({"kind": "forbidden", "units": units}),
+		Outcome::Indeterminate { discovered } => {
+			json!({"kind": "indeterminate", "discovered": discovered})
+		}
 	}
 }
 
@@ -546,7 +588,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -568,7 +610,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -595,7 +637,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -621,7 +663,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -651,7 +693,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -753,7 +795,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let mut discovered = vec![
@@ -780,13 +822,42 @@ mod tests {
 	}
 
 	#[test]
+	fn unknown_portal_expectation_does_not_fail_check() {
+		// DB unreachable → portal expectation is Unknown. The doctor must
+		// not flag this as a service-check failure: we don't know what the
+		// portal should be doing, so any running/stopped state is fine.
+		let cfg = central_cfg(true);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg,
+			None,
+			false,
+		);
+		let discovered = vec![
+			d("tamanu-central-tasks", None, true),
+			d("tamanu-frontend", Some("a"), true),
+			d("tamanu-frontend", Some("b"), true),
+			d("tamanu-central-api", Some("1"), true),
+			d("tamanu-central-api", Some("2"), true),
+			d("tamanu-central-fhir-resolve", None, true),
+			d("tamanu-central-fhir-refresh", None, true),
+			// patient portal is running; with Unknown expectation, that
+			// must NOT count as a failure.
+			d("tamanu-patientportal", None, true),
+		];
+		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
+		assert!(matches!(check.status, CheckStatus::Pass), "{check:?}");
+	}
+
+	#[test]
 	fn central_with_fhir_requires_workers() {
 		let cfg = central_cfg(true);
 		let exps = expected(
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -823,7 +894,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -840,7 +911,13 @@ mod tests {
 	#[test]
 	fn pm2_facility_happy() {
 		let cfg = cfg(false);
-		let exps = expected(Supervisor::Pm2, ApiServerKind::Facility, &cfg, false, false);
+		let exps = expected(
+			Supervisor::Pm2,
+			ApiServerKind::Facility,
+			&cfg,
+			Some(false),
+			false,
+		);
 		let discovered = vec![
 			Discovered {
 				name: "tamanu-tasks".into(),
@@ -939,7 +1016,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -975,7 +1052,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -1024,7 +1101,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![
@@ -1058,7 +1135,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg,
-			false,
+			Some(false),
 			false,
 		);
 		let discovered = vec![

--- a/crates/tamanu/src/doctor/checks/version_drift.rs
+++ b/crates/tamanu/src/doctor/checks/version_drift.rs
@@ -50,7 +50,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 	// expected set.
 	let patient_portal_enabled = match ctx.db.as_deref() {
 		Some(client) => crate::server_info::query_patient_portal_enabled(client).await,
-		None => false,
+		None => None,
 	};
 	let patient_portal_instanced =
 		matches!(supervisor, Supervisor::Systemd) && systemd_patient_portal_instanced();

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -349,9 +349,14 @@ where
 ///
 /// Settings are stored as one row per dotted leaf path, with the value column
 /// as `JSONB`. The default if the row is absent is `false` (per the global
-/// schema in `packages/settings/src/schema/global.ts`), so we treat missing
-/// rows and decode failures as `false`.
-pub async fn query_patient_portal_enabled(client: &tokio_postgres::Client) -> bool {
+/// schema in `packages/settings/src/schema/global.ts`), so missing rows
+/// resolve to `Some(false)`.
+///
+/// Returns `None` only when the query itself failed — that's the
+/// "DB unreachable" / "transient SQL error" case, kept distinct from
+/// `Some(false)` so callers can emit an Unknown expectation rather than
+/// silently treating outage as opt-out.
+pub async fn query_patient_portal_enabled(client: &tokio_postgres::Client) -> Option<bool> {
 	match client
 		.query_opt(
 			"SELECT value FROM settings WHERE key = 'features.patientPortal' LIMIT 1",
@@ -359,15 +364,16 @@ pub async fn query_patient_portal_enabled(client: &tokio_postgres::Client) -> bo
 		)
 		.await
 	{
-		Ok(Some(row)) => row
-			.try_get::<_, serde_json::Value>(0)
-			.ok()
-			.and_then(|v| v.as_bool())
-			.unwrap_or(false),
-		Ok(None) => false,
+		Ok(Some(row)) => Some(
+			row.try_get::<_, serde_json::Value>(0)
+				.ok()
+				.and_then(|v| v.as_bool())
+				.unwrap_or(false),
+		),
+		Ok(None) => Some(false),
 		Err(err) => {
 			debug!(%err, "could not query features.patientPortal setting");
-			false
+			None
 		}
 	}
 }

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -91,6 +91,12 @@ pub enum ExpectedState {
 	Up,
 	/// Must NOT be active and (on systemd) must NOT be enabled.
 	Down,
+	/// We couldn't resolve what this service should be doing — typically
+	/// because the signal that drives the expectation (e.g. a Tamanu DB
+	/// setting) was unreachable. Lifecycle commands leave Unknown
+	/// services alone: neither start nor stop them. Doctor and status
+	/// report the row without flagging a failure.
+	Unknown,
 }
 
 impl Instances {
@@ -136,12 +142,16 @@ impl Instances {
 
 /// All services expected to exist (or be absent) for this deployment.
 ///
-/// `patient_portal_enabled` is the `features.patientPortal` setting read from
-/// the central server's DB. Callers without a DB connection should pass
-/// `false`; we'll then emit a Down expectation, which is the same thing the
-/// doctor would have asserted on a deployment that hasn't opted into the
-/// portal. The signal is sourced from the DB rather than `local.json5`
-/// because Tamanu's central-server code reads the setting (not the unused
+/// `patient_portal_enabled` carries the `features.patientPortal` setting
+/// from the central server's DB as a tri-state:
+/// - `Some(true)` → portal expected Up
+/// - `Some(false)` → portal expected Down (the deployment has opted out)
+/// - `None` → expectation is Unknown (signal couldn't be resolved, usually
+///   because the DB is unreachable). Lifecycle commands skip Unknown
+///   services so a transient outage doesn't trigger spurious stops/starts.
+///
+/// The signal is sourced from the DB rather than `local.json5` because
+/// Tamanu's central-server code reads the setting (not the unused
 /// `patientPortal.portalUrl` config field) to decide whether to mount the
 /// portal API.
 ///
@@ -149,13 +159,12 @@ impl Instances {
 /// true, expect a frontend-style `Named(["a", "b"])` template; when false,
 /// expect the historical singleton. Callers should source this from
 /// [`systemd_patient_portal_instanced`] on systemd hosts and pass `false`
-/// otherwise (the singleton default has no false-positive impact when the
-/// expectation is Down anyway).
+/// otherwise.
 pub fn expected(
 	supervisor: Supervisor,
 	kind: ApiServerKind,
 	config: &TamanuConfig,
-	patient_portal_enabled: bool,
+	patient_portal_enabled: Option<bool>,
 	patient_portal_instanced: bool,
 ) -> Vec<Expectation> {
 	let mut out = Vec::new();
@@ -255,12 +264,23 @@ pub fn expected(
 			// and bulk-restart. Expected Up iff the Tamanu DB setting
 			// `features.patientPortal` is true — if the flag is on but
 			// nothing's running, that's an ops misalignment worth
-			// flagging.
+			// flagging. When the DB is unreachable we can't decide,
+			// so the expectation is Unknown and lifecycle commands
+			// leave the portal alone.
 			if matches!(supervisor, Supervisor::Systemd) {
-				let portal_state = if patient_portal_enabled {
-					ExpectedState::Up
-				} else {
-					ExpectedState::Down
+				let (portal_state, portal_reason) = match patient_portal_enabled {
+					Some(true) => (
+						ExpectedState::Up,
+						"DB setting features.patientPortal is true".to_string(),
+					),
+					Some(false) => (
+						ExpectedState::Down,
+						"DB setting features.patientPortal is false".to_string(),
+					),
+					None => (
+						ExpectedState::Unknown,
+						"DB unreachable, cannot read features.patientPortal".to_string(),
+					),
 				};
 				let portal_instances = if patient_portal_instanced {
 					Instances::Named(&["a", "b"])
@@ -271,9 +291,7 @@ pub fn expected(
 					name: "tamanu-patientportal",
 					instances: portal_instances,
 					state: portal_state,
-					reason: format!(
-						"DB setting features.patientPortal is {patient_portal_enabled}"
-					),
+					reason: portal_reason,
 					legacy: false,
 					behind_caddy: true,
 				});
@@ -420,7 +438,7 @@ mod tests {
 			Supervisor::Pm2,
 			ApiServerKind::Facility,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		assert_eq!(
@@ -441,7 +459,7 @@ mod tests {
 			Supervisor::Pm2,
 			ApiServerKind::Central,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		assert_eq!(
@@ -469,7 +487,7 @@ mod tests {
 			Supervisor::Pm2,
 			ApiServerKind::Central,
 			&cfg(true),
-			false,
+			Some(false),
 			false,
 		);
 		assert_eq!(
@@ -489,7 +507,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		assert_eq!(
@@ -515,7 +533,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(true),
-			true,
+			Some(true),
 			true,
 		);
 		assert_eq!(
@@ -540,7 +558,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
-			true,
+			Some(true),
 			true,
 		);
 		let pp = es
@@ -559,7 +577,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
-			true,
+			Some(true),
 			false,
 		);
 		let pp = es
@@ -568,6 +586,30 @@ mod tests {
 			.expect("patient portal expectation should be present");
 		assert_eq!(pp.state, ExpectedState::Up);
 		assert_eq!(pp.instances, Instances::Single);
+	}
+
+	#[test]
+	fn central_systemd_marks_patient_portal_unknown_when_db_unreachable() {
+		// `patient_portal_enabled = None` means "we couldn't read the DB
+		// flag" — the expectation must be Unknown so lifecycle commands
+		// leave the portal alone rather than guessing Down.
+		let es = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg(false),
+			None,
+			false,
+		);
+		let pp = es
+			.iter()
+			.find(|e| e.name == "tamanu-patientportal")
+			.expect("portal expectation should still be emitted");
+		assert_eq!(pp.state, ExpectedState::Unknown);
+		assert!(
+			pp.reason.contains("DB"),
+			"reason should mention DB: {}",
+			pp.reason
+		);
 	}
 
 	#[test]
@@ -580,7 +622,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		let pp = es
@@ -596,7 +638,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
-			true,
+			Some(true),
 			true,
 		);
 		assert!(es.iter().all(|e| e.name != "tamanu-patientportal"));
@@ -611,7 +653,7 @@ mod tests {
 			Supervisor::Pm2,
 			ApiServerKind::Central,
 			&cfg(true),
-			true,
+			Some(true),
 			true,
 		);
 		assert!(es.iter().all(|e| e.name != "tamanu-patientportal"));
@@ -623,7 +665,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		let fe = es.iter().find(|e| e.name == "tamanu-frontend").unwrap();
@@ -637,7 +679,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		let api = es.iter().find(|e| e.name == "tamanu-facility-api").unwrap();
@@ -683,7 +725,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		assert!(rolling_for(&central, "tamanu-central-api"));
@@ -693,7 +735,7 @@ mod tests {
 			Supervisor::Pm2,
 			ApiServerKind::Facility,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		assert!(rolling_for(&facility_pm2, "tamanu-api"));
@@ -707,7 +749,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
-			true,
+			Some(true),
 			true,
 		);
 		assert!(rolling_for(&central, "tamanu-patientportal"));
@@ -721,7 +763,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(false),
-			true,
+			Some(true),
 			false,
 		);
 		assert!(!rolling_for(&central, "tamanu-patientportal"));
@@ -735,7 +777,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Central,
 			&cfg(true),
-			true,
+			Some(true),
 			true,
 		);
 		assert!(!rolling_for(&central, "tamanu-central-tasks"));
@@ -746,7 +788,7 @@ mod tests {
 			Supervisor::Systemd,
 			ApiServerKind::Facility,
 			&cfg(false),
-			false,
+			Some(false),
 			false,
 		);
 		assert!(!rolling_for(&facility, "tamanu-facility-sync"));


### PR DESCRIPTION
🤖 New rule: when a DB-derived signal is unreachable, the expectation is `Unknown` — not a guessed `Down`. Lifecycle commands leave Unknown services alone (no start, no stop, no restart). Status table and doctor surface the row separately so operators can see the gap. This is the right default whenever we can't know what the deployment intends.

Stacked on #417.

## Summary

- New `ExpectedState::Unknown` variant alongside `Up` and `Down`.
- `query_patient_portal_enabled` (and the with-wait variant) now return `Option<bool>`: `None` means "DB query failed", distinct from `Some(false)` ("DB says portal is off").
- `services::expected()` takes `Option<bool>` for `patient_portal_enabled`; `None` emits an Unknown expectation with reason "DB unreachable, cannot read features.patientPortal".
- `tamanu start` / `stop` / `restart` already filter on `state == Up` or `state == Down`, so Unknown is naturally excluded; an explicit `warn_unknown_expectations` helper logs each skipped service so an operator running interactively sees what was left out and why.
- Doctor's `tamanu_service` check gains an `Outcome::Indeterminate` variant: the row appears in diagnostics (so the gap is visible) but doesn't count as a failure — the check's whole premise is that we *know* what should be there, and we don't.
- Status table shows `unknown` in the Expected column with a Yellow cell colour (attention, not failure), and an Actual cell that describes whatever's actually present without claiming it's right or wrong.
- New tests: `expected()` emits Unknown when `None`; doctor's `unknown_portal_expectation_does_not_fail_check`; `plan_start_skips_unknown_expectations`; `plan_stop_skips_unknown_expectations`.

## Interaction with #416

`WaitForDb::Yes` still serves a purpose — giving the DB a chance to come up before we decide it's unreachable — but a timeout there now resolves to Unknown rather than a guessed `false`. That's the safer fallback: no DB → no decision → no action.
