### PR TITLE
Set a User-Agent on all HTTP clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sysinfo",
  "time",
  "tokio",
  "tracing",

--- a/crates/alertd/src/commands.rs
+++ b/crates/alertd/src/commands.rs
@@ -26,7 +26,7 @@ pub fn default_server_addrs() -> Vec<std::net::SocketAddr> {
 pub async fn try_connect_daemon(
 	addrs: &[std::net::SocketAddr],
 ) -> miette::Result<(reqwest::Client, String)> {
-	let client = reqwest::Client::new();
+	let client = crate::http_client();
 	let mut last_error = None;
 
 	for addr in addrs {

--- a/crates/alertd/src/commands/reload.rs
+++ b/crates/alertd/src/commands/reload.rs
@@ -6,7 +6,7 @@ use tracing::info;
 /// until one succeeds. This is an alternative to SIGHUP that works on all platforms
 /// including Windows.
 pub async fn send_reload(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
-	let client = reqwest::Client::new();
+	let client = crate::http_client();
 
 	let mut last_error = None;
 

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -105,6 +105,7 @@ pub async fn run_with_shutdown_and_reload(
 	let canopy_client = match CanopyClient::new(
 		daemon_config.tamanu_version.clone(),
 		daemon_config.device_key_pem.as_ref().map(|r| r.0.as_str()),
+		crate::http_builder,
 	)
 	.await
 	{
@@ -145,7 +146,7 @@ pub async fn run_with_shutdown_and_reload(
 
 	let ctx = Arc::new(InternalContext {
 		pg_pool: pool,
-		http_client: reqwest::Client::new(),
+		http_client: crate::http_client(),
 		canopy_client,
 	});
 

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -34,6 +34,21 @@ pub use tasks::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse}
 /// The version of the alertd library
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Base builder for alertd's outbound HTTP clients.
+///
+/// Carries the browser-style `bestool/<version>` User-Agent (and whatever else
+/// [`canopy::client_builder`] sets). Call sites add their own timeouts etc.
+pub fn http_builder() -> reqwest::ClientBuilder {
+	canopy::client_builder(VERSION)
+}
+
+/// A built [`reqwest::Client`] from [`http_builder`].
+pub fn http_client() -> reqwest::Client {
+	http_builder()
+		.build()
+		.expect("failed to build alertd HTTP client")
+}
+
 /// Email server configuration
 #[derive(Debug, Clone)]
 pub struct EmailConfig {

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -74,7 +74,7 @@ serde_json = "1.0.143"
 serde_path_to_error = { version = "0.1.17", optional = true }
 serde_yaml = { version = "0.9.33", optional = true }
 ssh-key = { version = "0.6.6", optional = true }
-sysinfo = { workspace = true, optional = true }
+sysinfo = { workspace = true }
 target-tuples = { version = "0.16.1", optional = true }
 tempfile = "3.21.0"
 tera = { version = "1.19.1", optional = true }
@@ -111,7 +111,7 @@ caddy = ["download", "dep:tera"]
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 crypto = ["dep:algae-cli", "dep:blake3", "dep:merkle_hash"]
 file = ["dep:blake3", "dep:indicatif", "dep:tokio-util"]
-kopia = ["dep:bestool-kopia", "bestool-kopia/cli", "dep:comfy-table", "dep:sysinfo"]
+kopia = ["dep:bestool-kopia", "bestool-kopia/cli", "dep:comfy-table"]
 rdp = ["dep:duct", "dep:privilege", "dep:quick-xml", "dep:tauri-winrt-notification", "dep:windows-service"]
 self-update = ["download", "dep:semver", "dep:upgrade", "dep:windows-env"]
 ssh = ["dep:dirs", "dep:duct", "dep:fs4", "dep:ssh-key", "dep:privilege", "dep:windows-acl"]
@@ -146,7 +146,6 @@ tamanu-alerts = [
 	"dep:pulldown-cmark",
 	"dep:serde_path_to_error",
 	"dep:serde_yaml",
-	"dep:sysinfo",
 	"dep:tera",
 	"dep:tokio-postgres",
 	"dep:walkdir",
@@ -173,8 +172,8 @@ tamanu-download = ["__tamanu", "download"]
 tamanu-find = ["__tamanu"]
 tamanu-greenmask = ["__tamanu", "tamanu-config", "dep:bestool-psql", "dep:dunce", "dep:serde_yaml", "dep:walkdir"]
 tamanu-lifecycle = ["__tamanu", "tamanu-config", "dep:bestool-postgres", "dep:comfy-table", "dep:owo-colors", "dep:privilege"]
-tamanu-logs = ["__tamanu", "tamanu-config", "dep:bestool-postgres", "dep:owo-colors", "dep:sysinfo"]
-tamanu-meta-ticket = ["__tamanu", "tamanu-config", "bestool-tamanu/meta-ticket", "dep:base64", "dep:bestool-psql", "dep:p256", "dep:rand_core", "dep:sysinfo", "dep:tokio-postgres"]
+tamanu-logs = ["__tamanu", "tamanu-config", "dep:bestool-postgres", "dep:owo-colors"]
+tamanu-meta-ticket = ["__tamanu", "tamanu-config", "bestool-tamanu/meta-ticket", "dep:base64", "dep:bestool-psql", "dep:p256", "dep:rand_core", "dep:tokio-postgres"]
 tamanu-psql = ["__tamanu", "tamanu-config", "dep:bestool-canopy", "dep:bestool-psql"]
 tamanu-sync = ["__tamanu", "tamanu-config"]
 tamanu-tags = ["__tamanu", "tamanu-config", "dep:bestool-canopy", "dep:comfy-table"]
@@ -195,7 +194,7 @@ iti = [ # enable all iti subcommands
 ]
 iti-battery = ["__iti", "dep:rppal"]
 iti-improv-wifi = ["__iti", "dep:improv-wifi", "dep:rppal"]
-iti-lcd = ["__iti", "dep:ctrlc", "dep:embedded-graphics", "dep:rpi-st7789v2-driver", "dep:sysinfo"]
+iti-lcd = ["__iti", "dep:ctrlc", "dep:embedded-graphics", "dep:rpi-st7789v2-driver"]
 iti-temperature = ["__iti", "dep:duct"]
 __iti = ["dep:zmq"] # internal feature to enable the iti subcommand common code
 

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -201,7 +201,11 @@ fn add_self_to_path() -> Result<()> {
 #[cfg(windows)]
 async fn is_alertd_service_running() -> bool {
 	// Try to query the alertd HTTP API status endpoint
-	match reqwest::get("http://127.0.0.1:8271/status").await {
+	match crate::http::client()
+		.get("http://127.0.0.1:8271/status")
+		.send()
+		.await
+	{
 		Ok(response) => response.status().is_success(),
 		Err(_) => false,
 	}

--- a/crates/bestool/src/actions/tamanu/alerts/command.rs
+++ b/crates/bestool/src/actions/tamanu/alerts/command.rs
@@ -221,6 +221,7 @@ pub async fn run(args: AlertsArgs, ctx: Context) -> Result<()> {
 	let canopy_client = match bestool_canopy::CanopyClient::new(
 		version.to_string(),
 		device_key_pem.as_deref(),
+		crate::http::client_builder,
 	)
 	.await
 	{
@@ -245,7 +246,7 @@ pub async fn run(args: AlertsArgs, ctx: Context) -> Result<()> {
 	let config = Arc::new(config);
 	let internal_ctx = Arc::new(InternalContext {
 		pg_client: client,
-		http_client: reqwest::Client::new(),
+		http_client: crate::http::client(),
 		canopy_client,
 	});
 

--- a/crates/bestool/src/actions/tamanu/artifacts.rs
+++ b/crates/bestool/src/actions/tamanu/artifacts.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use comfy_table::{ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use detect_targets::detect_targets;
 use miette::{IntoDiagnostic, Result};
-use reqwest::{Client, Url};
+use reqwest::Url;
 use serde::Deserialize;
 use std::str::FromStr;
 use target_tuples::{
@@ -59,7 +59,7 @@ pub struct Artifact {
 
 pub async fn get_artifacts(version: &str, for_platform: &Platform) -> Result<Vec<Artifact>> {
 	let url = format!("https://meta.tamanu.app/versions/{version}/artifacts");
-	let client = Client::new();
+	let client = crate::http::client();
 
 	let response = client.get(&url).send().await.into_diagnostic()?;
 

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -85,7 +85,7 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	let config = Arc::new(load_config(&root, None)?);
 
 	let database_url = config.database_url();
-	let http_client = reqwest::Client::new();
+	let http_client = crate::http::client();
 
 	let (sweep, source) = if args.no_daemon {
 		(

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -591,7 +591,7 @@ pub async fn reload_caddy() {
 #[cfg(target_os = "windows")]
 async fn reload_caddy_via_admin_api(path: &str) -> std::result::Result<(), String> {
 	let content = std::fs::read(path).map_err(|e| format!("read {path}: {e}"))?;
-	let client = reqwest::Client::builder()
+	let client = crate::http::client_builder()
 		.timeout(Duration::from_secs(5))
 		.build()
 		.map_err(|e| format!("build client: {e}"))?;

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -408,7 +408,13 @@ pub async fn run(args: PsqlArgs, ctx: Context) -> Result<()> {
 
 	let canopy = if let Some(ref tamanu_version) = version {
 		let device_key = read_device_key();
-		match CanopyClient::new(tamanu_version.clone(), device_key.as_deref()).await {
+		match CanopyClient::new(
+			tamanu_version.clone(),
+			device_key.as_deref(),
+			crate::http::client_builder,
+		)
+		.await
+		{
 			Ok(Some(client)) => {
 				if client.is_tailscale().await {
 					debug!("canopy ready via tailscale for snippet fetch");
@@ -578,7 +584,11 @@ async fn fetch_redactions_from_source(version: &str) -> Result<HashSet<ColumnRef
 	let url = format!("https://docs.data.bes.au/tamanu/v{version}/manifest.json");
 	debug!("fetching redactions from {}", url);
 
-	let response = reqwest::get(&url).await.into_diagnostic()?;
+	let response = crate::http::client()
+		.get(&url)
+		.send()
+		.await
+		.into_diagnostic()?;
 	let text = response.text().await.into_diagnostic()?;
 
 	parse_manifest(&text)

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -205,7 +205,7 @@ async fn bulk_restart(supervisor: Supervisor, targets: &[String]) -> Result<()> 
 }
 
 fn http_client() -> Result<Client> {
-	Client::builder()
+	crate::http::client_builder()
 		.timeout(Duration::from_secs(5))
 		.build()
 		.into_diagnostic()

--- a/crates/bestool/src/actions/tamanu/sync.rs
+++ b/crates/bestool/src/actions/tamanu/sync.rs
@@ -136,7 +136,7 @@ pub async fn run(args: SyncArgs, ctx: Context) -> Result<()> {
 		.ok_or_else(|| miette::miette!("config has no sync.syncApiConnection block"))?;
 	debug!(%base_url, %service_name, ?kind, "preparing sync");
 
-	let client = Client::builder()
+	let client = crate::http::client_builder()
 		// No client-side timeout: we manage the overall and start timeouts
 		// ourselves, around the whole retry loop. The sync sub-process's
 		// `/sync/run` has no server-side timeout either, so a single POST can

--- a/crates/bestool/src/actions/tamanu/tags.rs
+++ b/crates/bestool/src/actions/tamanu/tags.rs
@@ -118,8 +118,12 @@ enum Source {
 
 async fn fetch_online(tamanu_version: &str) -> Result<Vec<String>> {
 	let device_key = read_device_key();
-	let canopy = CanopyClient::new(tamanu_version.to_owned(), device_key.as_deref())
-		.await?
+	let canopy = CanopyClient::new(
+		tamanu_version.to_owned(),
+		device_key.as_deref(),
+		crate::http::client_builder,
+	)
+	.await?
 		.ok_or_else(|| miette!("no canopy auth path: no tailscale, no device key"))?;
 
 	debug!(

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info, instrument};
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 pub async fn reqwest_client() -> Result<reqwest::Client> {
-	let mut builder = reqwest::Client::builder();
+	let mut builder = crate::http::client_builder();
 	for source in [
 		DownloadSource::Tools,
 		DownloadSource::Servers,
@@ -39,7 +39,7 @@ pub async fn reqwest_client() -> Result<reqwest::Client> {
 }
 
 pub async fn client() -> Result<Client> {
-	let mut builder = Client::default_builder(crate::APP_NAME, None, &mut iter::empty());
+	let mut builder = Client::default_builder(crate::http::user_agent(), None, &mut iter::empty());
 	for source in [
 		DownloadSource::Tools,
 		DownloadSource::Servers,

--- a/crates/bestool/src/http.rs
+++ b/crates/bestool/src/http.rs
@@ -1,0 +1,55 @@
+use std::sync::OnceLock;
+
+/// Browser-style user-agent sent on every outbound HTTP request bestool makes.
+///
+/// `bestool/<version> (<os>; <arch>)`, e.g.
+/// `bestool/1.18.1 (Linux 7.0.9 Arch Linux; x86_64)`. The OS comment is
+/// detected at runtime and cached.
+pub(crate) fn user_agent() -> &'static str {
+	static UA: OnceLock<String> = OnceLock::new();
+	UA.get_or_init(|| {
+		let os = sysinfo::System::long_os_version()
+			.or_else(sysinfo::System::name)
+			.unwrap_or_else(|| std::env::consts::OS.to_owned());
+		format!(
+			"bestool/{} ({os}; {})",
+			env!("CARGO_PKG_VERSION"),
+			sysinfo::System::cpu_arch(),
+		)
+	})
+}
+
+/// Base builder for all of bestool's `reqwest` clients.
+///
+/// Sets the [`user_agent`] and opts into honouring `SSLKEYLOGFILE` (a no-op
+/// unless that env var is set at runtime). Call sites add their own timeouts,
+/// DNS overrides, etc. on top.
+pub(crate) fn client_builder() -> reqwest::ClientBuilder {
+	reqwest::Client::builder()
+		.user_agent(user_agent())
+		.tls_sslkeylogfile(true)
+}
+
+/// A built [`reqwest::Client`] from [`client_builder`] with default settings.
+pub(crate) fn client() -> reqwest::Client {
+	client_builder()
+		.build()
+		.expect("failed to build bestool HTTP client")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn user_agent_has_product_and_os_comment() {
+		let ua = user_agent();
+		assert!(ua.starts_with("bestool/"), "unexpected user-agent: {ua}");
+		assert!(ua.contains('('), "expected OS comment in: {ua}");
+		assert!(ua.ends_with(')'), "expected OS comment in: {ua}");
+		assert!(
+			ua.contains(sysinfo::System::cpu_arch().as_str()),
+			"expected arch in: {ua}"
+		);
+	}
+}

--- a/crates/bestool/src/lib.rs
+++ b/crates/bestool/src/lib.rs
@@ -8,12 +8,10 @@ pub(crate) mod args;
 #[cfg(feature = "download")]
 pub(crate) mod download;
 pub mod find_postgres;
+pub(crate) mod http;
 
 #[cfg(feature = "tamanu-alerts")]
 pub(crate) mod postgres_to_value;
-
-#[allow(dead_code)] // some subcommands don't use it, but it's easier to have it everywhere
-pub(crate) const APP_NAME: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
 #[cfg(doc)]
 pub mod __help {

--- a/crates/canopy/Cargo.toml
+++ b/crates/canopy/Cargo.toml
@@ -21,6 +21,7 @@ rcgen = { workspace = true }
 reqwest = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+sysinfo = { workspace = true }
 time = "0.3"
 tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -2,6 +2,7 @@ use std::{
 	fmt,
 	io::Write,
 	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+	sync::{Arc, OnceLock},
 	time::Duration,
 };
 
@@ -54,6 +55,37 @@ pub const CERT_RENEW_AFTER: Duration = Duration::from_secs(5 * 24 * 60 * 60);
 /// Timeout for the tailscale availability probe.
 const TAILSCALE_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Factory producing the base [`reqwest::ClientBuilder`] for canopy's clients.
+///
+/// The caller supplies this so it owns cross-cutting client config (user-agent,
+/// `SSLKEYLOGFILE`, proxies, …). Canopy invokes it whenever it needs to build or
+/// rebuild a client — at probe time, on mTLS cert renewal, and on reload — then
+/// layers its own concerns (mTLS identity, DNS overrides, timeouts) on top.
+pub type ClientBuilderFactory = Arc<dyn Fn() -> reqwest::ClientBuilder + Send + Sync>;
+
+/// Browser-style user-agent string, e.g. `bestool/1.2.3 (Linux 7.0.9 Arch Linux; x86_64)`.
+///
+/// `product` and `version` identify the calling binary; the OS comment is
+/// detected at runtime and cached.
+pub fn user_agent(product: &str, version: &str) -> String {
+	static OS_COMMENT: OnceLock<String> = OnceLock::new();
+	let os_comment = OS_COMMENT.get_or_init(|| {
+		let os = sysinfo::System::long_os_version()
+			.or_else(sysinfo::System::name)
+			.unwrap_or_else(|| std::env::consts::OS.to_owned());
+		format!("{os}; {}", sysinfo::System::cpu_arch())
+	});
+	format!("{product}/{version} ({os_comment})")
+}
+
+/// A [`reqwest::ClientBuilder`] carrying the `bestool` [`user_agent`] for `version`.
+///
+/// Convenience for callers that don't need any extra client config; suitable as
+/// the base of a [`ClientBuilderFactory`].
+pub fn client_builder(version: &str) -> reqwest::ClientBuilder {
+	reqwest::Client::builder().user_agent(user_agent("bestool", version))
+}
+
 /// RFC 5424 syslog severities accepted by the canopy `/events` API.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -102,6 +134,8 @@ pub struct CanopyClient {
 	/// that don't carry one. Sourced from the running Tamanu install's
 	/// `package.json` (via `find_tamanu`); not the bestool / alertd version.
 	tamanu_version: String,
+	/// Produces the base client builder; see [`ClientBuilderFactory`].
+	make_builder: ClientBuilderFactory,
 	state: RwLock<State>,
 }
 
@@ -137,28 +171,35 @@ impl CanopyClient {
 	///
 	/// `tamanu_version` is the version of the Tamanu install this client
 	/// speaks for; sent on every request via the `X-Version` header.
+	///
+	/// `make_builder` supplies the base [`reqwest::ClientBuilder`] — see
+	/// [`ClientBuilderFactory`]. Use [`client_builder`] for a sensible default.
 	pub async fn new(
 		tamanu_version: impl Into<String>,
 		device_key_pem: Option<&str>,
+		make_builder: impl Fn() -> reqwest::ClientBuilder + Send + Sync + 'static,
 	) -> Result<Option<Self>> {
 		let tamanu_version = tamanu_version.into();
 		let device_key = device_key_pem.map(|s| Redacted(s.to_owned()));
+		let make_builder: ClientBuilderFactory = Arc::new(make_builder);
 
-		if let Some(http) = probe_tailscale().await {
+		if let Some(http) = probe_tailscale(&make_builder).await {
 			debug!("canopy: tailscale endpoint reachable, preferring it");
 			return Ok(Some(Self {
 				device_key,
 				tamanu_version,
+				make_builder,
 				state: RwLock::new(State::Tailscale(http)),
 			}));
 		}
 
 		if let Some(pem) = device_key_pem {
 			debug!("canopy: tailscale unreachable, falling back to mTLS");
-			let http = build_mtls_http(pem)?;
+			let http = build_mtls_http(&make_builder, pem)?;
 			return Ok(Some(Self {
 				device_key,
 				tamanu_version,
+				make_builder,
 				state: RwLock::new(State::Mtls(http)),
 			}));
 		}
@@ -175,7 +216,7 @@ impl CanopyClient {
 	///
 	/// Intended to be called when the daemon receives a reload signal.
 	pub async fn refresh(&self) -> Result<()> {
-		if let Some(http) = probe_tailscale().await {
+		if let Some(http) = probe_tailscale(&self.make_builder).await {
 			let mut state = self.state.write().await;
 			if !state.is_tailscale() {
 				debug!("canopy refresh: switching to tailscale path");
@@ -185,7 +226,7 @@ impl CanopyClient {
 		}
 
 		if let Some(pem) = &self.device_key {
-			let http = build_mtls_http(&pem.0)?;
+			let http = build_mtls_http(&self.make_builder, &pem.0)?;
 			let mut state = self.state.write().await;
 			if state.is_tailscale() {
 				debug!("canopy refresh: tailscale dropped, falling back to mTLS");
@@ -211,7 +252,7 @@ impl CanopyClient {
 		if state.is_tailscale() {
 			return Ok(());
 		}
-		*state = State::Mtls(build_mtls_http(&pem.0)?);
+		*state = State::Mtls(build_mtls_http(&self.make_builder, &pem.0)?);
 		Ok(())
 	}
 
@@ -380,7 +421,7 @@ impl CanopyClient {
 ///   tailscale callers (everything else 403s with `tagged-device-not-allowed`);
 /// - it's a `GET` with no body, no `VersionHeader` requirement, and no auth;
 /// - it's read-only, so probing it has no side effects.
-async fn probe_tailscale() -> Option<reqwest::Client> {
+async fn probe_tailscale(make_builder: &ClientBuilderFactory) -> Option<reqwest::Client> {
 	let dns_addrs: Vec<SocketAddr> = tailscale_resolver()
 		.lookup_ip("canopy")
 		.await
@@ -388,7 +429,7 @@ async fn probe_tailscale() -> Option<reqwest::Client> {
 		.map(|addrs| addrs.iter().map(|ip| SocketAddr::new(ip, 443)).collect())
 		.unwrap_or_default();
 	if !dns_addrs.is_empty()
-		&& let Some(client) = try_probe(&dns_addrs).await
+		&& let Some(client) = try_probe(&dns_addrs, make_builder).await
 	{
 		return Some(client);
 	}
@@ -401,11 +442,14 @@ async fn probe_tailscale() -> Option<reqwest::Client> {
 		?hardcoded,
 		"canopy tailscale DNS lookup empty or probe failed, trying hardcoded IPs"
 	);
-	try_probe(&hardcoded).await
+	try_probe(&hardcoded, make_builder).await
 }
 
-async fn try_probe(addrs: &[SocketAddr]) -> Option<reqwest::Client> {
-	let client = reqwest::Client::builder()
+async fn try_probe(
+	addrs: &[SocketAddr],
+	make_builder: &ClientBuilderFactory,
+) -> Option<reqwest::Client> {
+	let client = make_builder()
 		.timeout(TAILSCALE_PROBE_TIMEOUT)
 		.resolve_to_addrs(TAILSCALE_HOST, addrs)
 		.build()
@@ -448,7 +492,10 @@ fn gzip_bytes(bytes: &[u8]) -> std::io::Result<Vec<u8>> {
 	encoder.finish()
 }
 
-fn build_mtls_http(device_key_pem: &str) -> Result<reqwest::Client> {
+fn build_mtls_http(
+	make_builder: &ClientBuilderFactory,
+	device_key_pem: &str,
+) -> Result<reqwest::Client> {
 	let key_pair = KeyPair::from_pem(device_key_pem)
 		.into_diagnostic()
 		.wrap_err("parsing device key PEM")?;
@@ -478,7 +525,7 @@ fn build_mtls_http(device_key_pem: &str) -> Result<reqwest::Client> {
 		.into_diagnostic()
 		.wrap_err("building reqwest TLS identity")?;
 
-	reqwest::Client::builder()
+	make_builder()
 		.identity(identity)
 		.use_rustls_tls()
 		.timeout(Duration::from_secs(30))
@@ -498,25 +545,30 @@ KxD5Wipc/h8lglVsy1UFZq/SZbGhRANCAAT2EsEq7xjeWVnim9XwdYXga/LBbppm
 fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 -----END PRIVATE KEY-----";
 
+	fn test_factory() -> ClientBuilderFactory {
+		Arc::new(reqwest::Client::builder)
+	}
+
 	#[test]
 	fn build_mtls_http_from_p256_key() {
 		// Direct mTLS-path build, bypassing the async constructor / tailscale probe.
-		let result = build_mtls_http(TEST_DEVICE_KEY);
+		let result = build_mtls_http(&test_factory(), TEST_DEVICE_KEY);
 		assert!(result.is_ok(), "{:?}", result.err());
 	}
 
 	#[test]
 	fn build_mtls_http_fails_on_garbage_key() {
-		assert!(build_mtls_http("not a real PEM").is_err());
+		assert!(build_mtls_http(&test_factory(), "not a real PEM").is_err());
 	}
 
 	#[tokio::test]
 	async fn renew_with_mtls_state_swaps_in_fresh_client() {
 		// Construct an mTLS-state client directly (no network probe) and renew it.
-		let http = build_mtls_http(TEST_DEVICE_KEY).unwrap();
+		let http = build_mtls_http(&test_factory(), TEST_DEVICE_KEY).unwrap();
 		let client = CanopyClient {
 			device_key: Some(Redacted(TEST_DEVICE_KEY.to_owned())),
 			tamanu_version: "2.54.2".into(),
+			make_builder: test_factory(),
 			state: RwLock::new(State::Mtls(http)),
 		};
 		client.renew().await.expect("renew should succeed");
@@ -530,10 +582,26 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 		let client = CanopyClient {
 			device_key: None,
 			tamanu_version: "2.54.2".into(),
+			make_builder: test_factory(),
 			state: RwLock::new(State::Tailscale(http)),
 		};
 		client.renew().await.expect("renew should be a no-op");
 		assert!(client.is_tailscale().await);
+	}
+
+	#[test]
+	fn user_agent_has_product_and_os_comment() {
+		let ua = user_agent("bestool", "1.2.3");
+		assert!(
+			ua.starts_with("bestool/1.2.3 "),
+			"unexpected user-agent: {ua}"
+		);
+		assert!(ua.contains('('), "expected OS comment in: {ua}");
+		assert!(ua.ends_with(')'), "expected OS comment in: {ua}");
+		assert!(
+			ua.contains(sysinfo::System::cpu_arch().as_str()),
+			"expected arch in: {ua}"
+		);
 	}
 
 	#[test]

--- a/crates/canopy/src/lib.rs
+++ b/crates/canopy/src/lib.rs
@@ -3,7 +3,8 @@ use std::fmt;
 mod client;
 
 pub use client::{
-	CERT_RENEW_AFTER, CanopyClient, DEFAULT_CANOPY_URL, NewEvent, Severity, TAILSCALE_URL,
+	CERT_RENEW_AFTER, CanopyClient, ClientBuilderFactory, DEFAULT_CANOPY_URL, NewEvent, Severity,
+	TAILSCALE_URL, client_builder, user_agent,
 };
 
 /// Wraps a sensitive value so its `Debug` output doesn't leak the contents.


### PR DESCRIPTION
🤖 Previously, bestool's HTTP requests (to canopy and elsewhere) carried no `User-Agent` header at all. This sets a browser-style one on every outbound HTTP client across the three binaries.

The User-Agent is `bestool/<version> (<os>; <arch>)`, e.g. `bestool/1.18.1 (Linux 7.0.9 Arch Linux; x86_64)`, where the version is the calling binary's own crate version and the OS comment is detected at runtime via sysinfo.

## How it's wired

- **canopy** — `CanopyClient::new` now takes a client-builder factory (`Fn() -> reqwest::ClientBuilder`), so the caller owns cross-cutting client config (User-Agent, `SSLKEYLOGFILE`, …). Canopy invokes it at probe time, on mTLS cert renewal, and on reload, then layers its own identity/DNS/timeout concerns on top. Also exposes `user_agent(product, version)` and `client_builder(version)` helpers.
- **alertd** — routes its reqwest clients through a shared `http_builder`/`http_client` (User-Agent via canopy's `client_builder`) and hands canopy the same factory.
- **bestool** — a single `crate::http` factory carries the User-Agent and opts into honouring `SSLKEYLOGFILE` (a no-op unless that env var is set). Every reqwest client is built from it — artifacts, sync, lifecycle, restart, doctor, psql, alerts, self-update, download — and it's the factory handed to `CanopyClient::new`. The binstalk download client uses the same User-Agent string. `sysinfo` becomes a non-optional dependency, and the now-unused `APP_NAME` constant is dropped.

The factory seam means future client-wide options (proxies, etc.) get set in one place per binary.
