### PR TITLE
fix(tamanu/alertd): restore status subcommand, accept deprecated --glob

### DIFF
--- a/crates/alertd/src/commands.rs
+++ b/crates/alertd/src/commands.rs
@@ -1,0 +1,58 @@
+//! Clients for the daemon's control HTTP API.
+
+use tracing::info;
+
+pub use status::get_status;
+
+mod status;
+
+/// Default server addresses to try when connecting to the daemon
+pub fn default_server_addrs() -> Vec<std::net::SocketAddr> {
+	vec![
+		"[::1]:8271".parse().unwrap(),
+		"127.0.0.1:8271".parse().unwrap(),
+	]
+}
+
+/// Attempt to connect to a running daemon at any of the provided addresses
+///
+/// Returns a tuple of (client, base_url) on success, or an error if no daemon could be reached.
+pub async fn try_connect_daemon(
+	addrs: &[std::net::SocketAddr],
+) -> miette::Result<(reqwest::Client, String)> {
+	let client = crate::http_client();
+	let mut last_error = None;
+
+	for addr in addrs {
+		let url = format!("http://{}", addr);
+		info!("trying to connect to daemon at {}", url);
+
+		// Try to connect with a simple status check
+		let test_response = match client.get(format!("{}/status", url)).send().await {
+			Ok(resp) => resp,
+			Err(e) => {
+				info!("failed to connect to {}: {}", url, e);
+				last_error = Some(e);
+				continue;
+			}
+		};
+
+		if test_response.status().is_success() {
+			info!("connected to daemon at {}", url);
+			return Ok((client, url));
+		}
+	}
+
+	if let Some(err) = last_error {
+		Err(miette::miette!(
+			"failed to connect to daemon at any of {} address(es): {}",
+			addrs.len(),
+			err
+		))
+	} else {
+		Err(miette::miette!(
+			"no daemon found at any of {} address(es)",
+			addrs.len()
+		))
+	}
+}

--- a/crates/alertd/src/commands/status.rs
+++ b/crates/alertd/src/commands/status.rs
@@ -1,0 +1,106 @@
+use miette::miette;
+use tracing::info;
+
+use super::try_connect_daemon;
+use crate::http_server::StatusResponse;
+
+pub async fn get_status(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
+	let (client, url) = try_connect_daemon(addrs).await?;
+
+	// Fetch /status
+	let status_response = client
+		.get(format!("{url}/status"))
+		.send()
+		.await
+		.map_err(|e| miette!("failed to fetch status: {e}"))?;
+
+	if !status_response.status().is_success() {
+		return Err(miette!(
+			"status endpoint returned {}",
+			status_response.status()
+		));
+	}
+
+	let status: StatusResponse = status_response
+		.json()
+		.await
+		.map_err(|e| miette!("failed to parse status response: {e}"))?;
+
+	// Fetch /health
+	let health_response = client
+		.get(format!("{url}/health"))
+		.send()
+		.await
+		.map_err(|e| miette!("failed to fetch health: {e}"))?;
+
+	let health_status_code = health_response.status().as_u16();
+	let health: serde_json::Value = health_response
+		.json()
+		.await
+		.map_err(|e| miette!("failed to parse health response: {e}"))?;
+
+	info!("connected to daemon at {url}");
+
+	let local_version = crate::VERSION;
+
+	println!("Name:      {}", status.name);
+	println!("Version:   {}", status.version);
+	if status.version != local_version {
+		println!(
+			"           WARNING: running daemon is {}, but this CLI is {local_version}",
+			status.version
+		);
+		println!("           Consider restarting the service to pick up the new version.");
+	}
+	println!("PID:       {}", status.pid);
+	println!("Started:   {}", status.started_at);
+
+	let healthy = health
+		.get("healthy")
+		.and_then(|v| v.as_bool())
+		.unwrap_or(false);
+
+	if healthy {
+		println!("Health:    ok");
+	} else {
+		println!("Health:    UNHEALTHY (HTTP {health_status_code})");
+	}
+
+	if let Some(uptime) = health.get("uptime_secs").and_then(|v| v.as_i64()) {
+		println!("Uptime:    {}", format_duration(uptime));
+	}
+
+	if let Some(last) = health
+		.get("last_activity_secs_ago")
+		.and_then(|v| v.as_i64())
+	{
+		println!("Last tick: {last}s ago");
+	} else {
+		println!("Last tick: (none yet)");
+	}
+
+	if let Some(timeout) = health.get("watchdog_timeout_secs").and_then(|v| v.as_u64()) {
+		println!("Watchdog:  {}", format_duration(timeout as i64));
+	} else {
+		println!("Watchdog:  disabled");
+	}
+
+	if !healthy {
+		std::process::exit(1);
+	}
+
+	Ok(())
+}
+
+fn format_duration(secs: i64) -> String {
+	let hours = secs / 3600;
+	let mins = (secs % 3600) / 60;
+	let secs = secs % 60;
+	if hours > 0 {
+		format!("{hours}h {mins}m {secs}s")
+	} else if mins > 0 {
+		format!("{mins}m {secs}s")
+	} else {
+		format!("{secs}s")
+	}
+}

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -3,6 +3,7 @@ use std::{fmt, sync::Arc, time::Duration};
 pub use bestool_canopy as canopy;
 pub use bestool_canopy::Redacted;
 
+pub mod commands;
 mod context;
 mod daemon;
 pub mod doctor;

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1333,6 +1333,9 @@ Starts the daemon which runs the doctor healthcheck sweep on a schedule and post
 
 ###### **Options:**
 
+* `--glob <GLOB>` — Deprecated, does nothing.
+
+   Previously selected the alert definition files to load. The daemon no longer loads alert definitions; the option is still accepted so existing invocations keep working until they are migrated.
 * `--no-server` — Disable the HTTP server
 * `--server-addr <SERVER_ADDR>` — HTTP server bind address(es)
 

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -54,6 +54,7 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool tamanu`↴](#bestool-tamanu)
 * [`bestool tamanu alertd`↴](#bestool-tamanu-alertd)
 * [`bestool tamanu alertd run`↴](#bestool-tamanu-alertd-run)
+* [`bestool tamanu alertd status`↴](#bestool-tamanu-alertd-status)
 * [`bestool tamanu artifacts`↴](#bestool-tamanu-artifacts)
 * [`bestool tamanu backup`↴](#bestool-tamanu-backup)
 * [`bestool tamanu backup-configs`↴](#bestool-tamanu-backup-configs)
@@ -1318,6 +1319,7 @@ files.
 ###### **Subcommands:**
 
 * `run` — Run the healthcheck daemon
+* `status` — Show status and health of a running daemon
 
 
 
@@ -1343,6 +1345,22 @@ Starts the daemon which runs the doctor healthcheck sweep on a schedule and post
 * `--no-watchdog` — Disable the watchdog
 
    By default, the daemon will exit if no task activity is detected within the watchdog timeout. This flag disables that behaviour.
+
+
+
+## `bestool tamanu alertd status`
+
+Show status and health of a running daemon
+
+Connects to the running daemon's HTTP API and displays version, uptime, health, and watchdog information. Exits with code 1 if the daemon is unhealthy.
+
+**Usage:** `bestool tamanu alertd status [OPTIONS]`
+
+###### **Options:**
+
+* `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try
+
+   Can be provided multiple times. Will attempt to connect to each address in order until one succeeds. Defaults to [::1]:8271 and 127.0.0.1:8271
 
 
 

--- a/crates/bestool/src/actions/tamanu/alertd.rs
+++ b/crates/bestool/src/actions/tamanu/alertd.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, path::Path, sync::Arc};
 
 use clap::{Parser, Subcommand};
 use miette::Result;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use bestool_tamanu::{
 	config::{TamanuConfig, load_config},
@@ -29,6 +29,14 @@ pub struct AlertdArgs {
 /// Common arguments for running the daemon
 #[derive(Debug, Clone, Parser)]
 struct DaemonArgs {
+	/// Deprecated, does nothing.
+	///
+	/// Previously selected the alert definition files to load. The daemon no
+	/// longer loads alert definitions; the option is still accepted so
+	/// existing invocations keep working until they are migrated.
+	#[arg(long, value_name = "GLOB")]
+	glob: Vec<String>,
+
 	/// Disable the HTTP server
 	#[arg(long)]
 	no_server: bool,
@@ -170,12 +178,17 @@ async fn build_config(
 	tamanu_version: &node_semver::Version,
 	config: TamanuConfig,
 	DaemonArgs {
+		glob,
 		no_server,
 		server_addr,
 		watchdog_timeout,
 		no_watchdog,
 	}: DaemonArgs,
 ) -> Result<bestool_alertd::DaemonConfig> {
+	if !glob.is_empty() {
+		warn!("--glob is deprecated and does nothing; alert definitions are no longer loaded");
+	}
+
 	let database_url = config.database_url();
 	let pg_pool = bestool_postgres::pool::create_pool(&database_url, "bestool-alertd").await?;
 

--- a/crates/bestool/src/actions/tamanu/alertd.rs
+++ b/crates/bestool/src/actions/tamanu/alertd.rs
@@ -66,6 +66,19 @@ enum Command {
 		daemon: DaemonArgs,
 	},
 
+	/// Show status and health of a running daemon
+	///
+	/// Connects to the running daemon's HTTP API and displays version, uptime,
+	/// health, and watchdog information. Exits with code 1 if the daemon is unhealthy.
+	Status {
+		/// HTTP server address(es) to try
+		///
+		/// Can be provided multiple times. Will attempt to connect to each address
+		/// in order until one succeeds. Defaults to [::1]:8271 and 127.0.0.1:8271
+		#[arg(long)]
+		server_addr: Vec<SocketAddr>,
+	},
+
 	/// Install the daemon as a Windows service
 	///
 	/// Creates a Windows service named 'bestool-alertd' that will start automatically
@@ -97,6 +110,14 @@ enum Command {
 
 pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 	match args.command {
+		Command::Status { server_addr } => {
+			let addrs = if server_addr.is_empty() {
+				bestool_alertd::commands::default_server_addrs()
+			} else {
+				server_addr
+			};
+			bestool_alertd::commands::get_status(&addrs).await
+		}
 		Command::Run { daemon } => {
 			let (version, root) = find_tamanu(ctx.require::<TamanuArgs>())?;
 			let config = load_config(&root, None)?;


### PR DESCRIPTION
🤖 Two compatibility fixes for `bestool tamanu alertd` after the alert-engine retirement (#441).

**Restore the `status` subcommand.** The retirement removed all the daemon-control passthrough subcommands, but `status` is daemon health rather than alert management — and the `/status` and `/health` HTTP endpoints it reads were kept. `bestool_alertd::commands` is back, trimmed to the status client only (`get_status`, `try_connect_daemon`, `default_server_addrs`), using the User-Agent `http_client()`. `bestool tamanu alertd status [--server-addr …]` prints name, version (warning on CLI/daemon version skew), PID, start time, health, uptime, last tick, and watchdog config; exits 1 if the daemon is unhealthy. The alert-management subcommands (`reload`/`pause-alert`/`validate`/`loaded-alerts`) stay removed.

**Accept the deprecated `--glob` option on `run`.** Existing service invocations still pass `--glob`; without the option clap errors out and the daemon fails to start. It's now accepted and ignored, documented as deprecated, with a runtime warning when used — so deployed hosts keep working until their invocations are migrated.

USAGE.md regenerated for both.
