### PR TITLE
fix(tamanu): surface unreadable running versions instead of guessing

### DIFF
--- a/crates/alertd/src/doctor/checks/version_drift.rs
+++ b/crates/alertd/src/doctor/checks/version_drift.rs
@@ -5,11 +5,15 @@
 //! complete, etc. The user-visible symptom for those is "everything looks
 //! OK in `tamanu status`" but the service is actually serving stale code.
 
+use std::collections::HashMap;
+
 use serde_json::{Value, json};
 
 use bestool_tamanu::{
-	services::{Supervisor, expected, parse_systemd_unit, systemd_patient_portal_instanced},
-	versions,
+	services::{
+		Expectation, Supervisor, expected, parse_systemd_unit, systemd_patient_portal_instanced,
+	},
+	versions::{self, ExpectedVersions},
 };
 
 use super::CheckContext;
@@ -43,8 +47,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 		.with_detail("install_version", ctx.tamanu_version.to_string());
 	}
 
+	let running = match versions::running_versions_linux().await {
+		Ok(map) => map,
+		// We couldn't read what's running, so we can't judge drift. Bail before
+		// the DB round-trip below — there's nothing to compare against.
+		Err(reason) => return unreadable_check(&reason),
+	};
 	let expected_versions = versions::expected_for_supervisor(supervisor, &ctx.tamanu_version);
-	let running = versions::running_versions_linux().await;
 
 	// Only look at units that show up in our expectations registry. Hand-
 	// started or orphaned containers aren't drift; they're outside the
@@ -63,11 +72,36 @@ pub async fn run(ctx: CheckContext) -> Check {
 		patient_portal_instanced,
 	);
 
+	evaluate_drift(&running, &expected_versions, &expectations)
+}
+
+/// Warning result for when `podman ps` couldn't be read at all. We can't judge
+/// drift, and must not report a pass — that would dress up a blind check as a
+/// healthy one. Most often this is alertd lacking access to the root-owned
+/// containers (see the podman-socket / privilege notes).
+fn unreadable_check(reason: &str) -> Check {
+	Check::warning(
+		"version_drift",
+		"could not read running container versions",
+		format!("`podman ps` failed, so version drift can't be checked: {reason}"),
+	)
+	.with_detail("supervisor", "systemd")
+}
+
+/// Compare each running container's image tag against the version the
+/// deployment is configured for, given an already-read `running` map. An empty
+/// map is a genuine "nothing running" pass — distinct from the unreadable case
+/// handled by [`unreadable_check`].
+fn evaluate_drift(
+	running: &HashMap<String, String>,
+	expected_versions: &ExpectedVersions,
+	expectations: &[Expectation],
+) -> Check {
 	let mut rows: Vec<Value> = Vec::new();
 	let mut drifted: Vec<String> = Vec::new();
 	let mut total_running = 0usize;
 
-	for (unit, actual) in &running {
+	for (unit, actual) in running {
 		let Some((base, _instance)) = parse_systemd_unit(unit) else {
 			continue;
 		};
@@ -117,5 +151,92 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Check::fail("version_drift", summary, drifted.join("; "))
 			.with_detail("expected", expected_summary)
 			.with_detail("instances", Value::Array(rows))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::doctor::check::CheckStatus;
+	use bestool_tamanu::services::{ExpectedState, Instances};
+
+	fn exp(name: &'static str, instances: Instances) -> Expectation {
+		Expectation {
+			name,
+			instances,
+			state: ExpectedState::Up,
+			reason: "test".into(),
+			legacy: false,
+			behind_caddy: false,
+		}
+	}
+
+	fn ev(tamanu: &str, frontend: Option<&str>) -> ExpectedVersions {
+		ExpectedVersions {
+			tamanu: Some(tamanu.into()),
+			frontend: frontend.map(Into::into),
+		}
+	}
+
+	#[test]
+	fn unreadable_is_warning_not_pass() {
+		// The regression that motivated this: a blind check must NOT look healthy.
+		let check = unreadable_check("podman not found on PATH");
+		assert!(matches!(check.status, CheckStatus::Warning(_)), "{check:?}");
+	}
+
+	#[test]
+	fn empty_running_is_pass() {
+		// podman answered with nothing running — genuinely fine, distinct from blind.
+		let exps = [exp("tamanu-central-api", Instances::NumericAtLeast(2))];
+		let check = evaluate_drift(&HashMap::new(), &ev("v2.54.7", None), &exps);
+		assert!(matches!(check.status, CheckStatus::Pass), "{check:?}");
+	}
+
+	#[test]
+	fn matching_versions_pass() {
+		let exps = [exp("tamanu-central-api", Instances::NumericAtLeast(2))];
+		let running = HashMap::from([
+			(
+				"tamanu-central-api@1.service".to_string(),
+				"v2.54.7".to_string(),
+			),
+			(
+				"tamanu-central-api@2.service".to_string(),
+				"v2.54.7".to_string(),
+			),
+		]);
+		let check = evaluate_drift(&running, &ev("v2.54.7", None), &exps);
+		assert!(matches!(check.status, CheckStatus::Pass), "{check:?}");
+	}
+
+	#[test]
+	fn drifted_frontend_fails_naming_the_unit() {
+		// env wants frontend v2.54.12 but the container is still on v2.54.7 —
+		// exactly the case `tamanu status` couldn't see when run unprivileged.
+		let exps = [
+			exp("tamanu-frontend", Instances::Named(&["a", "b"])),
+			exp("tamanu-central-api", Instances::NumericAtLeast(2)),
+		];
+		let running = HashMap::from([(
+			"tamanu-frontend@a.service".to_string(),
+			"v2.54.7".to_string(),
+		)]);
+		let check = evaluate_drift(&running, &ev("v2.54.7", Some("v2.54.12")), &exps);
+		match &check.status {
+			CheckStatus::Fail(reason) => {
+				assert!(reason.contains("tamanu-frontend@a"), "{reason}")
+			}
+			other => panic!("expected fail, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn unexpected_unit_is_not_drift() {
+		let exps = [exp("tamanu-central-api", Instances::NumericAtLeast(2))];
+		let running =
+			HashMap::from([("tamanu-orphan@1.service".to_string(), "v1.0.0".to_string())]);
+		let check = evaluate_drift(&running, &ev("v2.54.7", None), &exps);
+		assert!(matches!(check.status, CheckStatus::Pass), "{check:?}");
 	}
 }

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table, presets::UTF8_HORIZONTAL_ONLY};
 use miette::{IntoDiagnostic, Result, bail};
 use serde::Serialize;
+use tracing::warn;
 
 use bestool_tamanu::{
 	services::{self, ExpectedState, Expectation, Supervisor},
@@ -86,10 +87,20 @@ pub async fn run(args: StatusArgs, ctx: Context) -> Result<()> {
 	// authoritative) drift signals upstream.
 	let (install_version, _root) = find_tamanu(tamanu).await?;
 	let expected_versions = versions::expected_for_supervisor(supervisor, &install_version);
-	let running_versions = match supervisor {
-		Supervisor::Systemd => versions::running_versions_linux().await,
-		Supervisor::Pm2 => HashMap::new(),
+	// `Err` here means we couldn't read podman at all (vs. an empty map, which
+	// means nothing is running). Keep the reason so the render can say the
+	// Version column is showing expected-only rather than silently presenting
+	// the configured version as if it were confirmed running.
+	let (running_versions, running_error) = match supervisor {
+		Supervisor::Systemd => match versions::running_versions_linux().await {
+			Ok(map) => (map, None),
+			Err(reason) => (HashMap::new(), Some(reason)),
+		},
+		Supervisor::Pm2 => (HashMap::new(), None),
 	};
+	if let Some(reason) = &running_error {
+		warn!(%reason, "could not read running container versions; Version column shows expected only");
+	}
 	let probe = VersionProbe {
 		supervisor,
 		expected: expected_versions,
@@ -111,6 +122,13 @@ pub async fn run(args: StatusArgs, ctx: Context) -> Result<()> {
 
 	let (table, any_short) = render_table(&groups, &probe, use_colours);
 	println!("{table}");
+
+	if let Some(reason) = &running_error {
+		println!(
+			"\nNote: couldn't read running container versions ({reason}); the Version \
+			 column shows the configured (expected) versions only, not what's live."
+		);
+	}
 
 	if any_short {
 		bail!("some expectations are not met");

--- a/crates/tamanu/src/versions.rs
+++ b/crates/tamanu/src/versions.rs
@@ -124,35 +124,41 @@ pub fn parse_image_tag(image: &str) -> Option<&str> {
 }
 
 /// Returns a map from systemd unit name (e.g. `tamanu-central-api@1.service`)
-/// to the running container's image tag. Best-effort: containers without an
-/// image tag, or containers not labelled as systemd-managed, are skipped.
+/// to the running container's image tag. Containers without an image tag, or
+/// not labelled as systemd-managed, are skipped.
 ///
-/// Empty `HashMap` when podman is unavailable or no relevant containers are
-/// running — the caller treats "no entry for unit X" as "actual version
-/// unknown".
+/// `Ok(map)` means podman answered — an empty map then genuinely means "no
+/// tamanu containers are running". `Err(reason)` means we couldn't ask at all:
+/// podman is missing, or (the common case) the containers are root-owned and
+/// this process can't see them — e.g. an unprivileged `podman ps`. Callers
+/// must distinguish the two: surfacing `Err` as "no containers" hides a blind
+/// spot behind a healthy-looking result.
 #[cfg(target_os = "linux")]
 #[instrument(level = "debug")]
-pub async fn running_versions_linux() -> HashMap<String, String> {
-	use std::process::Stdio;
+pub async fn running_versions_linux() -> Result<HashMap<String, String>, String> {
 	let result = tokio::process::Command::new("podman")
 		.args([
 			"ps",
 			"--format",
 			"{{.Labels.PODMAN_SYSTEMD_UNIT}}\t{{.Image}}",
 		])
-		.stderr(Stdio::null())
 		.output()
 		.await;
 	let output = match result {
 		Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).into_owned(),
 		Ok(o) => {
-			debug!(status = %o.status, "podman ps exited non-zero; no actual-version info");
-			return HashMap::new();
+			let stderr = String::from_utf8_lossy(&o.stderr);
+			let stderr = stderr.trim();
+			return Err(if stderr.is_empty() {
+				format!("podman ps exited {}", o.status)
+			} else {
+				format!("podman ps exited {}: {stderr}", o.status)
+			});
 		}
-		Err(err) => {
-			debug!(%err, "podman ps unavailable; no actual-version info");
-			return HashMap::new();
+		Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+			return Err("podman not found on PATH".to_string());
 		}
+		Err(err) => return Err(format!("could not run podman ps: {err}")),
 	};
 
 	let mut out = HashMap::new();
@@ -171,12 +177,12 @@ pub async fn running_versions_linux() -> HashMap<String, String> {
 		};
 		out.insert(unit.to_string(), tag.to_string());
 	}
-	out
+	Ok(out)
 }
 
 #[cfg(not(target_os = "linux"))]
-pub async fn running_versions_linux() -> HashMap<String, String> {
-	HashMap::new()
+pub async fn running_versions_linux() -> Result<HashMap<String, String>, String> {
+	Ok(HashMap::new())
 }
 
 /// Parse a version string leniently, tolerating a leading `v` (image tags and
@@ -211,8 +217,12 @@ pub fn pick_running_version(running: &HashMap<String, String>) -> Option<Version
 }
 
 /// The version of Tamanu that's actually running, from container image tags.
+/// `None` when podman can't be read or nothing is running.
 pub async fn running_version() -> Option<Version> {
-	pick_running_version(&running_versions_linux().await)
+	match running_versions_linux().await {
+		Ok(map) => pick_running_version(&map),
+		Err(_) => None,
+	}
 }
 
 /// The version Tamanu last recorded in its own database. The server writes


### PR DESCRIPTION
🤖 Stacked on #488.

`running_versions_linux()` returned an empty map both when podman genuinely had nothing running and when it couldn't be read at all. Two consumers then treated "couldn't read" as "nothing wrong":

- alertd's `version_drift` reported a healthy pass ("no running tamanu containers detected") whenever podman was unreadable — a blind check masquerading as green, hiding the drift it exists to catch.
- `tamanu status` silently showed expected-only versions.

`running_versions_linux()` now returns `Result`: `Ok(map)` (empty means nothing running) vs `Err(reason)` (podman missing, or root-owned containers invisible). `version_drift` now returns a warning naming the reason; `status` logs and prints a note that the Version column is expected-only. The verdict is split into pure `unreadable_check`/`evaluate_drift` helpers with tests.
