### PR TITLE
fix(tamanu): retire leftover singleton units instead of rolling them

### DIFF
--- a/crates/alertd/src/doctor/checks/tamanu_service.rs
+++ b/crates/alertd/src/doctor/checks/tamanu_service.rs
@@ -250,11 +250,20 @@ fn reconcile_down_with_enabled(
 	}
 }
 
-fn match_expectation(exp: &Expectation, discovered: &[Discovered]) -> (Outcome, Vec<usize>) {
+fn match_expectation(
+	supervisor: Supervisor,
+	exp: &Expectation,
+	discovered: &[Discovered],
+) -> (Outcome, Vec<usize>) {
 	let matched_idx: Vec<usize> = discovered
 		.iter()
 		.enumerate()
-		.filter(|(_, d)| d.name == exp.name && exp.instances.admits_instance(d.instance.as_deref()))
+		.filter(|(_, d)| {
+			d.name == exp.name
+				&& exp
+					.instances
+					.admits_instance(supervisor, d.instance.as_deref())
+		})
 		.map(|(i, _)| i)
 		.collect();
 
@@ -336,7 +345,7 @@ fn evaluate(
 	let mut failures: Vec<String> = Vec::new();
 
 	for exp in expectations {
-		let (outcome, idxs) = match_expectation(exp, discovered);
+		let (outcome, idxs) = match_expectation(supervisor, exp, discovered);
 		for i in idxs {
 			matched_any[i] = true;
 		}
@@ -805,6 +814,49 @@ mod tests {
 			.expect("services payload_extra");
 		let extras = services
 			.get("extras")
+			.and_then(Value::as_array)
+			.expect("extras array");
+		assert_eq!(extras.len(), 1);
+		assert_eq!(extras[0].as_str().unwrap(), "tamanu-patientportal.service");
+	}
+
+	#[test]
+	fn leftover_singleton_does_not_satisfy_instanced_portal() {
+		// Host mid-migration: the @a/@b template is installed (so the portal
+		// expectation is instanced and Up) but only the old singleton is
+		// running. The singleton must not count toward the instanced
+		// requirement — the check should fail for the missing @a/@b, and the
+		// singleton lands in `extras`.
+		let cfg = central_cfg(false);
+		let exps = expected(
+			Supervisor::Systemd,
+			ApiServerKind::Central,
+			&cfg,
+			Some(true),
+			true,
+		);
+		let discovered = vec![
+			d("tamanu-central-tasks", None, true),
+			d("tamanu-frontend", Some("a"), true),
+			d("tamanu-frontend", Some("b"), true),
+			d("tamanu-central-api", Some("1"), true),
+			d("tamanu-central-api", Some("2"), true),
+			d("tamanu-central-fhir-resolve", None, true),
+			d("tamanu-central-fhir-refresh", None, true),
+			d("tamanu-patientportal", None, true),
+		];
+		let check = evaluate(Supervisor::Systemd, &exps, &discovered);
+		match &check.status {
+			CheckStatus::Fail(reason) => assert!(
+				reason.contains("tamanu-patientportal"),
+				"reason was {reason:?}"
+			),
+			other => panic!("expected fail, got {other:?}"),
+		}
+		let extras = check
+			.payload_extras
+			.get("services")
+			.and_then(|s| s.get("extras"))
 			.and_then(Value::as_array)
 			.expect("extras array");
 		assert_eq!(extras.len(), 1);

--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -284,6 +284,7 @@ pub fn warn_unknown_expectations(expectations: &[&Expectation]) {
 /// instances are dropped (they're not "expected", so lifecycle commands
 /// don't touch them).
 pub fn group_by_expectation<'a>(
+	supervisor: Supervisor,
 	expectations: &'a [&'a Expectation],
 	instances: &[Instance],
 ) -> Vec<(&'a Expectation, Vec<Instance>)> {
@@ -293,13 +294,72 @@ pub fn group_by_expectation<'a>(
 			let matches: Vec<Instance> = instances
 				.iter()
 				.filter(|d| {
-					d.name == exp.name && exp.instances.admits_instance(d.instance.as_deref())
+					d.name == exp.name
+						&& exp.instances.admits_instance(supervisor, d.instance.as_deref())
 				})
 				.cloned()
 				.collect();
 			(*exp, matches)
 		})
 		.collect()
+}
+
+/// Discovered running instances that belong (by name) to a templated,
+/// expected-Up expectation but whose shape that expectation doesn't admit —
+/// i.e. a leftover bare singleton on a host that's since migrated to the
+/// `@a`/`@b` template. Grouped under the expectation they're stale for so
+/// callers can find the instanced replacements.
+///
+/// `restart` retires these (stop + disable) once the instanced units are up
+/// and serving, so a singleton→instanced migration takes no downtime.
+/// systemd-only: pm2 has no `@instance` notion, so a `None` instance there is
+/// a legitimate cluster member, not a stale singleton.
+pub fn stale_shape_groups<'a>(
+	supervisor: Supervisor,
+	expectations: &'a [&'a Expectation],
+	instances: &[Instance],
+) -> Vec<(&'a Expectation, Vec<Instance>)> {
+	if !matches!(supervisor, Supervisor::Systemd) {
+		return Vec::new();
+	}
+	expectations
+		.iter()
+		.filter(|exp| {
+			matches!(exp.state, services::ExpectedState::Up) && exp.instances.min_count() >= 2
+		})
+		.filter_map(|exp| {
+			let stale: Vec<Instance> = instances
+				.iter()
+				.filter(|d| {
+					d.running
+						&& d.name == exp.name
+						&& !exp.instances.admits_instance(supervisor, d.instance.as_deref())
+				})
+				.cloned()
+				.collect();
+			(!stale.is_empty()).then_some((*exp, stale))
+		})
+		.collect()
+}
+
+/// Stop then disable a batch of systemd units, best-effort. Used to retire
+/// leftover singleton units after a host has migrated to an instanced layout:
+/// failures are logged but never abort the caller, since the units are
+/// already redundant and the migration's success doesn't hinge on them.
+///
+/// `stop` works even on a masked unit (systemd only refuses *activation* of
+/// masked units, not deactivation); `disable` clears any enablement so the
+/// unit can't return on the next boot.
+pub async fn retire_systemd_units(units: &[String]) {
+	if units.is_empty() {
+		return;
+	}
+	if let Err(e) = systemd::stop(units).await {
+		warn!(?units, "could not stop leftover units: {e}");
+	}
+	if let Err(e) = systemd::disable(units).await {
+		warn!(?units, "could not disable leftover units: {e}");
+	}
 }
 
 /// On Linux/systemd, re-exec the current process under sudo if not
@@ -776,12 +836,111 @@ mod tests {
 			inst("tamanu-central-tasks", None, true),
 			inst("tamanu-orphan", None, true), // unrelated, dropped
 		];
-		let groups = group_by_expectation(&expectations, &instances);
+		let groups = group_by_expectation(Supervisor::Systemd, &expectations, &instances);
 		assert_eq!(groups.len(), 2);
 		assert_eq!(groups[0].0.name, "tamanu-central-api");
 		assert_eq!(groups[0].1.len(), 2);
 		assert_eq!(groups[1].0.name, "tamanu-central-tasks");
 		assert_eq!(groups[1].1.len(), 1);
+	}
+
+	fn named_exp(name: &'static str, names: &'static [&'static str]) -> Expectation {
+		Expectation {
+			name,
+			instances: Instances::Named(names),
+			state: ExpectedState::Up,
+			reason: "test".into(),
+			legacy: false,
+			behind_caddy: true,
+		}
+	}
+
+	#[test]
+	fn group_by_expectation_excludes_leftover_singleton_on_systemd() {
+		// Host mid-migration: the @a/@b template is installed (so the portal
+		// expectation is instanced) but an old singleton `tamanu-patientportal`
+		// is still running. On systemd that singleton must NOT be grouped under
+		// the instanced expectation — otherwise restart would try to roll the
+		// bare (and possibly masked) `.service` unit.
+		let portal = named_exp("tamanu-patientportal", &["a", "b"]);
+		let expectations = [&portal];
+		let instances = vec![
+			inst("tamanu-patientportal", None, true),
+			inst("tamanu-patientportal", Some("a"), true),
+			inst("tamanu-patientportal", Some("b"), true),
+		];
+		let groups = group_by_expectation(Supervisor::Systemd, &expectations, &instances);
+		assert_eq!(groups.len(), 1);
+		let matched: Vec<Option<&str>> =
+			groups[0].1.iter().map(|i| i.instance.as_deref()).collect();
+		assert_eq!(matched, vec![Some("a"), Some("b")]);
+	}
+
+	#[test]
+	fn stale_shape_groups_finds_leftover_singleton() {
+		let portal = named_exp("tamanu-patientportal", &["a", "b"]);
+		let expectations = [&portal];
+		let instances = vec![
+			inst("tamanu-patientportal", None, true),
+			inst("tamanu-patientportal", Some("a"), true),
+			inst("tamanu-patientportal", Some("b"), true),
+		];
+		let stale = stale_shape_groups(Supervisor::Systemd, &expectations, &instances);
+		assert_eq!(stale.len(), 1);
+		assert_eq!(stale[0].0.name, "tamanu-patientportal");
+		assert_eq!(stale[0].1.len(), 1);
+		assert_eq!(stale[0].1[0].instance, None);
+	}
+
+	#[test]
+	fn stale_shape_groups_ignores_stopped_singleton() {
+		// A leftover singleton that isn't running needs no retiring — it's
+		// already down. (It'd surface as a Down-expectation concern elsewhere,
+		// not as something restart should stop.)
+		let portal = named_exp("tamanu-patientportal", &["a", "b"]);
+		let expectations = [&portal];
+		let instances = vec![inst("tamanu-patientportal", None, false)];
+		let stale = stale_shape_groups(Supervisor::Systemd, &expectations, &instances);
+		assert!(stale.is_empty());
+	}
+
+	#[test]
+	fn stale_shape_groups_ignores_singleton_expectation() {
+		// On an un-migrated host the expectation is itself a singleton, so the
+		// running `None` unit is the real thing, not a leftover.
+		let portal = exp("tamanu-patientportal");
+		let expectations = [&portal];
+		let instances = vec![inst("tamanu-patientportal", None, true)];
+		let stale = stale_shape_groups(Supervisor::Systemd, &expectations, &instances);
+		assert!(stale.is_empty());
+	}
+
+	#[test]
+	fn stale_shape_groups_empty_on_pm2() {
+		// pm2 clusters legitimately share one name with no @suffix, so a `None`
+		// instance under a templated expectation is a member, not a leftover.
+		let api = templated_exp("tamanu-api");
+		let expectations = [&api];
+		let instances = vec![
+			inst("tamanu-api", None, true),
+			inst("tamanu-api", None, true),
+		];
+		let stale = stale_shape_groups(Supervisor::Pm2, &expectations, &instances);
+		assert!(stale.is_empty());
+	}
+
+	#[test]
+	fn stale_shape_groups_skips_down_and_unknown() {
+		let mut down = named_exp("tamanu-patientportal", &["a", "b"]);
+		down.state = ExpectedState::Down;
+		let mut unknown = named_exp("tamanu-patientportal", &["a", "b"]);
+		unknown.state = ExpectedState::Unknown;
+		let running = vec![inst("tamanu-patientportal", None, true)];
+		for exp in [&down, &unknown] {
+			let expectations = [exp];
+			let stale = stale_shape_groups(Supervisor::Systemd, &expectations, &running);
+			assert!(stale.is_empty(), "{:?} should not retire", exp.state);
+		}
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -6,7 +6,7 @@ use reqwest::{Client, Url};
 use tracing::{debug, info, warn};
 
 use bestool_tamanu::{
-	services::{self, ExpectedState, Expectation, Supervisor},
+	services::{self, ExpectedState, Expectation, Supervisor, parse_systemd_unit},
 	systemd,
 };
 
@@ -65,7 +65,12 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 	let matched = services::match_names(&expectations, &names)?;
 	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor).await?;
-	let groups = lifecycle::group_by_expectation(&matched, &discovered);
+	let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);
+	// Leftover singletons on a host that's migrated to an instanced layout:
+	// retired (stop + disable) at the end, once their instanced replacements
+	// are up and serving. Detected against the full discovered set, since
+	// `group_by_expectation` no longer admits them into the instanced group.
+	let retire = lifecycle::stale_shape_groups(supervisor, &matched, &discovered);
 
 	lifecycle::ensure_root_or_reexec(supervisor)?;
 
@@ -139,11 +144,66 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 		}
 	}
 
+	// Retire leftover singletons last: the instanced replacements were
+	// brought up in the start batch (and Caddy reloaded), so cutting the
+	// singleton now completes a singleton→instanced migration with no gap in
+	// service. We confirm the replacements are actually serving first.
+	if !retire.is_empty() {
+		for (exp, instances) in &retire {
+			let stale: Vec<String> = instances.iter().map(Instance::display).collect();
+			info!(
+				service = exp.name,
+				?stale,
+				"retiring leftover units after migration to instanced layout"
+			);
+			if !args.no_probe_http {
+				wait_replacements_ready(supervisor, exp, &client).await?;
+			} else {
+				// No readiness signal to wait on; give the freshly-started
+				// replacements the same grace a roll would before cutting over.
+				debug!(seconds = args.cooldown.as_secs(), "cooldown before retiring");
+				tokio::time::sleep(args.cooldown).await;
+			}
+		}
+		let units: Vec<String> = retire
+			.iter()
+			.flat_map(|(_, instances)| instances.iter().map(Instance::unit))
+			.collect();
+		lifecycle::retire_systemd_units(&units).await;
+	}
+
 	if let Some(url) = &args.check_url {
 		info!(%url, "final end-to-end probe");
 		probe::probe_url(&client, url, Duration::from_secs(60)).await?;
 	}
 
+	Ok(())
+}
+
+/// Block until every instanced unit the expectation requires responds to an
+/// HTTP probe. Used before retiring a leftover singleton, so we never cut the
+/// old unit until its replacements are serving. Units without a constructable
+/// probe URL (no container IP yet) are skipped — same best-effort semantics as
+/// the rolling probe.
+async fn wait_replacements_ready(
+	supervisor: Supervisor,
+	exp: &Expectation,
+	client: &Client,
+) -> Result<()> {
+	for unit in exp.instances.required_systemd_units(exp.name) {
+		let Some((base, instance)) = parse_systemd_unit(&unit) else {
+			continue;
+		};
+		let inst = Instance {
+			name: base.to_string(),
+			instance: instance.map(str::to_string),
+			pm_id: None,
+			running: true,
+		};
+		if let Some(url) = probe::instance_probe_url(supervisor, &inst)? {
+			probe::probe_until_ready(client, &url).await;
+		}
+	}
 	Ok(())
 }
 

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -81,7 +81,7 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 	let matched = services::match_names(&expectations, &names)?;
 	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor).await?;
-	let groups = lifecycle::group_by_expectation(&matched, &discovered);
+	let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);
 
 	let stop_plan = if args.up_only {
 		StopPlan::default()
@@ -160,7 +160,7 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 	// any fails to respond in time.
 	if started_behind_caddy && !args.no_probe_http {
 		let discovered = lifecycle::discover(supervisor).await?;
-		let groups = lifecycle::group_by_expectation(&matched, &discovered);
+		let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);
 		let to_probe = instances_to_probe(&groups);
 		probe_started(supervisor, &to_probe, args.probe_timeout).await?;
 	}

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -53,7 +53,7 @@ pub async fn run(args: StatusArgs, ctx: Context) -> Result<()> {
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
 	let matched = services::match_names(&expectations, &names)?;
 	let discovered = lifecycle::discover(supervisor).await?;
-	let mut groups = lifecycle::group_by_expectation(&matched, &discovered);
+	let mut groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);
 	if matches!(supervisor, Supervisor::Systemd) {
 		let candidates: HashSet<String> = groups
 			.iter()

--- a/crates/bestool/src/actions/tamanu/stop.rs
+++ b/crates/bestool/src/actions/tamanu/stop.rs
@@ -33,7 +33,7 @@ pub async fn run(args: StopArgs, ctx: Context) -> Result<()> {
 	let matched = services::match_names(&expectations, &names)?;
 	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor).await?;
-	let groups = lifecycle::group_by_expectation(&matched, &discovered);
+	let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);
 
 	let targets = plan_stop(supervisor, &groups);
 	if targets.is_empty() {

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -127,14 +127,24 @@ impl Instances {
 	}
 
 	/// Whether a discovered `instance` (the bit after `@`, or `None` if there
-	/// was no `@` suffix) is one this pattern admits.
-	pub fn admits_instance(&self, instance: Option<&str>) -> bool {
+	/// was no `@` suffix) is one this pattern admits under `supervisor`.
+	///
+	/// The `None` case is supervisor-dependent. pm2 has no `@instance`
+	/// notation, so every process of a clustered service carries
+	/// `instance: None` — there a templated pattern (`NumericAtLeast` /
+	/// `Named`) must admit `None`. On systemd a `None` means a bare singleton
+	/// `.service` unit, which does **not** satisfy a templated expectation:
+	/// admitting it would let a leftover singleton (e.g. an older
+	/// `tamanu-patientportal.service` on a host since migrated to the `@a`/`@b`
+	/// template) masquerade as a healthy instanced member, and would make
+	/// `tamanu restart` try to roll the singleton unit itself.
+	pub fn admits_instance(&self, supervisor: Supervisor, instance: Option<&str>) -> bool {
 		match (self, instance) {
 			(Instances::Single, None) => true,
 			(Instances::Single, Some(_)) => false,
-			(Instances::NumericAtLeast(_), None) => true, // pm2 case
+			(Instances::NumericAtLeast(_), None) => matches!(supervisor, Supervisor::Pm2),
 			(Instances::NumericAtLeast(_), Some(s)) => s.chars().all(|c| c.is_ascii_digit()),
-			(Instances::Named(_), None) => true, // pm2 case
+			(Instances::Named(_), None) => matches!(supervisor, Supervisor::Pm2),
 			(Instances::Named(xs), Some(s)) => xs.contains(&s),
 		}
 	}
@@ -659,24 +669,31 @@ mod tests {
 	#[test]
 	fn admits_instance_numeric_only_takes_digits() {
 		let n = Instances::NumericAtLeast(1);
-		assert!(n.admits_instance(Some("1")));
-		assert!(n.admits_instance(Some("42")));
-		assert!(!n.admits_instance(Some("a")));
-		assert!(n.admits_instance(None)); // pm2
+		assert!(n.admits_instance(Supervisor::Systemd, Some("1")));
+		assert!(n.admits_instance(Supervisor::Systemd, Some("42")));
+		assert!(!n.admits_instance(Supervisor::Systemd, Some("a")));
+		// pm2 clusters share one name with no @suffix, so None is admitted;
+		// on systemd a bare singleton must not satisfy a numeric template.
+		assert!(n.admits_instance(Supervisor::Pm2, None));
+		assert!(!n.admits_instance(Supervisor::Systemd, None));
 	}
 
 	#[test]
 	fn admits_instance_named_matches_listed() {
 		let n = Instances::Named(&["a", "b"]);
-		assert!(n.admits_instance(Some("a")));
-		assert!(n.admits_instance(Some("b")));
-		assert!(!n.admits_instance(Some("c")));
+		assert!(n.admits_instance(Supervisor::Systemd, Some("a")));
+		assert!(n.admits_instance(Supervisor::Systemd, Some("b")));
+		assert!(!n.admits_instance(Supervisor::Systemd, Some("c")));
+		// Same supervisor split as the numeric case: pm2 None admitted,
+		// systemd singleton rejected.
+		assert!(n.admits_instance(Supervisor::Pm2, None));
+		assert!(!n.admits_instance(Supervisor::Systemd, None));
 	}
 
 	#[test]
 	fn admits_instance_single_rejects_atsuffix() {
-		assert!(Instances::Single.admits_instance(None));
-		assert!(!Instances::Single.admits_instance(Some("1")));
+		assert!(Instances::Single.admits_instance(Supervisor::Systemd, None));
+		assert!(!Instances::Single.admits_instance(Supervisor::Systemd, Some("1")));
 	}
 
 	fn rolling_for(es: &[Expectation], name: &str) -> bool {


### PR DESCRIPTION
🤖 `bestool tamanu restart` crashed on a host mid-migration from a singleton patient-portal to the instanced `@a`/`@b` layout: the leftover (and masked) `tamanu-patientportal.service` was rolled and failed with `Unit is masked`.

Root cause: `Instances::admits_instance` ignored the supervisor, so its pm2-only `None` arms also matched on systemd — a bare singleton `.service` satisfied a templated expectation and got swept into the rolling set.

Changes:
- `admits_instance` is now supervisor-aware: the `None` arms are pm2-only, so on systemd a bare singleton no longer satisfies a templated (`Named`/`NumericAtLeast`) expectation. The shared doctor check inherits the stricter matching (a leftover singleton now surfaces as an extra, not a phantom instanced member).
- `restart` grows a retire phase: once the instanced replacements are up, HTTP-probed, and Caddy has reloaded, leftover singletons are stopped and disabled — a no-downtime singleton→instanced cutover.

Tests cover the grouping fix, `stale_shape_groups` detection, and the doctor regression.
