### PR TITLE
fix(psql): handle dollar-quotes and comments when splitting statements

### DIFF
--- a/crates/psql/src/parser.rs
+++ b/crates/psql/src/parser.rs
@@ -1,4 +1,5 @@
 pub(crate) use comments::strip_comment;
+pub(crate) use lex::SqlLexState;
 pub(crate) use metacommands::{
 	DebugWhat, ListItem, Metacommand, ResultFormat, ResultSubcommand, parse_metacommand,
 };
@@ -6,6 +7,7 @@ pub(crate) use multi::parse_multi_input;
 pub(crate) use query_modifiers::{QueryModifier, QueryModifiers, parse_query_modifiers};
 
 mod comments;
+mod lex;
 mod metacommands;
 mod multi;
 mod query_modifiers;

--- a/crates/psql/src/parser/lex.rs
+++ b/crates/psql/src/parser/lex.rs
@@ -1,0 +1,104 @@
+//! Shared SQL lexical-state tracking.
+//!
+//! Both the REPL statement scanner ([`super::multi`]) and the query executor
+//! need to find statement boundaries (`;`, and for the REPL also `\g`) without
+//! being fooled by characters that appear inside string literals, dollar-quoted
+//! strings, or comments. This module owns that lexical bookkeeping so the two
+//! call sites share one implementation instead of each tracking quote state
+//! their own way.
+
+/// Lexical state of an in-progress scan over SQL text.
+#[derive(Debug, Default)]
+pub(crate) struct SqlLexState {
+	in_single_quote: bool,
+	in_double_quote: bool,
+	in_dollar_quote: Option<String>,
+	in_line_comment: bool,
+	block_comment_depth: usize,
+	prev: char,
+}
+
+impl SqlLexState {
+	/// True when the scanner is in ordinary code — not inside a string,
+	/// dollar-quoted body, or comment — i.e. where a `;` or `\g` is a real
+	/// statement terminator.
+	pub(crate) fn in_code(&self) -> bool {
+		!self.in_single_quote
+			&& !self.in_double_quote
+			&& self.in_dollar_quote.is_none()
+			&& !self.in_line_comment
+			&& self.block_comment_depth == 0
+	}
+
+	/// Advance the state across the token starting at `chars[i]`, appending the
+	/// consumed character(s) to `out`. Returns the number of characters consumed
+	/// (more than one only for dollar-quote delimiters such as `$tag$`).
+	pub(crate) fn step(&mut self, chars: &[char], i: usize, out: &mut String) -> usize {
+		let ch = chars[i];
+
+		// Dollar-quote delimiters ($tag$ or $$), recognised both to open a quote
+		// and (when already inside one with a matching tag) to close it.
+		if ch == '$'
+			&& !self.in_single_quote
+			&& !self.in_double_quote
+			&& !self.in_line_comment
+			&& self.block_comment_depth == 0
+			&& let Some((tag, len)) = match_dollar_tag(chars, i)
+		{
+			out.extend(&chars[i..i + len]);
+			match &self.in_dollar_quote {
+				Some(open) if *open == tag => self.in_dollar_quote = None,
+				Some(_) => {}
+				None => self.in_dollar_quote = Some(tag),
+			}
+			self.prev = '$';
+			return len;
+		}
+
+		match ch {
+			_ if self.in_line_comment => {
+				if ch == '\n' {
+					self.in_line_comment = false;
+				}
+			}
+			_ if self.in_dollar_quote.is_some() => {}
+			'\'' if !self.in_double_quote && self.block_comment_depth == 0 && self.prev != '\\' => {
+				self.in_single_quote = !self.in_single_quote;
+			}
+			'"' if !self.in_single_quote && self.block_comment_depth == 0 && self.prev != '\\' => {
+				self.in_double_quote = !self.in_double_quote;
+			}
+			_ if self.in_single_quote || self.in_double_quote => {}
+			'*' if self.prev == '/' => {
+				self.block_comment_depth += 1;
+			}
+			'/' if self.prev == '*' && self.block_comment_depth > 0 => {
+				self.block_comment_depth -= 1;
+			}
+			_ if self.block_comment_depth > 0 => {}
+			'-' if self.prev == '-' => {
+				self.in_line_comment = true;
+			}
+			_ => {}
+		}
+
+		out.push(ch);
+		self.prev = ch;
+		1
+	}
+}
+
+/// If a dollar-quote delimiter (`$tag$` or `$$`) starts at `chars[start]`,
+/// return its tag (without the dollars) and its length in characters.
+fn match_dollar_tag(chars: &[char], start: usize) -> Option<(String, usize)> {
+	let mut j = start + 1;
+	while j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '_') {
+		j += 1;
+	}
+	if j < chars.len() && chars[j] == '$' {
+		let tag: String = chars[start + 1..j].iter().collect();
+		Some((tag, j + 1 - start))
+	} else {
+		None
+	}
+}

--- a/crates/psql/src/parser/multi.rs
+++ b/crates/psql/src/parser/multi.rs
@@ -6,7 +6,10 @@ use winnow::{
 	token::{any, take_till},
 };
 
-use super::{Metacommand, QueryModifiers, parse_metacommand, parse_query_modifiers, strip_comment};
+use super::{
+	Metacommand, QueryModifiers, SqlLexState, parse_metacommand, parse_query_modifiers,
+	strip_comment,
+};
 use crate::{input::ReplAction, repl::ReplState};
 
 /// Parse multiple statements from input, returning completed actions and remaining buffer
@@ -171,190 +174,64 @@ enum SqlResult {
 
 /// Parse SQL until a terminator (semicolon or \g) is found
 ///
-/// This function handles various PostgreSQL syntax features to avoid
-/// treating content inside strings or comments as statement terminators:
+/// Lexical bookkeeping (string literals, dollar-quoted strings, line and block
+/// comments) is handled by [`SqlLexState`] so that semicolons and `\g` inside
+/// strings or comments are not treated as terminators. This function layers the
+/// REPL-specific terminator policy on top:
 ///
-/// Supported:
-/// - Single-quoted strings: 'text'
-/// - Double-quoted identifiers: "identifier"
-/// - Dollar-quoted strings: $tag$text$tag$ (including empty tags: $$text$$)
-/// - Line comments: -- comment
-/// - Block comments: /* comment */ (including nested: /* outer /* inner */ */)
-/// - Escape sequences in strings (handled naturally by tracking quote state)
+/// - a `;` in code ends the statement (left in the input for the caller);
+/// - a `\g`/`\G` in code ends the statement (left in the input for the caller);
+/// - a newline in code immediately followed by a non-`\g` metacommand ends the
+///   statement (the newline is consumed, the metacommand left for the caller).
 ///
-/// The parser correctly handles:
-/// - Semicolons inside strings and comments
-/// - Operators that look like comments (e.g., `- -` for subtraction)
-/// - Arrays with string literals: ARRAY['a;b', 'c;d']
-///
-/// Not specifically handled (but work correctly due to quote tracking):
-/// - Escape strings: E'text\n' (treated as regular strings)
-/// - Unicode strings: U&'text' (treated as regular strings)
-/// - Bit/hex strings: B'101', X'1a2b' (treated as regular strings)
-///
-/// Potential future additions if needed:
-/// - C-style escape sequences: E'\\' vs E'\' (currently relies on prev_char check)
-/// - String continuation across lines (PostgreSQL allows this)
-/// - Special handling for specific operators
+/// On a terminator, `*input` is advanced to point at the terminator (or, for the
+/// metacommand-newline case, at the metacommand). Returns `Backtrack` if the
+/// input ends before any terminator is found.
 fn sql_until_terminator(input: &mut &str) -> Result<SqlResult, ErrMode<ContextError>> {
+	let original = *input;
+	let chars: Vec<char> = original.chars().collect();
+	let mut state = SqlLexState::default();
 	let mut result = String::new();
-	let mut in_single_quote = false;
-	let mut in_double_quote = false;
-	let mut in_dollar_quote: Option<String> = None;
-	let mut in_line_comment = false;
-	let mut block_comment_depth: usize = 0;
-	let mut prev_char = '\0';
+	let mut byte_pos = 0;
+	let mut i = 0;
 
-	while !input.is_empty() {
-		let before = *input;
-		let ch: char = any::<_, ContextError>
-			.parse_next(input)
-			.map_err(ErrMode::Backtrack)?;
+	while i < chars.len() {
+		let ch = chars[i];
 
-		match ch {
-			'\n' => {
-				in_line_comment = false;
-				result.push(ch);
-
-				// Check if next non-whitespace is a metacommand
-				if !in_single_quote
-					&& !in_double_quote
-					&& in_dollar_quote.is_none()
-					&& block_comment_depth == 0
-				{
-					let rest = input.trim_start();
-					if rest.starts_with('\\')
-						&& let Some(second_char) = rest.chars().nth(1)
-						&& second_char != 'g'
-						&& second_char != 'G'
-					{
-						// This is a metacommand, end the query here
-						result.pop(); // Remove the newline
-						return Ok(SqlResult::BackslashG(result.trim().to_string()));
-					}
-				}
-			}
-			'-' if !in_single_quote
-				&& !in_double_quote
-				&& in_dollar_quote.is_none()
-				&& block_comment_depth == 0
-				&& !in_line_comment
-				&& prev_char == '-' =>
-			{
-				in_line_comment = true;
-				result.push(ch);
-			}
-			'/' if !in_single_quote
-				&& !in_double_quote
-				&& in_dollar_quote.is_none()
-				&& !in_line_comment
-				&& prev_char == '*'
-				&& block_comment_depth > 0 =>
-			{
-				// End of block comment
-				block_comment_depth -= 1;
-				result.push(ch);
-			}
-			'*' if !in_single_quote
-				&& !in_double_quote
-				&& in_dollar_quote.is_none()
-				&& !in_line_comment
-				&& prev_char == '/' =>
-			{
-				// Start of block comment
-				block_comment_depth += 1;
-				result.push(ch);
-			}
-			'\'' if !in_double_quote
-				&& in_dollar_quote.is_none()
-				&& !in_line_comment
-				&& block_comment_depth == 0
-				&& prev_char != '\\' =>
-			{
-				in_single_quote = !in_single_quote;
-				result.push(ch);
-			}
-			'"' if !in_single_quote
-				&& in_dollar_quote.is_none()
-				&& !in_line_comment
-				&& block_comment_depth == 0
-				&& prev_char != '\\' =>
-			{
-				in_double_quote = !in_double_quote;
-				result.push(ch);
-			}
-			'$' if !in_single_quote
-				&& !in_double_quote
-				&& !in_line_comment
-				&& block_comment_depth == 0 =>
-			{
-				// Check for dollar-quoted string
-				result.push(ch);
-				*input = before;
-				let _ = any::<_, ContextError>.parse_next(input); // consume the $
-
-				// Extract the tag (alphanumeric/underscore characters between the dollars)
-				let tag_start = *input;
-				let mut tag = String::new();
-				while let Some(next_ch) = input.chars().next() {
-					if next_ch.is_alphanumeric() || next_ch == '_' {
-						tag.push(next_ch);
-						let _ = any::<_, ContextError>.parse_next(input);
-						result.push(next_ch);
-					} else if next_ch == '$' {
-						// Found closing $, this is a dollar quote
-						let _ = any::<_, ContextError>.parse_next(input);
-						result.push('$');
-
-						if let Some(ref current_tag) = in_dollar_quote {
-							// Check if this closes the current dollar quote
-							if &tag == current_tag {
-								in_dollar_quote = None;
-							}
-						} else {
-							// Starting a new dollar quote
-							in_dollar_quote = Some(tag);
-						}
-						break;
-					} else {
-						// Not a dollar quote, just a regular $ character
-						*input = tag_start;
-						break;
-					}
-				}
-			}
-			';' if !in_single_quote
-				&& !in_double_quote
-				&& in_dollar_quote.is_none()
-				&& !in_line_comment
-				&& block_comment_depth == 0 =>
-			{
-				// Found terminating semicolon
-				*input = before;
+		if state.in_code() {
+			// Terminating semicolon: leave it for the caller to consume.
+			if ch == ';' {
+				*input = &original[byte_pos..];
 				return Ok(SqlResult::Semicolon(result.trim().to_string()));
 			}
-			'\\' if !in_single_quote
-				&& !in_double_quote
-				&& in_dollar_quote.is_none()
-				&& !in_line_comment
-				&& block_comment_depth == 0 =>
-			{
-				// Check if next char is 'g' or 'G'
-				if let Some(next_ch) = input.chars().next()
-					&& (next_ch == 'g' || next_ch == 'G')
+
+			// \g / \G terminator: leave it for the caller to consume.
+			if ch == '\\' && chars.get(i + 1).is_some_and(|c| *c == 'g' || *c == 'G') {
+				*input = &original[byte_pos..];
+				return Ok(SqlResult::BackslashG(result.trim().to_string()));
+			}
+
+			// Newline followed by a (non-\g) metacommand ends the query here;
+			// consume the newline and leave the metacommand for the caller.
+			if ch == '\n' {
+				let mut k = i + 1;
+				while k < chars.len() && chars[k].is_whitespace() {
+					k += 1;
+				}
+				if chars.get(k) == Some(&'\\')
+					&& chars.get(k + 1).is_some_and(|c| *c != 'g' && *c != 'G')
 				{
-					// Found \g terminator
-					*input = before;
+					*input = &original[byte_pos + ch.len_utf8()..];
 					return Ok(SqlResult::BackslashG(result.trim().to_string()));
 				}
-				result.push(ch);
-			}
-			_ => {
-				result.push(ch);
 			}
 		}
 
-		prev_char = ch;
+		let n = state.step(&chars, i, &mut result);
+		for ch in &chars[i..i + n] {
+			byte_pos += ch.len_utf8();
+		}
+		i += n;
 	}
 
 	// No terminator found

--- a/crates/psql/src/query.rs
+++ b/crates/psql/src/query.rs
@@ -20,7 +20,7 @@ use bestool_postgres::{
 
 use crate::{
 	column_extractor::extract_column_refs,
-	parser::{QueryModifier, QueryModifiers},
+	parser::{QueryModifier, QueryModifiers, SqlLexState},
 	repl::ReplState,
 	schema_cache::SchemaCacheManager,
 	signals::{reset_sigint, sigint_received},
@@ -90,46 +90,31 @@ pub(crate) async fn execute_query<W: AsyncWrite + Unpin>(
 	Ok(())
 }
 
-/// Split SQL into multiple statements by semicolon
+/// Split SQL into multiple statements by semicolon.
+///
+/// Semicolons inside single/double-quoted strings, dollar-quoted strings
+/// (including nested and untagged `$$`), line comments (`--`) and block
+/// comments (`/* */`, nestable) are not treated as statement separators.
 fn split_statements(sql: &str) -> Vec<String> {
+	let chars: Vec<char> = sql.chars().collect();
 	let mut statements = Vec::new();
 	let mut current = String::new();
-	let mut in_string = false;
-	let mut string_char = ' ';
-	let mut escaped = false;
+	let mut state = SqlLexState::default();
+	let mut i = 0;
 
-	for ch in sql.chars() {
-		if escaped {
-			current.push(ch);
-			escaped = false;
+	while i < chars.len() {
+		if state.in_code() && chars[i] == ';' {
+			let trimmed = current.trim();
+			if !trimmed.is_empty() {
+				statements.push(trimmed.to_string());
+			}
+			current.clear();
+			state = SqlLexState::default();
+			i += 1;
 			continue;
 		}
 
-		match ch {
-			'\\' if in_string => {
-				escaped = true;
-				current.push(ch);
-			}
-			'\'' | '"' => {
-				if !in_string {
-					in_string = true;
-					string_char = ch;
-				} else if ch == string_char {
-					in_string = false;
-				}
-				current.push(ch);
-			}
-			';' if !in_string => {
-				let trimmed = current.trim();
-				if !trimmed.is_empty() {
-					statements.push(trimmed.to_string());
-				}
-				current.clear();
-			}
-			_ => {
-				current.push(ch);
-			}
-		}
+		i += state.step(&chars, i, &mut current);
 	}
 
 	// Add remaining statement if any
@@ -577,6 +562,59 @@ mod tests {
 		let statements = split_statements(sql);
 		assert_eq!(statements.len(), 2);
 		assert_eq!(statements[0], "SELECT 1");
+		assert_eq!(statements[1], "SELECT 2");
+	}
+
+	#[test]
+	fn test_split_statements_dollar_quoted_function() {
+		let sql = "CREATE FUNCTION f() RETURNS void AS $function$\nBEGIN\n  SELECT 1;\nEND;\n$function$ LANGUAGE plpgsql";
+		let statements = split_statements(sql);
+		assert_eq!(statements.len(), 1);
+		assert_eq!(statements[0], sql);
+	}
+
+	#[test]
+	fn test_split_statements_untagged_dollar_quote() {
+		let sql = "SELECT $$a; b$$; SELECT 2";
+		let statements = split_statements(sql);
+		assert_eq!(statements.len(), 2);
+		assert_eq!(statements[0], "SELECT $$a; b$$");
+		assert_eq!(statements[1], "SELECT 2");
+	}
+
+	#[test]
+	fn test_split_statements_nested_dollar_quote() {
+		let sql = "SELECT $outer$x $inner$y;z$inner$ w;$outer$; SELECT 2";
+		let statements = split_statements(sql);
+		assert_eq!(statements.len(), 2);
+		assert_eq!(statements[0], "SELECT $outer$x $inner$y;z$inner$ w;$outer$");
+		assert_eq!(statements[1], "SELECT 2");
+	}
+
+	#[test]
+	fn test_split_statements_line_comment() {
+		let sql = "SELECT 1 -- ; not a separator\n; SELECT 2";
+		let statements = split_statements(sql);
+		assert_eq!(statements.len(), 2);
+		assert_eq!(statements[1], "SELECT 2");
+	}
+
+	#[test]
+	fn test_split_statements_block_comment() {
+		let sql = "SELECT /* ; nested ; */ 1; SELECT 2";
+		let statements = split_statements(sql);
+		assert_eq!(statements.len(), 2);
+		assert_eq!(statements[0], "SELECT /* ; nested ; */ 1");
+		assert_eq!(statements[1], "SELECT 2");
+	}
+
+	#[test]
+	fn test_split_statements_dollar_quoted_with_string_literals() {
+		// Single quotes inside a dollar-quoted body must not toggle string state.
+		let sql = "CREATE FUNCTION f(d json) RETURNS void AS $function$\nBEGIN\n  RETURN QUERY SELECT d->>'a', d->>'b';\nEND;\n$function$ LANGUAGE plpgsql; SELECT 2";
+		let statements = split_statements(sql);
+		assert_eq!(statements.len(), 2);
+		assert!(statements[0].ends_with("LANGUAGE plpgsql"));
 		assert_eq!(statements[1], "SELECT 2");
 	}
 


### PR DESCRIPTION
🤖 Pasting a multi-statement script containing a `CREATE FUNCTION ... $function$ ... $function$` body failed with a PostgreSQL `42601` syntax error pointing at the opening `$function$`, e.g.:

```
  6 │ AS $function$
    ·    ┬
    ·    ╰── error here
```

The REPL-level scanner correctly kept the whole function as a single statement, but `execute_query` then re-split the interpolated SQL on semicolons using `split_statements`, which tracked only single/double-quoted strings. Semicolons inside the dollar-quoted body (`... name_distance;`, `END;`) were treated as statement separators, so the statement was cut mid-body and PostgreSQL received an unterminated dollar-quoted string.

The REPL scanner (`sql_until_terminator`) already handled dollar-quotes, line comments and block comments correctly, so rather than duplicate that logic the shared lexical bookkeeping is extracted into `SqlLexState`. Both `split_statements` and the REPL scanner now drive it, leaving only their differing terminator policy (`;` only vs `;` + `\g` + metacommand lines) at each call site. This also removes a latent character-duplication bug in the old inline dollar-tag parser.
