### PR TITLE
Report nodeVersion in healthcheck status data

### DIFF
--- a/crates/tamanu/src/doctor/server_info.rs
+++ b/crates/tamanu/src/doctor/server_info.rs
@@ -12,7 +12,7 @@ use sysinfo::{Disks, System};
 use tokio::net::TcpStream;
 use tracing::debug;
 
-use crate::server_info::detect_virtualisation;
+use crate::server_info::{detect_node_version, detect_virtualisation};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const IPV4_PROBE_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 443);
@@ -40,6 +40,10 @@ pub struct Filesystem {
 pub struct ServerInfo {
 	pub bestool_version: &'static str,
 	pub tamanu_version: String,
+	/// Host's installed Node.js version (bare, no leading `v`), if node is on
+	/// `PATH`. Omitted when node isn't installed or can't be queried.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub node_version: Option<String>,
 	pub hostname: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub canonical_url: Option<String>,
@@ -120,6 +124,7 @@ pub async fn gather(
 	ServerInfo {
 		bestool_version,
 		tamanu_version: tamanu_version.to_string(),
+		node_version: detect_node_version().await,
 		hostname: System::host_name(),
 		canonical_url: facts.canonical_url,
 		current_sync_tick: facts.current_sync_tick,

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -510,6 +510,36 @@ pub async fn get_tailscale_info() -> (Option<String>, Option<String>) {
 	(ip, name)
 }
 
+/// Detect the host's installed Node.js version by running `node --version`.
+///
+/// Returns `None` if node isn't on `PATH` or the command fails. The leading
+/// `v` that node prints (e.g. `v20.11.0`) is stripped, so the value is a bare
+/// version string.
+pub async fn detect_node_version() -> Option<String> {
+	let output = tokio::process::Command::new("node")
+		.arg("--version")
+		.output()
+		.await
+		.ok()?;
+	if !output.status.success() {
+		debug!(status = %output.status, "node --version failed");
+		return None;
+	}
+
+	parse_node_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parse the output of `node --version` (e.g. `v20.11.0\n`) into a bare version
+/// string. Returns `None` for empty/whitespace-only input.
+fn parse_node_version(raw: &str) -> Option<String> {
+	let version = raw.trim().trim_start_matches('v');
+	if version.is_empty() {
+		None
+	} else {
+		Some(version.to_string())
+	}
+}
+
 /// Linux: read `systemd-detect-virt`'s output. Returns `None` if the command
 /// is unavailable. The string is whatever systemd reports (e.g. `kvm`, `lxc`,
 /// `none` for bare metal).
@@ -638,6 +668,22 @@ mod tests {
 			.expect_err("no file, no db → must error");
 		let msg = format!("{err}");
 		assert!(msg.contains("server-id"), "{msg}");
+	}
+
+	#[test]
+	fn parse_node_version_strips_v_prefix_and_whitespace() {
+		assert_eq!(parse_node_version("v20.11.0\n").as_deref(), Some("20.11.0"));
+		assert_eq!(
+			parse_node_version("  v18.19.1  ").as_deref(),
+			Some("18.19.1")
+		);
+		assert_eq!(parse_node_version("20.11.0").as_deref(), Some("20.11.0"));
+	}
+
+	#[test]
+	fn parse_node_version_treats_empty_as_none() {
+		assert!(parse_node_version("").is_none());
+		assert!(parse_node_version("  \n").is_none());
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Adds the host's installed Node.js version to the doctor healthcheck status payload as `nodeVersion`, alongside `tamanuVersion` and the other server facts.

It's detected by running `node --version` (the leading `v` is stripped, so the value is a bare version like `20.11.0`). The field is omitted from the payload when node isn't on `PATH` or the command fails, mirroring how the other optional facts behave.
