### PR TITLE
fix(psql): \e edits the previous query, not the \e invocation

### DIFF
--- a/crates/psql/src/repl.rs
+++ b/crates/psql/src/repl.rs
@@ -47,8 +47,10 @@ mod tests;
 
 impl ReplAction {
 	pub(crate) async fn handle(self, ctx: &mut ReplContext<'_>, line: &str) -> ControlFlow<()> {
-		// Add to history, except for SnippetSave
-		if !matches!(self, ReplAction::SnippetSave { .. }) {
+		// Add to history, except for SnippetSave and Edit. Edit must be excluded
+		// so that `handle_edit` picks up the previous query as the editor's
+		// initial content rather than the `\e` invocation itself.
+		if !matches!(self, ReplAction::SnippetSave { .. } | ReplAction::Edit) {
 			let history = ctx.rl.history_mut();
 			if let Err(e) = history.add_entry(line.into()) {
 				debug!("failed to add to history: {e}");

--- a/crates/psql/src/repl/tests.rs
+++ b/crates/psql/src/repl/tests.rs
@@ -28,6 +28,42 @@ fn test_snippet_save_excluded_from_preceding_command() {
 	}
 }
 
+#[test]
+fn test_edit_invocation_excluded_from_history() {
+	use crate::audit::Audit;
+	use crate::input::ReplAction;
+	use rustyline::history::SearchDirection;
+	use tempfile::TempDir;
+
+	// The history-add guard in `ReplAction::handle` must skip the `\e`
+	// invocation, otherwise `handle_edit` would read `\e` as the editor's
+	// initial content instead of the previous query.
+	assert!(matches!(
+		ReplAction::Edit,
+		ReplAction::SnippetSave { .. } | ReplAction::Edit
+	));
+	assert!(!matches!(
+		ReplAction::Copy,
+		ReplAction::SnippetSave { .. } | ReplAction::Edit
+	));
+
+	// With `\e` excluded, the last history entry is the prior query, which is
+	// exactly what `handle_edit` seeds the editor buffer with.
+	let temp_dir = TempDir::new().unwrap();
+	let audit_path = temp_dir.path().join("history.redb");
+	let repl_state = Arc::new(Mutex::new(ReplState::new()));
+	let mut audit = Audit::open(&audit_path, Arc::clone(&repl_state)).unwrap();
+	audit.add_entry("SELECT 42;".into()).unwrap();
+
+	let last_idx = audit.len() - 1;
+	let initial = audit
+		.get(last_idx, SearchDirection::Forward)
+		.unwrap()
+		.map(|r| r.entry.to_string())
+		.unwrap_or_default();
+	assert_eq!(initial, "SELECT 42;");
+}
+
 #[tokio::test]
 async fn test_text_cast_for_record_types() {
 	let connection_string =


### PR DESCRIPTION
🤖 Typing `\e` in the psql REPL opened the external editor pre-filled with the literal text `\e` instead of the previous query.

`ReplAction::handle` adds the invocation line to history before dispatching, so by the time `handle_edit` read the last history entry as the editor's initial content, that entry was `\e` itself.

Fix: exclude `ReplAction::Edit` from the history-add guard (alongside the existing `SnippetSave` exclusion), so the editor is seeded with the actual previous query.
