### PR TITLE
chore: clippy round across the workspace

### DIFF
--- a/crates/bestool/src/actions/iti/battery.rs
+++ b/crates/bestool/src/actions/iti/battery.rs
@@ -126,8 +126,7 @@ pub async fn once(args: &BatteryArgs, rolling: Option<&mut VecDeque<f64>>) -> Re
 				Some(curr - pre)
 			})
 			.enumerate()
-			.filter(|(n, diff)| *n >= 4.min(rolling.len() - 1) && *diff != 0.0)
-			.next()
+			.find(|(n, diff)| *n >= 4.min(rolling.len() - 1) && *diff != 0.0)
 			.map(|(n, _)| n)
 			.unwrap_or(rolling.len() - 1);
 
@@ -239,7 +238,7 @@ pub async fn once(args: &BatteryArgs, rolling: Option<&mut VecDeque<f64>>) -> Re
 		const BLACK: [u8; 3] = [0, 0, 0];
 		const WHITE: [u8; 3] = [255, 255, 255];
 
-		let (fill, stroke) = if estimates.as_ref().map_or(false, |(rate, _)| *rate > 0.0) {
+		let (fill, stroke) = if estimates.as_ref().is_some_and(|(rate, _)| *rate > 0.0) {
 			(GREEN, BLACK)
 		} else if capacity <= 3.0 {
 			(RED, WHITE)
@@ -273,7 +272,12 @@ pub async fn once(args: &BatteryArgs, rolling: Option<&mut VecDeque<f64>>) -> Re
 				..Default::default()
 			});
 			(18, 254)
-		} else if estimates.is_some_and(|(rate, _)| !(rate > 0.0) && !(rate < -0.0)) {
+		} else if estimates.is_some_and(|(rate, _)| {
+			!matches!(
+				rate.partial_cmp(&0.0),
+				Some(std::cmp::Ordering::Less | std::cmp::Ordering::Greater)
+			)
+		}) {
 			if capacity == 100.0 {
 				items.push(Item {
 					x: 20,

--- a/crates/bestool/src/actions/iti/lcd.rs
+++ b/crates/bestool/src/actions/iti/lcd.rs
@@ -219,7 +219,7 @@ fn loop_inner(
 	let polled = zmq::poll(&mut polls, 1000)
 		.into_diagnostic()
 		.wrap_err("zmq: poll")?;
-	if running.load(Ordering::SeqCst) == false {
+	if !running.load(Ordering::SeqCst) {
 		info!("ctrl-c received, exiting");
 		return Ok(ControlFlow::Break(()));
 	}

--- a/crates/bestool/src/actions/iti/sparks.rs
+++ b/crates/bestool/src/actions/iti/sparks.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, iter::repeat, time::Duration};
+use std::{collections::VecDeque, iter::repeat_n, time::Duration};
 
 use clap::Parser;
 use miette::Result;
@@ -144,7 +144,7 @@ pub fn render(
 		FG_MEM,
 	));
 
-	send(&zmq_socket, Screen::Layout(items))?;
+	send(zmq_socket, Screen::Layout(items))?;
 
 	Ok(())
 }
@@ -156,8 +156,7 @@ fn spark_line<'a>(
 	height: i32,
 	colour: [u8; 3],
 ) -> impl Iterator<Item = Item> + 'a {
-	repeat(0.0)
-		.take((INNER_WIDTH as usize).saturating_sub(data.len()))
+	repeat_n(0.0, (INNER_WIDTH as usize).saturating_sub(data.len()))
 		.chain(data)
 		.map(move |v| {
 			let v = v.clamp(0.0, 1.0);


### PR DESCRIPTION
🤖 Final step of the healthcheck-consolidation series (stacked on #442). A workspace-wide clippy round addressing every warning, regardless of which crate it belongs to.

`cargo clippy --workspace --all-targets --all-features` fixes (all in the bestool iti modules):
- `battery.rs`: `filter(..).next()` → `find(..)`; `map_or(false, ..)` → `is_some_and(..)`; the partial-ord negation rewritten via `partial_cmp` (preserving the NaN/zero behaviour).
- `lcd.rs`: `== false` → `!`.
- `sparks.rs`: dropped a needless borrow; `repeat(0.0).take(n)` → `repeat_n(0.0, n)`.

The whole stack is now rebased on current main, builds clean, `cargo fmt --check` clean, zero clippy warnings, tests pass against the local central DB, and the Windows GNU cross-check is clean.
