### PR TITLE
ci: generate release changelogs in PRs without committing CHANGELOG.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
 *.txt
 /testfiles
+
+# release-plz generates these to populate the release PR body; we don't commit
+# them (matches CHANGELOG.md in the repo root and every crate directory).
+CHANGELOG.md

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,11 @@
 pr_name = "repo: release"
 pr_branch_prefix = "release-plz/"
 pr_labels = ["autorelease"]
-changelog_update = false
+# Generate changelogs so the release PR body lists the changes, but keep them
+# out of the repo: CHANGELOG.md is gitignored, so release-plz writes it to
+# populate the PR body without committing it. GitHub release notes are derived
+# from the committed file, so they stay empty by design.
+changelog_update = true
 git_tag_name = "{{ package }}-v{{ version }}"
 
 [[package]]


### PR DESCRIPTION
🤖 The release-plz config had `changelog_update = false`, which turned out to suppress changelog generation entirely — the most recent release PR (#425) and the GitHub release notes for v1.18.3 / bestool-tamanu-v0.9.1 all came out with empty changelog bodies.

This re-enables changelog generation so the release PR body lists the changes, and gitignores CHANGELOG.md so release-plz writes the file only to populate the PR body and never commits it to the repo. No CHANGELOG.md files are tracked, so there's nothing to remove.

Since release-plz only runs in CI, the no-commit behaviour with a gitignored changelog should be confirmed on the next release PR.
