### PR TITLE
feat(tamanu/start): probe started services and add --logs

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -2017,6 +2017,13 @@ brings up missing services without touching anything else.
 Idempotent: services already in the expected state are left alone.
 Use `tamanu status` first to see what's drifted.
 
+After starting, the behind-caddy HTTP services (API, frontend, patient
+portal) are probed for readiness within a one-minute budget
+(`--probe-timeout`); if any don't come up, `start` bails. Pass
+`--no-probe-http` to skip the check. With `--logs`, the tamanu service
+logs are streamed for the duration of the start so the operator can
+watch startup.
+
 **Usage:** `bestool tamanu start [OPTIONS] [NAMES]...`
 
 ###### **Arguments:**
@@ -2026,6 +2033,11 @@ Use `tamanu status` first to see what's drifted.
 ###### **Options:**
 
 * `--up-only` — Skip the stop/disable phase: only bring up missing Up services, leave any drifted Down services as-is. Useful when you want to avoid touching a service that's running but shouldn't be (e.g. because you're mid-investigation)
+* `--no-probe-http` — Skip the post-start HTTP readiness probe
+* `--probe-timeout <PROBE_TIMEOUT>` — How long to wait for started services to pass their readiness probe before bailing
+
+  Default value: `1m`
+* `--logs` — Stream tamanu service logs while starting
 
 
 

--- a/crates/bestool/src/actions/tamanu.rs
+++ b/crates/bestool/src/actions/tamanu.rs
@@ -12,6 +12,8 @@ use bestool_tamanu::find_tamanu as _find_tamanu;
 
 #[cfg(feature = "tamanu-lifecycle")]
 pub mod lifecycle;
+#[cfg(feature = "tamanu-lifecycle")]
+mod probe;
 
 /// Interact with Tamanu.
 ///

--- a/crates/bestool/src/actions/tamanu/probe.rs
+++ b/crates/bestool/src/actions/tamanu/probe.rs
@@ -1,0 +1,112 @@
+//! Shared HTTP readiness-probe helpers for the `tamanu` lifecycle
+//! subcommands.
+//!
+//! `restart` probes each freshly-rolled instance until it responds; `start`
+//! probes the behind-caddy services it brought up within a bounded budget.
+//! The probe URL construction (container IP for systemd, pm2 PORT for pm2)
+//! is shared so both commands target the same endpoint.
+
+use std::time::Duration;
+
+use jiff::SignedDuration;
+use miette::{IntoDiagnostic, Result, bail};
+use reqwest::{Client, Url};
+use tracing::{debug, info, warn};
+
+use bestool_tamanu::services::Supervisor;
+
+use crate::actions::tamanu::lifecycle::{self, Instance};
+
+pub fn http_client() -> Result<Client> {
+	crate::http::client_builder()
+		.timeout(Duration::from_secs(5))
+		.build()
+		.into_diagnostic()
+}
+
+pub fn parse_duration(s: &str) -> Result<Duration, String> {
+	s.parse::<SignedDuration>()
+		.map_err(|e| e.to_string())
+		.and_then(|d| Duration::try_from(d).map_err(|e| e.to_string()))
+}
+
+/// Construct the readiness-probe URL for an instance, or `None` when one
+/// can't be built (no container IP for systemd, no pm_id or no PORT for
+/// pm2). Logs at warn/info the same way the callers expect.
+pub fn instance_probe_url(supervisor: Supervisor, instance: &Instance) -> Result<Option<Url>> {
+	let url = match supervisor {
+		Supervisor::Systemd => {
+			let unit = instance.unit();
+			match lifecycle::container_ip_for_unit(&unit)? {
+				Some(ip) => format!("http://{ip}:3000/").parse().into_diagnostic()?,
+				None => {
+					warn!(unit, "no container IP discovered, skipping HTTP probe");
+					return Ok(None);
+				}
+			}
+		}
+		Supervisor::Pm2 => {
+			let Some(pm_id) = instance.pm_id else {
+				warn!(name = %instance.name, "pm2 instance has no pm_id, skipping HTTP probe");
+				return Ok(None);
+			};
+			match lifecycle::pm2_port_for(pm_id)? {
+				Some(port) => format!("http://127.0.0.1:{port}/").parse().into_diagnostic()?,
+				None => {
+					info!(name = %instance.name, pm_id, "no PORT in pm2 env, skipping HTTP probe");
+					return Ok(None);
+				}
+			}
+		}
+	};
+	Ok(Some(url))
+}
+
+/// Retry `url` every 500ms until it returns a non-5xx response. Never gives
+/// up. Used for the per-instance readiness probe in the rolling restart,
+/// where the container is guaranteed to come up (or the operator can ctrl+c).
+pub async fn probe_until_ready(client: &Client, url: &Url) {
+	loop {
+		match probe_once(client, url).await {
+			Ok(()) => {
+				debug!(%url, "probe OK");
+				return;
+			}
+			Err(err) => {
+				debug!(%url, err = %err, "probe not ready, retrying");
+				tokio::time::sleep(Duration::from_millis(500)).await;
+			}
+		}
+	}
+}
+
+/// Bounded probe: retries with the same 500ms cadence but bails after
+/// `timeout`. Used where a failure is an operator-facing result — the
+/// post-restart `--check-url` end-to-end check and the post-start readiness
+/// budget.
+pub async fn probe_url(client: &Client, url: &Url, timeout: Duration) -> Result<()> {
+	let deadline = std::time::Instant::now() + timeout;
+	loop {
+		match probe_once(client, url).await {
+			Ok(()) => {
+				debug!(%url, "probe OK");
+				return Ok(());
+			}
+			Err(last_err) => {
+				if std::time::Instant::now() >= deadline {
+					bail!("HTTP probe of {url} failed: {last_err}");
+				}
+				debug!(%url, err = %last_err, "probe not ready, retrying");
+				tokio::time::sleep(Duration::from_millis(500)).await;
+			}
+		}
+	}
+}
+
+async fn probe_once(client: &Client, url: &Url) -> std::result::Result<(), String> {
+	match client.get(url.clone()).send().await {
+		Ok(resp) if !resp.status().is_server_error() => Ok(()),
+		Ok(resp) => Err(format!("HTTP {}", resp.status())),
+		Err(e) => Err(e.to_string()),
+	}
+}

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
 use clap::Parser;
-use jiff::SignedDuration;
-use miette::{IntoDiagnostic, Result, bail};
+use miette::Result;
 use reqwest::{Client, Url};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use bestool_tamanu::{
 	services::{self, ExpectedState, Expectation, Supervisor},
@@ -16,6 +15,7 @@ use crate::actions::{
 	tamanu::{
 		TamanuArgs,
 		lifecycle::{self, Instance, WaitForDb},
+		probe,
 	},
 };
 
@@ -37,7 +37,7 @@ pub struct RestartArgs {
 	/// disabled (`--no-probe-http`). With probes enabled, the readiness
 	/// probe is the signal — once a fresh instance responds, we move on
 	/// to the next without waiting out the cooldown.
-	#[arg(long, default_value = "30s", value_parser = parse_duration)]
+	#[arg(long, default_value = "30s", value_parser = probe::parse_duration)]
 	pub cooldown: Duration,
 
 	/// Skip the per-instance HTTP probe. Useful if the deployment isn't
@@ -50,12 +50,6 @@ pub struct RestartArgs {
 	/// end-to-end reachability. Bails non-zero if the probe fails.
 	#[arg(long, value_name = "URL")]
 	pub check_url: Option<Url>,
-}
-
-fn parse_duration(s: &str) -> Result<Duration, String> {
-	s.parse::<SignedDuration>()
-		.map_err(|e| e.to_string())
-		.and_then(|d| Duration::try_from(d).map_err(|e| e.to_string()))
 }
 
 pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
@@ -76,7 +70,7 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 		bulk_behind_caddy,
 		rolling,
 	} = partition(supervisor, &groups);
-	let client = http_client()?;
+	let client = probe::http_client()?;
 
 	if !bulk.is_empty() {
 		info!(targets = ?bulk, "bulk-restarting non-rolling services");
@@ -135,7 +129,7 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 
 	if let Some(url) = &args.check_url {
 		info!(%url, "final end-to-end probe");
-		probe_url(&client, url, Duration::from_secs(60)).await?;
+		probe::probe_url(&client, url, Duration::from_secs(60)).await?;
 	}
 
 	Ok(())
@@ -204,13 +198,6 @@ async fn bulk_restart(supervisor: Supervisor, targets: &[String]) -> Result<()> 
 	}
 }
 
-fn http_client() -> Result<Client> {
-	crate::http::client_builder()
-		.timeout(Duration::from_secs(5))
-		.build()
-		.into_diagnostic()
-}
-
 /// Probe a freshly-restarted instance until it responds.
 ///
 /// Returns `Ok(true)` when the probe loop got a non-5xx response, `Ok(false)`
@@ -222,82 +209,11 @@ async fn probe_instance(
 	instance: &Instance,
 	client: &Client,
 ) -> Result<bool> {
-	let url = match supervisor {
-		Supervisor::Systemd => {
-			let unit = instance.unit();
-			match lifecycle::container_ip_for_unit(&unit)? {
-				Some(ip) => format!("http://{ip}:3000/").parse().into_diagnostic()?,
-				None => {
-					warn!(unit, "no container IP discovered, skipping HTTP probe");
-					return Ok(false);
-				}
-			}
-		}
-		Supervisor::Pm2 => {
-			let Some(pm_id) = instance.pm_id else {
-				warn!(name = %instance.name, "pm2 instance has no pm_id, skipping HTTP probe");
-				return Ok(false);
-			};
-			match lifecycle::pm2_port_for(pm_id)? {
-				Some(port) => format!("http://127.0.0.1:{port}/").parse().into_diagnostic()?,
-				None => {
-					info!(name = %instance.name, pm_id, "no PORT in pm2 env, skipping HTTP probe");
-					return Ok(false);
-				}
-			}
-		}
+	let Some(url) = probe::instance_probe_url(supervisor, instance)? else {
+		return Ok(false);
 	};
-	probe_until_ready(client, &url).await;
+	probe::probe_until_ready(client, &url).await;
 	Ok(true)
-}
-
-/// Retry `url` every 500ms until it returns a non-5xx response. Never gives
-/// up. Used for the per-instance readiness probe in the rolling restart,
-/// where the container is guaranteed to come up (or the operator can ctrl+c).
-async fn probe_until_ready(client: &Client, url: &Url) {
-	loop {
-		match probe_once(client, url).await {
-			Ok(()) => {
-				debug!(%url, "probe OK");
-				return;
-			}
-			Err(err) => {
-				debug!(%url, err = %err, "probe not ready, retrying");
-				tokio::time::sleep(Duration::from_millis(500)).await;
-			}
-		}
-	}
-}
-
-/// Bounded probe used for the post-restart `--check-url` end-to-end check.
-/// Retries with the same 500ms cadence but bails after `timeout` — unlike
-/// the per-instance probe, a failure here is an actual operator-facing
-/// result (the user explicitly asked us to verify the URL).
-async fn probe_url(client: &Client, url: &Url, timeout: Duration) -> Result<()> {
-	let deadline = std::time::Instant::now() + timeout;
-	loop {
-		match probe_once(client, url).await {
-			Ok(()) => {
-				debug!(%url, "probe OK");
-				return Ok(());
-			}
-			Err(last_err) => {
-				if std::time::Instant::now() >= deadline {
-					bail!("HTTP probe of {url} failed: {last_err}");
-				}
-				debug!(%url, err = %last_err, "probe not ready, retrying");
-				tokio::time::sleep(Duration::from_millis(500)).await;
-			}
-		}
-	}
-}
-
-async fn probe_once(client: &Client, url: &Url) -> std::result::Result<(), String> {
-	match client.get(url.clone()).send().await {
-		Ok(resp) if !resp.status().is_server_error() => Ok(()),
-		Ok(resp) => Err(format!("HTTP {}", resp.status())),
-		Err(e) => Err(e.to_string()),
-	}
 }
 
 #[cfg(test)]

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -1,7 +1,12 @@
-use std::collections::HashSet;
+use std::{
+	collections::HashSet,
+	process::{Child, Command, Stdio},
+	time::{Duration, Instant},
+};
 
 use clap::Parser;
-use miette::{IntoDiagnostic, Result, bail};
+use miette::{IntoDiagnostic, Result, WrapErr, bail};
+use tracing::{debug, info, warn};
 
 use bestool_tamanu::{
 	services::{self, ExpectedState, Expectation, Supervisor},
@@ -13,6 +18,7 @@ use crate::actions::{
 	tamanu::{
 		TamanuArgs,
 		lifecycle::{self, Instance, WaitForDb},
+		probe,
 	},
 };
 
@@ -26,6 +32,13 @@ use crate::actions::{
 ///
 /// Idempotent: services already in the expected state are left alone.
 /// Use `tamanu status` first to see what's drifted.
+///
+/// After starting, the behind-caddy HTTP services (API, frontend, patient
+/// portal) are probed for readiness within a one-minute budget
+/// (`--probe-timeout`); if any don't come up, `start` bails. Pass
+/// `--no-probe-http` to skip the check. With `--logs`, the tamanu service
+/// logs are streamed for the duration of the start so the operator can
+/// watch startup.
 #[derive(Debug, Clone, Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct StartArgs {
@@ -39,6 +52,18 @@ pub struct StartArgs {
 	/// because you're mid-investigation).
 	#[arg(long)]
 	pub up_only: bool,
+
+	/// Skip the post-start HTTP readiness probe.
+	#[arg(long)]
+	pub no_probe_http: bool,
+
+	/// How long to wait for started services to pass their readiness probe before bailing.
+	#[arg(long, default_value = "1m", value_parser = probe::parse_duration)]
+	pub probe_timeout: Duration,
+
+	/// Stream tamanu service logs while starting.
+	#[arg(long)]
+	pub logs: bool,
 }
 
 pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
@@ -93,6 +118,21 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 
 	lifecycle::ensure_root_or_reexec(supervisor)?;
 
+	// Spawn the log follower (if requested) before issuing the start, so the
+	// operator sees startup output as it happens. The guard's Drop kills the
+	// follower when `run` returns — on success or on a bail from the probe
+	// phase below.
+	let _follower = if args.logs {
+		let log_targets: Vec<String> = groups
+			.iter()
+			.filter(|(exp, _)| exp.state == ExpectedState::Up)
+			.map(|(exp, _)| exp.name.to_string())
+			.collect();
+		spawn_log_follower(supervisor, &log_targets)
+	} else {
+		None
+	};
+
 	if !stop_plan.is_empty() {
 		execute_stop(supervisor, &stop_plan).await?;
 	}
@@ -117,7 +157,121 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 		lifecycle::reload_caddy().await;
 	}
 
+	// Verify the behind-caddy HTTP services actually came up. The supervisor
+	// reporting the unit active isn't the same as the container accepting
+	// connections, so probe each within a single overall budget and bail if
+	// any fails to respond in time.
+	if started_behind_caddy && !args.no_probe_http {
+		let discovered = lifecycle::discover(supervisor).await?;
+		let groups = lifecycle::group_by_expectation(&matched, &discovered);
+		let to_probe = instances_to_probe(&groups);
+		probe_started(supervisor, &to_probe, args.probe_timeout).await?;
+	}
+
 	Ok(())
+}
+
+/// Select the running, behind-caddy, expected-Up instances to probe after a
+/// start. Excludes non-behind-caddy, non-running, and non-Up instances.
+fn instances_to_probe(groups: &[(&Expectation, Vec<Instance>)]) -> Vec<Instance> {
+	let mut out = Vec::new();
+	for (exp, instances) in groups {
+		if exp.state != ExpectedState::Up || !exp.behind_caddy {
+			continue;
+		}
+		for inst in instances {
+			if inst.running {
+				out.push(inst.clone());
+			}
+		}
+	}
+	out
+}
+
+/// Probe every selected instance for readiness within a single overall
+/// deadline. Bails (naming the instance) on the first one that doesn't pass
+/// in time. Instances without a constructable probe URL are skipped.
+async fn probe_started(
+	supervisor: Supervisor,
+	instances: &[Instance],
+	timeout: Duration,
+) -> Result<()> {
+	if instances.is_empty() {
+		return Ok(());
+	}
+	let client = probe::http_client()?;
+	let deadline = Instant::now() + timeout;
+	for inst in instances {
+		let Some(url) = probe::instance_probe_url(supervisor, inst)? else {
+			debug!(instance = %inst.display(), "no probe URL, skipping readiness check");
+			continue;
+		};
+		let remaining = deadline.saturating_duration_since(Instant::now());
+		if remaining.is_zero() {
+			bail!(
+				"readiness probe budget exhausted before probing {}",
+				inst.display()
+			);
+		}
+		info!(instance = %inst.display(), %url, "probing started service for readiness");
+		probe::probe_url(&client, &url, remaining)
+			.await
+			.wrap_err_with(|| format!("{} did not become ready", inst.display()))?;
+	}
+	Ok(())
+}
+
+/// Holds a spawned log-follower child process and kills it on drop, so the
+/// follower lives exactly as long as the `start` work and is torn down on
+/// both success and bail.
+struct LogFollower {
+	child: Child,
+}
+
+impl Drop for LogFollower {
+	fn drop(&mut self) {
+		let _ = self.child.kill();
+		let _ = self.child.wait();
+	}
+}
+
+/// Spawn a log follower for the given service base names, inheriting stdio so
+/// its output interleaves with `start`'s progress logs. Spawn failures are
+/// non-fatal: warn and return `None`.
+fn spawn_log_follower(supervisor: Supervisor, targets: &[String]) -> Option<LogFollower> {
+	if targets.is_empty() {
+		return None;
+	}
+	let mut cmd = match supervisor {
+		Supervisor::Systemd => {
+			let mut cmd = Command::new("journalctl");
+			cmd.args(["-f", "-n", "0"]);
+			for t in targets {
+				cmd.arg("-u").arg(format!("{t}*"));
+			}
+			cmd
+		}
+		Supervisor::Pm2 => {
+			let mut deduped: Vec<&String> = Vec::new();
+			for t in targets {
+				if !deduped.contains(&t) {
+					deduped.push(t);
+				}
+			}
+			let mut cmd = Command::new("pm2");
+			cmd.args(["logs", "--lines", "0"]);
+			cmd.args(deduped);
+			cmd
+		}
+	};
+	cmd.stdin(Stdio::null());
+	match cmd.spawn() {
+		Ok(child) => Some(LogFollower { child }),
+		Err(err) => {
+			warn!(%err, "could not start log follower; continuing without it");
+			None
+		}
+	}
 }
 
 /// What `plan_stop` decided to do for the Down-side normalisation phase.
@@ -551,5 +705,76 @@ mod tests {
 		)];
 		let plan = plan_stop(Supervisor::Pm2, &groups, |_| false);
 		assert_eq!(plan.delete, vec!["tamanu-fhir-resolve"]);
+	}
+
+	fn down_behind_caddy_exp(name: &'static str) -> Expectation {
+		Expectation {
+			name,
+			instances: Instances::Single,
+			state: ExpectedState::Down,
+			reason: "test".into(),
+			legacy: false,
+			behind_caddy: true,
+		}
+	}
+
+	fn inst(name: &str, running: bool) -> Instance {
+		Instance {
+			name: name.into(),
+			instance: None,
+			pm_id: None,
+			running,
+		}
+	}
+
+	#[test]
+	fn instances_to_probe_includes_behind_caddy_running_up() {
+		let api = exp("tamanu-central-api", true);
+		let groups = vec![(&api, vec![inst("tamanu-central-api", true)])];
+		let probed = instances_to_probe(&groups);
+		assert_eq!(probed.len(), 1);
+		assert_eq!(probed[0].name, "tamanu-central-api");
+	}
+
+	#[test]
+	fn instances_to_probe_excludes_non_behind_caddy() {
+		let tasks = exp("tamanu-central-tasks", false);
+		let groups = vec![(&tasks, vec![inst("tamanu-central-tasks", true)])];
+		assert!(instances_to_probe(&groups).is_empty());
+	}
+
+	#[test]
+	fn instances_to_probe_excludes_not_running() {
+		let api = exp("tamanu-central-api", true);
+		let groups = vec![(&api, vec![inst("tamanu-central-api", false)])];
+		assert!(instances_to_probe(&groups).is_empty());
+	}
+
+	#[test]
+	fn instances_to_probe_excludes_non_up() {
+		// Down (and Unknown) behind-caddy services must not be probed — we
+		// didn't start them, so their readiness is none of start's business.
+		let portal = down_behind_caddy_exp("tamanu-patientportal");
+		let unknown = unknown_exp("tamanu-patientportal-2");
+		let groups = vec![
+			(&portal, vec![inst("tamanu-patientportal", true)]),
+			(&unknown, vec![inst("tamanu-patientportal-2", true)]),
+		];
+		assert!(instances_to_probe(&groups).is_empty());
+	}
+
+	#[test]
+	fn instances_to_probe_mixed_batch_keeps_only_eligible() {
+		let api = exp("tamanu-central-api", true);
+		let tasks = exp("tamanu-central-tasks", false);
+		let portal = down_behind_caddy_exp("tamanu-patientportal");
+		let groups = vec![
+			(&api, vec![inst("tamanu-central-api", true)]),
+			(&tasks, vec![inst("tamanu-central-tasks", true)]),
+			(&portal, vec![inst("tamanu-patientportal", true)]),
+		];
+		let probed = instances_to_probe(&groups);
+		assert_eq!(probed.len(), 1);
+		assert_eq!(probed[0].name, "tamanu-central-api");
 	}
 }


### PR DESCRIPTION
🤖 `tamanu start` previously returned as soon as the supervisor reported the units active — but an active unit isn't the same as the container accepting connections, so a service could be "started" yet not actually serving. This makes `start` verify readiness using the same HTTP probes the `restart` command already had, and adds a `--logs` option to watch startup.

First commit extracts the probe primitives (`http_client`, `probe_until_ready`, `probe_url`, `probe_once`, `parse_duration`, and the probe-URL construction) out of `restart.rs` into a shared `probe` module, with `restart` delegating to it — no behaviour change.

Second commit adds to `start`:
- After the post-start caddy reload, it re-discovers the now-running services and probes every behind-caddy, expected-Up instance for readiness within a single overall budget (`--probe-timeout`, default 1m). If any fails to respond in time, `start` bails with an error naming the service. `--no-probe-http` skips the check.
- `--logs` streams the tamanu service logs (journalctl on systemd, pm2 logs on Windows) for the duration of the start, torn down via a Drop guard when the command returns (on success or bail).

The instance-selection logic is a pure helper covered by unit tests; the Windows build was cross-checked.
