### PR TITLE
fix(canopy): follow canopy API drift; add live-spec contract tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +167,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -566,6 +586,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "json5",
+ "jsonschema",
  "leon",
  "leon-macros",
  "lloggs",
@@ -1008,6 +1029,12 @@ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boxcar"
@@ -2124,6 +2151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,6 +2360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2536,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2850,7 +2914,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3648,6 +3723,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jwalk"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +4071,12 @@ dependencies = [
  "portable-atomic",
  "rapidhash",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "micromath"
@@ -4297,6 +4405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4563,6 +4677,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oval"
@@ -5573,6 +5693,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -6689,7 +6846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "flate2",
  "fnv",
  "once_cell",
@@ -7665,6 +7822,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7791,6 +7954,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7813,6 +7986,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -194,6 +194,7 @@ walg = []
 
 [dev-dependencies]
 age = { version = "0.11.3", features = ["async"] }
+jsonschema = { version = "0.46.5", default-features = false }
 trycmd = "1.2.0"
 
 [package.metadata.binstall]

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1892,8 +1892,9 @@ sub-process to talk to.
 
 Fetch this device's tags from canopy.
 
-Tags are stored server-side in canopy and identify what role / fleet /
-labels this device carries. The fetch is authenticated by the canopy
+Tags are key→value labels stored server-side in canopy, identifying what
+role / fleet / labels this device carries; the server's own tags are
+merged over its group's. The fetch is authenticated by the canopy
 client (tailscale identity, or mTLS with the device key).
 
 On a successful fetch the result is cached to disk alongside the
@@ -1906,7 +1907,7 @@ human-readable output.
 
 ###### **Options:**
 
-* `--json` — Emit the tags as JSON rather than a human-readable list
+* `--json` — Emit the tags as JSON rather than a human-readable table
 * `--offline` — Skip the network fetch and print whatever's in the cache, without trying canopy first. Useful for fully-offline diagnostic runs
 
 

--- a/crates/bestool/src/actions/canopy/register.rs
+++ b/crates/bestool/src/actions/canopy/register.rs
@@ -67,31 +67,31 @@ struct EnrollTicket {
 }
 
 #[derive(Serialize)]
-struct BeginRequest<'a> {
-	server_id: &'a str,
-	token: &'a str,
+pub(crate) struct BeginRequest<'a> {
+	pub(crate) server_id: &'a str,
+	pub(crate) token: &'a str,
 	/// DER SubjectPublicKeyInfo (base64), sent only over the tailscale path
 	/// where there's no client cert for canopy to read it from.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	spki: Option<&'a str>,
+	pub(crate) spki: Option<&'a str>,
 }
 
 #[derive(Deserialize)]
-struct BeginResponse {
-	nonce: String,
+pub(crate) struct BeginResponse {
+	pub(crate) nonce: String,
 	#[serde(default)]
-	channel_binding_required: bool,
+	pub(crate) channel_binding_required: bool,
 }
 
 #[derive(Serialize)]
-struct CompleteRequest<'a> {
-	server_id: &'a str,
-	nonce: &'a str,
-	signature: &'a str,
+pub(crate) struct CompleteRequest<'a> {
+	pub(crate) server_id: &'a str,
+	pub(crate) nonce: &'a str,
+	pub(crate) signature: &'a str,
 	/// DER SubjectPublicKeyInfo (base64), sent only over the tailscale path
 	/// where there's no client cert for canopy to read it from.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	spki: Option<&'a str>,
+	pub(crate) spki: Option<&'a str>,
 }
 
 /// Which network path the enrollment handshake takes.
@@ -134,9 +134,9 @@ impl Transport {
 }
 
 #[derive(Deserialize)]
-struct CompleteResponse {
-	server_id: String,
-	device_id: String,
+pub(crate) struct CompleteResponse {
+	pub(crate) server_id: String,
+	pub(crate) device_id: String,
 }
 
 /// RFC-7807-style problem body. Canopy's register errors are intentionally

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -18,10 +18,10 @@ use bestool_tamanu::{config::load_config, connection_url::ConnectionUrlBuilder};
 use super::{TamanuArgs, find_tamanu};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct Snippet {
-	sql: String,
+pub(crate) struct Snippet {
+	pub(crate) sql: String,
 	#[serde(default)]
-	description: Option<String>,
+	pub(crate) description: Option<String>,
 }
 
 /// Asynchronous snippet provider that fetches snippets from an API.

--- a/crates/bestool/src/actions/tamanu/tags.rs
+++ b/crates/bestool/src/actions/tamanu/tags.rs
@@ -8,7 +8,7 @@
 //! online fetch always overwrites it; an offline run consults whatever was
 //! last cached and warns that the data may be stale.
 
-use std::{path::Path, sync::Arc};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use bestool_canopy::{CanopyClient, DEFAULT_CANOPY_URL};
 use clap::Parser;
@@ -27,8 +27,9 @@ use crate::actions::{
 
 /// Fetch this device's tags from canopy.
 ///
-/// Tags are stored server-side in canopy and identify what role / fleet /
-/// labels this device carries. The fetch is authenticated by the canopy
+/// Tags are key→value labels stored server-side in canopy, identifying what
+/// role / fleet / labels this device carries; the server's own tags are
+/// merged over its group's. The fetch is authenticated by the canopy
 /// client (tailscale identity, or mTLS with the device key).
 ///
 /// On a successful fetch the result is cached to disk alongside the
@@ -39,7 +40,7 @@ use crate::actions::{
 #[derive(Debug, Clone, Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct TagsArgs {
-	/// Emit the tags as JSON rather than a human-readable list.
+	/// Emit the tags as JSON rather than a human-readable table.
 	#[arg(long)]
 	pub json: bool,
 
@@ -51,13 +52,16 @@ pub struct TagsArgs {
 
 /// On-disk shape for the tags cache.
 ///
-/// Wraps the bare tag list in a struct so we can carry a `fetched_at`
-/// timestamp for "how stale is this cache" reporting. Forward-compatible
-/// against future fields by being a named-fields struct rather than just
-/// `Vec<String>`.
+/// Wraps the tag map in a struct so we can carry a `fetched_at` timestamp
+/// for "how stale is this cache" reporting. Forward-compatible against
+/// future fields by being a named-fields struct rather than just the map.
+///
+/// Caches written before tags became a key→value map (when they were a bare
+/// list) fail to parse and are ignored by [`load_cache`], same as any other
+/// unparseable cache.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct TagsCache {
-	tags: Vec<String>,
+	tags: BTreeMap<String, String>,
 	#[serde(default)]
 	fetched_at: Option<jiff::Timestamp>,
 }
@@ -116,7 +120,7 @@ enum Source {
 	Cache(Option<jiff::Timestamp>),
 }
 
-async fn fetch_online(tamanu_version: &str) -> Result<Vec<String>> {
+async fn fetch_online(tamanu_version: &str) -> Result<BTreeMap<String, String>> {
 	let device_key = bestool_tamanu::server_info::fetch_device_key().await;
 	let canopy = CanopyClient::new(
 		tamanu_version.to_owned(),
@@ -136,28 +140,28 @@ async fn fetch_online(tamanu_version: &str) -> Result<Vec<String>> {
 		.into_diagnostic()
 		.wrap_err("parsing canopy base URL")?;
 
-	// `/public/tags/self` is reachable from tagged-device tailscale callers
-	// (the only mount that admits them); `/tags/self` is the mTLS path on
-	// the main canopy host.
+	// `/public/tags` is reachable from tagged-device tailscale callers
+	// (the only mount that admits them); `/tags` is the mTLS path on
+	// the main canopy host. Returns the merged server+group tag map.
 	let response = canopy
-		.get(&base, "/public/tags/self", "/tags/self")
+		.get(&base, "/public/tags", "/tags")
 		.await
-		.wrap_err("GET /tags/self via canopy")?;
+		.wrap_err("GET /tags via canopy")?;
 
 	let status = response.status();
 	if !status.is_success() {
 		let body = response.text().await.unwrap_or_default();
-		bail!("canopy /tags/self returned {status}: {body}");
+		bail!("canopy /tags returned {status}: {body}");
 	}
 
 	response
-		.json::<Vec<String>>()
+		.json::<BTreeMap<String, String>>()
 		.await
 		.into_diagnostic()
 		.wrap_err("decoding canopy tags response")
 }
 
-fn render_json(tags: &[String], source: Source) -> Result<()> {
+fn render_json(tags: &BTreeMap<String, String>, source: Source) -> Result<()> {
 	let payload = serde_json::json!({
 		"tags": tags,
 		"source": match source {
@@ -175,15 +179,15 @@ fn render_json(tags: &[String], source: Source) -> Result<()> {
 	Ok(())
 }
 
-fn render_text(tags: &[String], source: Source, use_colours: bool) -> Result<()> {
+fn render_text(tags: &BTreeMap<String, String>, source: Source, use_colours: bool) -> Result<()> {
 	if tags.is_empty() {
 		println!("(no tags assigned)");
 	} else {
 		let mut table = Table::new();
 		table.load_preset(NOTHING);
-		table.set_header(Row::from(vec!["Tag"]));
-		for t in tags {
-			table.add_row(Row::from(vec![t.clone()]));
+		table.set_header(Row::from(vec!["Tag", "Value"]));
+		for (key, value) in tags {
+			table.add_row(Row::from(vec![key.clone(), value.clone()]));
 		}
 		println!("{table}");
 	}

--- a/crates/bestool/src/canopy_contract.rs
+++ b/crates/bestool/src/canopy_contract.rs
@@ -1,0 +1,332 @@
+//! Contract tests against the live canopy OpenAPI spec.
+//!
+//! Fetches `https://meta.tamanu.app/api/openapi.json` and checks that every
+//! canopy endpoint bestool calls exists, that the payloads bestool sends
+//! validate against the spec's request schemas, and that spec-valid response
+//! samples decode into bestool's types. These tests need network access, and
+//! fail honestly when live canopy doesn't (yet) serve an endpoint bestool
+//! depends on.
+
+use std::collections::BTreeMap;
+
+use bestool_canopy::{NewEvent, Severity};
+use serde_json::{Value, json};
+use tokio::sync::OnceCell;
+
+use crate::actions::{
+	canopy::register::{BeginRequest, BeginResponse, CompleteRequest, CompleteResponse},
+	tamanu::{artifacts::Artifact, psql::Snippet},
+};
+
+const SPEC_URL: &str = "https://meta.tamanu.app/api/openapi.json";
+
+async fn spec() -> &'static Value {
+	static SPEC: OnceCell<Value> = OnceCell::const_new();
+	SPEC.get_or_init(|| async {
+		reqwest::Client::new()
+			.get(SPEC_URL)
+			.send()
+			.await
+			.expect("fetching live canopy spec")
+			.error_for_status()
+			.expect("fetching live canopy spec")
+			.json()
+			.await
+			.expect("parsing live canopy spec")
+	})
+	.await
+}
+
+/// Escape a path segment for use in a JSON pointer (RFC 6901).
+fn escape(segment: &str) -> String {
+	segment.replace('~', "~0").replace('/', "~1")
+}
+
+/// Look up `pointer` in the spec, resolving a single level of `$ref`.
+fn resolve<'a>(spec: &'a Value, pointer: &str) -> &'a Value {
+	let value = spec
+		.pointer(pointer)
+		.unwrap_or_else(|| panic!("live canopy spec is missing {pointer}"));
+	match value.get("$ref").and_then(Value::as_str) {
+		Some(target) => spec
+			.pointer(target.trim_start_matches('#'))
+			.unwrap_or_else(|| panic!("dangling $ref {target} in live canopy spec")),
+		None => value,
+	}
+}
+
+/// Compile a validator for the schema at `pointer` within the spec.
+///
+/// The target schema is cloned out as the root, with the spec's `components`
+/// grafted alongside it so internal `#/components/schemas/...` references
+/// resolve. (A root `$ref` to the pointer would be neater, but path templates
+/// like `{server_id}` aren't valid in `$ref` URIs.)
+fn validator_at(spec: &Value, pointer: &str) -> jsonschema::Validator {
+	let mut root = spec
+		.pointer(pointer)
+		.unwrap_or_else(|| panic!("live canopy spec is missing {pointer}"))
+		.clone();
+	root.as_object_mut()
+		.unwrap_or_else(|| panic!("schema at {pointer} is not an object"))
+		.insert("components".into(), spec["components"].clone());
+	jsonschema::validator_for(&root)
+		.unwrap_or_else(|err| panic!("compiling schema at {pointer}: {err}"))
+}
+
+fn assert_operation_exists(spec: &Value, path: &str, method: &str) {
+	let pointer = format!("/paths/{}/{method}", escape(path));
+	assert!(
+		spec.pointer(&pointer).is_some(),
+		"live canopy does not serve {} {path}",
+		method.to_uppercase(),
+	);
+}
+
+fn assert_valid(spec: &Value, pointer: &str, instance: &Value) {
+	let validator = validator_at(spec, pointer);
+	let errors: Vec<String> = validator
+		.iter_errors(instance)
+		.map(|err| format!("{err} (at instance path `{}`)", err.instance_path()))
+		.collect();
+	assert!(
+		errors.is_empty(),
+		"instance does not validate against {pointer}:\n{errors:#?}\ninstance: {instance:#}",
+	);
+}
+
+fn request_schema(path: &str, method: &str) -> String {
+	format!(
+		"/paths/{}/{method}/requestBody/content/application~1json/schema",
+		escape(path),
+	)
+}
+
+fn response_schema(path: &str, method: &str) -> String {
+	format!(
+		"/paths/{}/{method}/responses/200/content/application~1json/schema",
+		escape(path),
+	)
+}
+
+#[tokio::test]
+async fn events_request_matches_spec() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/events", "post");
+
+	let event = NewEvent {
+		source: "bestool-contract-test",
+		r#ref: "host/alert:target",
+		message: "message",
+		description: Some("description"),
+		severity: Some(Severity::Warning),
+		occurred_at: Some("2026-01-01T00:00:00Z".parse().unwrap()),
+		active: Some(true),
+	};
+	let instance = serde_json::to_value(&event).unwrap();
+	assert_valid(spec, &request_schema("/events", "post"), &instance);
+
+	// Negative case, proving the validation isn't vacuous: a retired syslog
+	// severity must be rejected.
+	let mut invalid = instance.clone();
+	invalid["severity"] = json!("notice");
+	let validator = validator_at(spec, &request_schema("/events", "post"));
+	assert!(
+		!validator.is_valid(&invalid),
+		"spec validation accepted a retired severity; the validator is not checking refs",
+	);
+}
+
+#[tokio::test]
+async fn severity_vocabulary_matches_spec() {
+	let spec = spec().await;
+	let spec_levels: Vec<&str> = resolve(spec, "/components/schemas/Severity")
+		.get("enum")
+		.and_then(Value::as_array)
+		.expect("Severity schema has an enum")
+		.iter()
+		.map(|v| v.as_str().expect("Severity enum values are strings"))
+		.collect();
+
+	// Exhaustive match: adding a Severity variant breaks this and forces the
+	// list below to be updated.
+	use Severity::*;
+	const ALL: &[Severity] = &[Critical, Error, Warning, Info, Debug];
+	for severity in ALL {
+		match severity {
+			Critical | Error | Warning | Info | Debug => {}
+		}
+	}
+
+	let ours: Vec<String> = ALL
+		.iter()
+		.map(|s| {
+			serde_json::to_value(s)
+				.unwrap()
+				.as_str()
+				.unwrap()
+				.to_owned()
+		})
+		.collect();
+
+	for level in &spec_levels {
+		assert!(
+			serde_json::from_value::<Severity>(json!(level)).is_ok(),
+			"canopy severity {level:?} does not deserialise into bestool's Severity",
+		);
+	}
+	for level in &ours {
+		assert!(
+			spec_levels.contains(&level.as_str()),
+			"bestool severity {level:?} is not accepted by canopy (spec has {spec_levels:?})",
+		);
+	}
+}
+
+#[tokio::test]
+async fn status_request_matches_spec() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/status/{server_id}", "post");
+
+	// Representative sweep payload: the reserved `healthy`/`health` keys plus
+	// free-form extras, as posted by alertd's doctor task.
+	let instance = json!({
+		"healthy": false,
+		"health": [
+			{"check": "uptime", "healthy": true, "uptime_secs": 12345},
+			{"check": "disk", "healthy": false, "free_percent": 3},
+		],
+		"hostname": "test-host",
+		"pg_version": "16.4",
+	});
+	assert_valid(
+		spec,
+		&request_schema("/status/{server_id}", "post"),
+		&instance,
+	);
+}
+
+#[tokio::test]
+async fn servers_probe_path_exists() {
+	// `GET /servers` is the no-auth probe `CanopyClient` uses to detect the
+	// tailscale path.
+	assert_operation_exists(spec().await, "/servers", "get");
+}
+
+#[tokio::test]
+async fn register_begin_matches_spec() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/servers/register/begin", "post");
+
+	let request = BeginRequest {
+		server_id: "00000000-0000-0000-0000-000000000000",
+		token: "enrollment-token",
+		spki: Some("c3BraQ=="),
+	};
+	let instance = serde_json::to_value(&request).unwrap();
+	assert_valid(
+		spec,
+		&request_schema("/servers/register/begin", "post"),
+		&instance,
+	);
+
+	let sample = json!({"nonce": "bm9uY2U=", "channel_binding_required": true});
+	assert_valid(
+		spec,
+		&response_schema("/servers/register/begin", "post"),
+		&sample,
+	);
+	let decoded: BeginResponse = serde_json::from_value(sample).unwrap();
+	assert_eq!(decoded.nonce, "bm9uY2U=");
+	assert!(decoded.channel_binding_required);
+}
+
+#[tokio::test]
+async fn register_complete_matches_spec() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/servers/register/complete", "post");
+
+	let request = CompleteRequest {
+		server_id: "00000000-0000-0000-0000-000000000000",
+		nonce: "bm9uY2U=",
+		signature: "c2lnbmF0dXJl",
+		spki: None,
+	};
+	let instance = serde_json::to_value(&request).unwrap();
+	assert_valid(
+		spec,
+		&request_schema("/servers/register/complete", "post"),
+		&instance,
+	);
+
+	let sample = json!({
+		"server_id": "00000000-0000-0000-0000-000000000000",
+		"device_id": "11111111-1111-1111-1111-111111111111",
+	});
+	assert_valid(
+		spec,
+		&response_schema("/servers/register/complete", "post"),
+		&sample,
+	);
+	let decoded: CompleteResponse = serde_json::from_value(sample).unwrap();
+	assert_eq!(decoded.server_id, "00000000-0000-0000-0000-000000000000");
+	assert_eq!(decoded.device_id, "11111111-1111-1111-1111-111111111111");
+}
+
+#[tokio::test]
+async fn tags_response_matches_decode() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/tags", "get");
+
+	let sample = json!({"role": "central", "fleet": "test"});
+	assert_valid(spec, &response_schema("/tags", "get"), &sample);
+	let decoded: BTreeMap<String, String> = serde_json::from_value(sample).unwrap();
+	assert_eq!(decoded["role"], "central");
+
+	// The schema must be a string→string map, matching what `tamanu tags`
+	// decodes; anything else (like the bare list it used to be) is drift.
+	let schema = resolve(spec, &response_schema("/tags", "get"));
+	assert_eq!(
+		schema.pointer("/additionalProperties/type"),
+		Some(&json!("string")),
+		"canopy /tags response is no longer a string→string map: {schema:#}",
+	);
+}
+
+#[tokio::test]
+async fn snippets_response_matches_decode() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/bestool/snippets", "get");
+
+	let sample = json!({
+		"slow-queries": {"sql": "select 1", "description": "example"},
+		"bare": {"sql": "select 2", "description": null},
+	});
+	assert_valid(spec, &response_schema("/bestool/snippets", "get"), &sample);
+	let decoded: BTreeMap<String, Snippet> = serde_json::from_value(sample).unwrap();
+	assert_eq!(decoded["slow-queries"].sql, "select 1");
+	assert_eq!(decoded["bare"].description, None);
+}
+
+#[tokio::test]
+async fn artifacts_response_matches_decode() {
+	let spec = spec().await;
+	assert_operation_exists(spec, "/versions/{version}/artifacts", "get");
+
+	let sample = json!([{
+		"id": "00000000-0000-0000-0000-000000000000",
+		"artifact_type": "central",
+		"platform": "linux-x86_64",
+		"download_url": "https://example.com/artifact.tar.gz",
+	}]);
+	assert_valid(
+		spec,
+		&response_schema("/versions/{version}/artifacts", "get"),
+		&sample,
+	);
+	let decoded: Vec<Artifact> = serde_json::from_value(sample).unwrap();
+	assert_eq!(decoded[0].artifact_type, "central");
+	assert_eq!(
+		decoded[0].download_url.as_str(),
+		"https://example.com/artifact.tar.gz",
+	);
+}

--- a/crates/bestool/src/lib.rs
+++ b/crates/bestool/src/lib.rs
@@ -5,6 +5,13 @@ pub use crate::args::get_args as args;
 
 pub(crate) mod actions;
 pub(crate) mod args;
+#[cfg(all(
+	test,
+	feature = "canopy-register",
+	feature = "tamanu-artifacts",
+	feature = "tamanu-psql"
+))]
+mod canopy_contract;
 #[cfg(feature = "download")]
 pub(crate) mod download;
 pub mod find_postgres;

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -98,16 +98,17 @@ pub async fn tailscale_client(make_builder: &ClientBuilderFactory) -> Option<req
 	probe_tailscale(make_builder).await
 }
 
-/// RFC 5424 syslog severities accepted by the canopy `/events` API.
+/// Severities accepted by the canopy `/events` API.
+///
+/// Canopy narrowed its vocabulary from RFC 5424 to this five-level set; the
+/// retired syslog severities (`emergency`, `alert`, `notice`) are rejected by
+/// the strict enum validation on `POST /events`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
-	Emergency,
-	Alert,
 	Critical,
 	Error,
 	Warning,
-	Notice,
 	Info,
 	Debug,
 }
@@ -652,8 +653,8 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 			"\"warning\""
 		);
 		assert_eq!(
-			serde_json::to_string(&Severity::Emergency).unwrap(),
-			"\"emergency\""
+			serde_json::to_string(&Severity::Critical).unwrap(),
+			"\"critical\""
 		);
 	}
 


### PR DESCRIPTION
🤖 Cross-checking bestool against canopy's OpenAPI spec turned up two cases of drift, both fixed here, plus contract tests so it doesn't happen silently again.

## Fixes

- **`tamanu tags`**: canopy serves merged server+group tags as a key→value map at `GET /tags`; bestool was still calling `/tags/self` and decoding a bare list, so the live fetch always failed over to the cache. Now calls `/tags` and decodes the map; the cache format follows, and old list-shaped caches are discarded like any unparseable cache.
- **`Severity`**: canopy retired the `emergency`/`alert`/`notice` syslog severities; the enum now matches its five-level vocabulary (`critical`/`error`/`warning`/`info`/`debug`). Currently dormant (nothing posts events yet), but it would have been rejected on first use.

## Contract tests

`crates/bestool/src/canopy_contract.rs` fetches the live spec from `meta.tamanu.app/api/openapi.json` and checks:

- every endpoint bestool calls exists (events, status, servers probe, register begin/complete, tags, snippets, artifacts);
- request payloads bestool sends validate against the spec's request schemas (with a negative case proving the validation isn't vacuous);
- spec-valid response samples decode into bestool's types.

Note: `register_begin_matches_spec` and `register_complete_matches_spec` fail until canopy deploys the register endpoints — registration genuinely doesn't work against live today, and the failures track that. They should clear on their own once canopy ships.
