### PR TITLE
fix(tamanu/doctor): unblock tokio workers + surface HTTP error chain

### DIFF
--- a/crates/bestool/src/actions/tamanu/meta_ticket.rs
+++ b/crates/bestool/src/actions/tamanu/meta_ticket.rs
@@ -60,8 +60,8 @@ pub async fn run(_args: MetaTicketArgs, ctx: Context) -> Result<()> {
 
 	let server_id = get_or_create_server_id(Some(&client)).await?;
 
-	let (tailscale_ip, tailscale_name) = get_tailscale_info();
-	let hosting = detect_hosting();
+	let (tailscale_ip, tailscale_name) = get_tailscale_info().await;
+	let hosting = detect_hosting().await;
 
 	let kind = if config.is_facility() {
 		"facility"
@@ -101,7 +101,7 @@ fn derive_public_key_pem(private_key_pem: &str) -> Result<String> {
 	Ok(pem)
 }
 
-fn detect_hosting() -> Option<String> {
+async fn detect_hosting() -> Option<String> {
 	if is_raspberry_pi() {
 		return Some("iti".to_string());
 	}
@@ -110,7 +110,7 @@ fn detect_hosting() -> Option<String> {
 		return Some("ec2".to_string());
 	}
 
-	match detect_virtualisation() {
+	match detect_virtualisation().await {
 		Some(virt) if virt == "none" => Some("bare metal".to_string()),
 		Some(virt) => Some(virt),
 		None => None,

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -74,7 +74,7 @@ pub async fn run(args: StatusArgs, ctx: Context) -> Result<()> {
 	let (install_version, _root) = find_tamanu(tamanu)?;
 	let expected_versions = versions::expected_for_supervisor(supervisor, &install_version);
 	let running_versions = match supervisor {
-		Supervisor::Systemd => versions::running_versions_linux(),
+		Supervisor::Systemd => versions::running_versions_linux().await,
 		Supervisor::Pm2 => HashMap::new(),
 	};
 	let probe = VersionProbe {

--- a/crates/tamanu/src/doctor/checks.rs
+++ b/crates/tamanu/src/doctor/checks.rs
@@ -61,8 +61,6 @@ pub struct CheckContext {
 /// The actual SQL message lives in the optional `DbError` underneath; this
 /// helper surfaces it where present and falls back to the source chain.
 pub fn fmt_db_error(err: &tokio_postgres::Error) -> String {
-	use std::error::Error;
-
 	if let Some(db) = err.as_db_error() {
 		let mut s = format!("{}: {}", db.severity(), db.message());
 		if let Some(detail) = db.detail() {
@@ -71,6 +69,18 @@ pub fn fmt_db_error(err: &tokio_postgres::Error) -> String {
 		}
 		return s;
 	}
+
+	fmt_chain(err)
+}
+
+/// Walk a `std::error::Error`'s source chain and join all the messages.
+///
+/// `reqwest::Error`'s Display is just "error sending request for url (...)";
+/// the actual cause (DNS error, connection refused, timed out, proxy failure)
+/// is one or two `.source()` calls down. Without walking the chain, doctor
+/// `FAIL` rows lose the only diagnostic that matters.
+pub fn fmt_chain<E: std::error::Error + ?Sized>(err: &E) -> String {
+	use std::error::Error;
 
 	let mut parts = vec![err.to_string()];
 	let mut src: Option<&dyn Error> = err.source();

--- a/crates/tamanu/src/doctor/checks/caddy_version.rs
+++ b/crates/tamanu/src/doctor/checks/caddy_version.rs
@@ -14,9 +14,8 @@
 //! check pre-emptively flags any 2.10.x / 2.11.x point releases that aren't
 //! 2.10.0–2.10.2 as unsafe on Linux until 2.11.4 ships.
 
-use std::process::Command;
-
 use node_semver::Version;
+use tokio::process::Command;
 
 use super::CheckContext;
 use crate::doctor::check::Check;
@@ -35,7 +34,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 		}
 	};
 
-	let output = match Command::new("caddy").arg("version").output() {
+	let output = match Command::new("caddy").arg("version").output().await {
 		Ok(o) if o.status.success() => o,
 		Ok(o) => {
 			let stderr = String::from_utf8_lossy(&o.stderr);

--- a/crates/tamanu/src/doctor/checks/http_errors.rs
+++ b/crates/tamanu/src/doctor/checks/http_errors.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tracing::{debug, warn};
 
-use super::CheckContext;
+use super::{CheckContext, fmt_chain};
 use crate::doctor::check::Check;
 
 const CADDY_METRICS_URL: &str = "http://localhost:2019/metrics";
@@ -108,7 +108,7 @@ async fn fetch_counts(client: &reqwest::Client) -> FetchResult {
 				return FetchResult::Skip(Check::skip(
 					"http_errors",
 					"caddy /metrics body read failed",
-					err.to_string(),
+					fmt_chain(&err),
 				));
 			}
 		},
@@ -126,7 +126,10 @@ async fn fetch_counts(client: &reqwest::Client) -> FetchResult {
 			return FetchResult::Skip(Check::skip(
 				"http_errors",
 				"caddy admin unreachable",
-				format!("could not reach caddy admin at {CADDY_METRICS_URL}: {err}"),
+				format!(
+					"could not reach caddy admin at {CADDY_METRICS_URL}: {}",
+					fmt_chain(&err)
+				),
 			));
 		}
 	};

--- a/crates/tamanu/src/doctor/checks/kopia_backup.rs
+++ b/crates/tamanu/src/doctor/checks/kopia_backup.rs
@@ -33,10 +33,10 @@ const FAIL_AGE_SECS: i64 = 24 * 60 * 60;
 
 pub async fn run(_ctx: CheckContext) -> Check {
 	if cfg!(target_os = "linux") {
-		return run_linux();
+		return run_linux().await;
 	}
 	if cfg!(target_os = "windows") {
-		return run_windows();
+		return run_windows().await;
 	}
 	Check::skip(
 		CHECK_NAME,
@@ -45,7 +45,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	)
 }
 
-fn run_linux() -> Check {
+async fn run_linux() -> Check {
 	let Some(kopia_binary) = bestool_kopia::find_kopia_binary(None) else {
 		return Check::skip(
 			CHECK_NAME,
@@ -66,11 +66,9 @@ fn run_linux() -> Check {
 		}
 	};
 
-	let output = match cmd
-		.args(["snapshot", "list", "--json", "--no-all"])
-		.env("KOPIA_CHECK_FOR_UPDATES", "false")
-		.output()
-	{
+	cmd.args(["snapshot", "list", "--json", "--no-all"])
+		.env("KOPIA_CHECK_FOR_UPDATES", "false");
+	let output = match tokio::process::Command::from(cmd).output().await {
 		Ok(o) if o.status.success() => o,
 		Ok(o) => {
 			let stderr = String::from_utf8_lossy(&o.stderr);
@@ -114,7 +112,7 @@ fn elevation_label(e: &Elevation) -> &'static str {
 	}
 }
 
-fn run_windows() -> Check {
+async fn run_windows() -> Check {
 	let Some(binary) = bestool_kopia::find_kopia_binary(None) else {
 		return Check::skip(
 			CHECK_NAME,
@@ -130,11 +128,12 @@ fn run_windows() -> Check {
 		);
 	};
 
-	let output = match std::process::Command::new(&binary)
+	let output = match tokio::process::Command::new(&binary)
 		.args(["snapshot", "list", "--json", "--no-all"])
 		.env("KOPIA_CONFIG_PATH", &config)
 		.env("KOPIA_CHECK_FOR_UPDATES", "false")
 		.output()
+		.await
 	{
 		Ok(o) if o.status.success() => o,
 		Ok(o) => {

--- a/crates/tamanu/src/doctor/checks/tailscale.rs
+++ b/crates/tamanu/src/doctor/checks/tailscale.rs
@@ -2,7 +2,7 @@ use super::CheckContext;
 use crate::{doctor::check::Check, server_info::get_tailscale_info};
 
 pub async fn run(_ctx: CheckContext) -> Check {
-	let (ip, name) = get_tailscale_info();
+	let (ip, name) = get_tailscale_info().await;
 	match (ip, name) {
 		(Some(ip), Some(name)) => Check::pass("tailscale", format!("{name} ({ip})"))
 			.with_detail("ip", ip)

--- a/crates/tamanu/src/doctor/checks/tamanu_http.rs
+++ b/crates/tamanu/src/doctor/checks/tamanu_http.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use super::CheckContext;
+use super::{CheckContext, fmt_chain};
 use crate::doctor::check::Check;
 
 const PING_URL: &str = "http://localhost/api/public/ping";
@@ -33,7 +33,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Err(err) => Check::fail(
 			"tamanu_http",
 			format!("could not reach {PING_URL}"),
-			err.to_string(),
+			fmt_chain(&err),
 		),
 	};
 

--- a/crates/tamanu/src/doctor/checks/time_sync.rs
+++ b/crates/tamanu/src/doctor/checks/time_sync.rs
@@ -1,14 +1,14 @@
-use std::process::Command;
+use tokio::process::Command;
 
 use super::CheckContext;
 use crate::doctor::check::Check;
 
 pub async fn run(_ctx: CheckContext) -> Check {
 	if cfg!(target_os = "linux") {
-		return run_linux();
+		return run_linux().await;
 	}
 	if cfg!(target_os = "windows") {
-		return run_windows();
+		return run_windows().await;
 	}
 	Check::skip(
 		"time_sync",
@@ -17,10 +17,11 @@ pub async fn run(_ctx: CheckContext) -> Check {
 	)
 }
 
-fn run_linux() -> Check {
+async fn run_linux() -> Check {
 	let output = match Command::new("timedatectl")
 		.args(["show", "-p", "NTPSynchronized", "--value"])
 		.output()
+		.await
 	{
 		Ok(o) if o.status.success() => o,
 		Ok(_) | Err(_) => {
@@ -60,8 +61,12 @@ fn run_linux() -> Check {
 ///
 /// If neither line is present (older Windows builds, locked-down configs), we
 /// skip rather than guessing.
-fn run_windows() -> Check {
-	let output = match Command::new("w32tm").args(["/query", "/status"]).output() {
+async fn run_windows() -> Check {
+	let output = match Command::new("w32tm")
+		.args(["/query", "/status"])
+		.output()
+		.await
+	{
 		Ok(o) if o.status.success() => o,
 		Ok(_) | Err(_) => {
 			return Check::skip(

--- a/crates/tamanu/src/doctor/checks/version_drift.rs
+++ b/crates/tamanu/src/doctor/checks/version_drift.rs
@@ -43,7 +43,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 	}
 
 	let expected_versions = versions::expected_for_supervisor(supervisor, &ctx.tamanu_version);
-	let running = versions::running_versions_linux();
+	let running = versions::running_versions_linux().await;
 
 	// Only look at units that show up in our expectations registry. Hand-
 	// started or orphaned containers aren't drift; they're outside the

--- a/crates/tamanu/src/doctor/server_info.rs
+++ b/crates/tamanu/src/doctor/server_info.rs
@@ -108,7 +108,7 @@ pub async fn gather(
 		})
 		.collect();
 
-	let virt = detect_virtualisation();
+	let virt = detect_virtualisation().await;
 	let virtualised = !matches!(virt.as_deref(), None | Some("none"));
 
 	let (ipv4, ipv6, nat64) = futures::join!(probe_ipv4(), probe_ipv6(), probe_nat64());

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -3,10 +3,7 @@
 //! Used by `meta_ticket`, `alertd`, and `doctor`. Kept here so each subcommand
 //! pulls from one place rather than reaching into a sibling's module.
 
-use std::{
-	path::{Path, PathBuf},
-	process::Command,
-};
+use std::path::{Path, PathBuf};
 
 use miette::{IntoDiagnostic, Result};
 use tracing::{debug, info, warn};
@@ -471,11 +468,12 @@ fn write_device_key_file(path: &Path, pem: &str) -> std::io::Result<()> {
 
 /// Read the tailscale Self node's first IP and DNS name, if tailscale is
 /// installed and responding to `status --json`.
-pub fn get_tailscale_info() -> (Option<String>, Option<String>) {
-	let output = match Command::new("tailscale")
+pub async fn get_tailscale_info() -> (Option<String>, Option<String>) {
+	let output = match tokio::process::Command::new("tailscale")
 		.arg("status")
 		.arg("--json")
 		.output()
+		.await
 	{
 		Ok(output) if output.status.success() => output,
 		Ok(output) => {
@@ -515,8 +513,11 @@ pub fn get_tailscale_info() -> (Option<String>, Option<String>) {
 /// Linux: read `systemd-detect-virt`'s output. Returns `None` if the command
 /// is unavailable. The string is whatever systemd reports (e.g. `kvm`, `lxc`,
 /// `none` for bare metal).
-pub fn detect_virtualisation() -> Option<String> {
-	let output = Command::new("systemd-detect-virt").output().ok()?;
+pub async fn detect_virtualisation() -> Option<String> {
+	let output = tokio::process::Command::new("systemd-detect-virt")
+		.output()
+		.await
+		.ok()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
 	if stdout.is_empty() {

--- a/crates/tamanu/src/versions.rs
+++ b/crates/tamanu/src/versions.rs
@@ -131,17 +131,23 @@ pub fn parse_image_tag(image: &str) -> Option<&str> {
 /// unknown".
 #[cfg(target_os = "linux")]
 #[instrument(level = "debug")]
-pub fn running_versions_linux() -> HashMap<String, String> {
-	let output = match duct::cmd!(
-		"podman",
-		"ps",
-		"--format",
-		"{{.Labels.PODMAN_SYSTEMD_UNIT}}\t{{.Image}}"
-	)
-	.stderr_null()
-	.read()
-	{
-		Ok(o) => o,
+pub async fn running_versions_linux() -> HashMap<String, String> {
+	use std::process::Stdio;
+	let result = tokio::process::Command::new("podman")
+		.args([
+			"ps",
+			"--format",
+			"{{.Labels.PODMAN_SYSTEMD_UNIT}}\t{{.Image}}",
+		])
+		.stderr(Stdio::null())
+		.output()
+		.await;
+	let output = match result {
+		Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).into_owned(),
+		Ok(o) => {
+			debug!(status = %o.status, "podman ps exited non-zero; no actual-version info");
+			return HashMap::new();
+		}
 		Err(err) => {
 			debug!(%err, "podman ps unavailable; no actual-version info");
 			return HashMap::new();
@@ -168,7 +174,7 @@ pub fn running_versions_linux() -> HashMap<String, String> {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn running_versions_linux() -> HashMap<String, String> {
+pub async fn running_versions_linux() -> HashMap<String, String> {
 	HashMap::new()
 }
 


### PR DESCRIPTION
🤖 Doctor's HTTP checks (`tamanu_http`, `http_errors`) intermittently fail in full sweeps on 1.16+ with `error sending request for url (...)`, but pass when run alone (`--check tamanu_http`).

Root cause: several doctor checks shell out to subprocesses via `std::process::Command::output()` (synchronous) from inside `async fn`s. Each such call parks the tokio worker thread it's running on until the subprocess returns. When N (= worker-count) of them fire concurrently, every worker is blocked in `wait()`, tokio's I/O reactor and timer wheel can't drive the in-flight HTTP requests, and hyper's connection task errors out before reqwest's 5 s `.timeout()` even fires. The visible symptom is the generic "error sending request" rather than "request timed out", because the transport task dies waiting for a worker.

Confirmed on a live host: full sweep — `tamanu_http` FAIL, `db_connect` 5414 ms; `--skip` the five blocking checks — `tamanu_http` PASS in 92 ms, `db_connect` drops to 95 ms.

## Changes

- `caddy_version`, `time_sync`, `kopia_backup`, `tailscale`, `version_drift` (via `running_versions_linux`), and the gather-side `detect_virtualisation` / `get_tailscale_info` now use `tokio::process::Command`. Functions that need it become `async`; callers (`status`, `doctor::server_info::gather`, `meta_ticket::detect_hosting`) are updated.
- `kopia_backup` keeps using `bestool_kopia::build_kopia_command` (returns `std::process::Command`) and converts to `tokio::process::Command::from(cmd)` before `.output().await`.
- `versions::running_versions_linux` switches from `duct::cmd!().read()` to `tokio::process::Command`, and its two callers (`status.rs`, `version_drift.rs`) `.await` it.

Separate first commit (`fix(tamanu/doctor): surface reqwest source chain in HTTP check errors`) makes `tamanu_http` / `http_errors` `FAIL` rows walk `std::error::Error::source()` so future transport errors carry the underlying cause instead of the opaque top-level Display.
