### PR TITLE
feat(algae): re-export age's SecretString and ExposeSecret

### DIFF
--- a/crates/algae-cli/src/lib.rs
+++ b/crates/algae-cli/src/lib.rs
@@ -71,8 +71,7 @@
 //! Or you can prompt for a passphrase with the same flags and logic as algae with:
 //!
 //! ```no_run
-//! use age::secrecy::ExposeSecret;
-//! use algae_cli::passphrases::PassphraseArgs;
+//! use algae_cli::passphrases::{ExposeSecret, PassphraseArgs};
 //! use clap::Parser;
 //! use miette::Result;
 //!

--- a/crates/algae-cli/src/passphrases.rs
+++ b/crates/algae-cli/src/passphrases.rs
@@ -1,11 +1,15 @@
 use std::path::PathBuf;
 
-use age::{secrecy::SecretString, Identity, Recipient};
+use age::{Identity, Recipient};
 use clap::Parser;
 use dialoguer::Password;
 use miette::{miette, Context as _, IntoDiagnostic as _, Result};
 use pinentry::PassphraseInput;
 use tokio::fs::read_to_string;
+
+/// Re-exported from [`age`] so dependents can name and read passphrase secrets
+/// without taking a direct dependency on age.
+pub use age::secrecy::{ExposeSecret, SecretString};
 
 /// [Clap][clap] arguments for passphrases.
 ///


### PR DESCRIPTION
🤖 Re-export age's `SecretString` and `ExposeSecret` from `algae_cli::passphrases`.

Dependents that obtain a passphrase via `PassphraseArgs` (e.g. `require_phrase`) otherwise had to add a direct dependency on `age` just to name or read the returned `SecretString`. Re-exporting both makes algae self-contained for passphrase secret handling, so consumers can use it without pulling in `age` themselves.

Also updates the library doc example to import these from algae rather than `age` directly.
