### PR TITLE
fix(tamanu): find caddy at C:\Caddy\caddy.exe when not on PATH

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -567,7 +567,7 @@ pub async fn reload_caddy() {
 	// API on the caddy process's behalf. Same end-state as the admin-API
 	// path above; this fallback handles the case where caddy is running
 	// but the admin endpoint is locked down or relocated.
-	let status = Command::new("caddy")
+	let status = Command::new(bestool_tamanu::caddy::program())
 		.args(["reload", "--config", path, "--adapter", "caddyfile"])
 		.status();
 	match status {

--- a/crates/tamanu/src/caddy.rs
+++ b/crates/tamanu/src/caddy.rs
@@ -1,0 +1,21 @@
+//! Locating the caddy executable.
+
+use std::path::PathBuf;
+
+/// The caddy executable to invoke.
+///
+/// On Windows, caddy is installed at `C:\Caddy\caddy.exe` and isn't
+/// necessarily on `PATH`; prefer that explicit location when it's present so
+/// the version healthcheck and the reload work on a stock install rather than
+/// silently skipping. Everywhere else — and as the Windows fallback — we rely
+/// on `caddy` being resolvable via `PATH`.
+pub fn program() -> PathBuf {
+	#[cfg(windows)]
+	{
+		let installed = PathBuf::from(r"C:\Caddy\caddy.exe");
+		if installed.is_file() {
+			return installed;
+		}
+	}
+	PathBuf::from("caddy")
+}

--- a/crates/tamanu/src/doctor/checks/caddy_version.rs
+++ b/crates/tamanu/src/doctor/checks/caddy_version.rs
@@ -18,7 +18,7 @@ use node_semver::Version;
 use tokio::process::Command;
 
 use super::CheckContext;
-use crate::doctor::check::Check;
+use crate::{caddy, doctor::check::Check};
 
 const CHECK_NAME: &str = "caddy_version";
 
@@ -34,7 +34,7 @@ pub async fn run(_ctx: CheckContext) -> Check {
 		}
 	};
 
-	let output = match Command::new("caddy").arg("version").output().await {
+	let output = match Command::new(caddy::program()).arg("version").output().await {
 		Ok(o) if o.status.success() => o,
 		Ok(o) => {
 			let stderr = String::from_utf8_lossy(&o.stderr);

--- a/crates/tamanu/src/lib.rs
+++ b/crates/tamanu/src/lib.rs
@@ -7,6 +7,7 @@ use miette::{IntoDiagnostic, Result, miette};
 use node_semver::Version;
 use tracing::{debug, instrument};
 
+pub mod caddy;
 pub mod config;
 pub mod connection_url;
 pub mod pm2;


### PR DESCRIPTION
🤖 On Windows, caddy is installed at `C:\Caddy\caddy.exe` and isn't necessarily on `PATH`. The `caddy_version` healthcheck invoked `caddy` by name and, when it wasn't on `PATH`, silently returned `SKIP` ("caddy not found") — so a stock Windows install got no caddy version signal. The reload CLI fallback (`reload_caddy`) had the same `PATH` dependency.

The `C:\Caddy` directory was already the convention everywhere else — the Caddyfile (`DEFAULT_CADDYFILE_PATH`, `backup_configs`, the reload `--config`) and the logs (`tamanu logs caddy`) — but nothing resolved the *binary* there.

This adds `bestool_tamanu::caddy::program()`, which prefers `C:\Caddy\caddy.exe` on Windows when it exists and otherwise falls back to `caddy` on `PATH` (non-Windows is unchanged), and uses it in both the version check and `reload_caddy`.
