### PR TITLE
fix(psql): \e opens an empty editor unless the previous command was also \e

### DIFF
--- a/crates/psql/src/audit/library.rs
+++ b/crates/psql/src/audit/library.rs
@@ -123,6 +123,7 @@ impl Audit {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			last_edit_content: None,
 			write_mode_active_at: None,
 		};
 

--- a/crates/psql/src/completer/snippets.rs
+++ b/crates/psql/src/completer/snippets.rs
@@ -159,6 +159,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			last_edit_content: None,
 			write_mode_active_at: None,
 		}));
 
@@ -202,6 +203,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			last_edit_content: None,
 			write_mode_active_at: None,
 		}));
 
@@ -243,6 +245,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			last_edit_content: None,
 			write_mode_active_at: None,
 		}));
 
@@ -287,6 +290,7 @@ mod tests {
 			result_store: crate::result_store::ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			last_edit_content: None,
 			write_mode_active_at: None,
 		}));
 

--- a/crates/psql/src/repl.rs
+++ b/crates/psql/src/repl.rs
@@ -47,14 +47,22 @@ mod tests;
 
 impl ReplAction {
 	pub(crate) async fn handle(self, ctx: &mut ReplContext<'_>, line: &str) -> ControlFlow<()> {
-		// Add to history, except for SnippetSave and Edit. Edit must be excluded
-		// so that `handle_edit` picks up the previous query as the editor's
-		// initial content rather than the `\e` invocation itself.
+		let is_edit = matches!(self, ReplAction::Edit);
+
+		// Add to history, except for SnippetSave and Edit. Edit is excluded so
+		// the bare `\e` invocation doesn't land in history; the query it
+		// produces is recorded separately by `handle_edit`.
 		if !matches!(self, ReplAction::SnippetSave { .. } | ReplAction::Edit) {
 			let history = ctx.rl.history_mut();
 			if let Err(e) = history.add_entry(line.into()) {
 				debug!("failed to add to history: {e}");
 			}
+		}
+
+		// `\e` only reopens the previous buffer when run back-to-back; any other
+		// command resets it so the next `\e` starts from an empty editor.
+		if !is_edit {
+			ctx.repl_state.lock().unwrap().last_edit_content = None;
 		}
 
 		self.dispatch(ctx, line).await
@@ -195,6 +203,7 @@ pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 		transaction_state: TransactionState::None,
 		result_store: ResultStore::new(),
 		initial_content: None,
+		last_edit_content: None,
 		write_mode_active_at: None,
 	};
 
@@ -323,6 +332,9 @@ pub async fn run(pool: PgPool, config: Arc<Config>) -> Result<()> {
 					if let Err(e) = history.add_entry(line.into()) {
 						debug!("failed to add to history: {e}");
 					}
+					// A buffered (incomplete) line is still a non-`\e` command,
+					// so it resets the editor-reopen chain.
+					ctx.repl_state.lock().unwrap().last_edit_content = None;
 				} else {
 					for action in actions {
 						if action.handle(&mut ctx, line).await.is_break() {

--- a/crates/psql/src/repl/edit.rs
+++ b/crates/psql/src/repl/edit.rs
@@ -1,24 +1,28 @@
 use std::ops::ControlFlow;
 
-use rustyline::history::{History, SearchDirection};
 use tracing::{debug, warn};
 
 use super::state::ReplContext;
 use crate::input::{ReplAction, handle_input};
 
+/// What to seed the `\e` editor with.
+///
+/// Empty by default; when the immediately-preceding command was also `\e`, its
+/// resulting buffer (passed here via `last_edit`), so back-to-back `\e` keeps
+/// refining the same text. Never the bare `\e` invocation itself.
+fn editor_seed(last_edit: Option<&str>) -> String {
+	match last_edit {
+		Some(prev) if prev.trim() != "\\e" => prev.to_string(),
+		_ => String::new(),
+	}
+}
+
 pub async fn handle_edit(ctx: &mut ReplContext<'_>) -> ControlFlow<()> {
 	use super::execute::handle_execute;
 
 	let initial_content = {
-		let hist_len = ctx.rl.history().len();
-		if hist_len > 0 {
-			match ctx.rl.history().get(hist_len - 1, SearchDirection::Forward) {
-				Ok(Some(result)) => result.entry.to_string(),
-				_ => String::new(),
-			}
-		} else {
-			String::new()
-		}
+		let state = ctx.repl_state.lock().unwrap();
+		editor_seed(state.last_edit_content.as_deref())
 	};
 
 	match edit::edit(&initial_content) {
@@ -27,6 +31,9 @@ pub async fn handle_edit(ctx: &mut ReplContext<'_>) -> ControlFlow<()> {
 
 			if !edited_trimmed.is_empty() {
 				debug!("editor returned content, processing it");
+
+				// Remember it so a follow-up `\e` reopens this buffer.
+				ctx.repl_state.lock().unwrap().last_edit_content = Some(edited_content.clone());
 
 				let history = ctx.rl.history_mut();
 				if let Err(e) = history.add_entry(edited_content.clone()) {
@@ -62,6 +69,8 @@ pub async fn handle_edit(ctx: &mut ReplContext<'_>) -> ControlFlow<()> {
 				}
 			} else {
 				debug!("editor returned empty content, skipping");
+				// The edit produced nothing, so a follow-up `\e` starts empty.
+				ctx.repl_state.lock().unwrap().last_edit_content = None;
 			}
 		}
 		Err(e) => {
@@ -70,4 +79,25 @@ pub async fn handle_edit(ctx: &mut ReplContext<'_>) -> ControlFlow<()> {
 	}
 
 	ControlFlow::Continue(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::editor_seed;
+
+	#[test]
+	fn seed_empty_by_default() {
+		assert_eq!(editor_seed(None), "");
+	}
+
+	#[test]
+	fn seed_reuses_previous_edit() {
+		assert_eq!(editor_seed(Some("SELECT 1")), "SELECT 1");
+	}
+
+	#[test]
+	fn seed_never_the_edit_metacommand() {
+		assert_eq!(editor_seed(Some("\\e")), "");
+		assert_eq!(editor_seed(Some("  \\e  ")), "");
+	}
 }

--- a/crates/psql/src/repl/state.rs
+++ b/crates/psql/src/repl/state.rs
@@ -31,6 +31,10 @@ pub struct ReplState {
 	pub result_store: ResultStore,
 	pub from_snippet_or_include: bool,
 	pub initial_content: Option<String>,
+	/// Buffer the last `\e` invocation produced, kept only while `\e`s run
+	/// back-to-back. A repeated `\e` reopens it so you can keep refining the
+	/// same text; any other command clears it, so the next `\e` starts empty.
+	pub last_edit_content: Option<String>,
 	/// When write mode was last considered "active" — either toggled on, or
 	/// just after a successful query while in write mode. Used by the idle
 	/// timeout watcher to decide when to revert write mode to read-only.
@@ -61,6 +65,7 @@ impl ReplState {
 			result_store: ResultStore::new(),
 			from_snippet_or_include: false,
 			initial_content: None,
+			last_edit_content: None,
 			write_mode_active_at: None,
 		}
 	}

--- a/crates/psql/src/repl/tests.rs
+++ b/crates/psql/src/repl/tests.rs
@@ -1509,6 +1509,7 @@ async fn test_exit_blocked_with_active_transaction() {
 		transaction_state: TransactionState::Active,
 		result_store: crate::result_store::ResultStore::new(),
 		initial_content: None,
+		last_edit_content: None,
 		write_mode_active_at: None,
 	}));
 
@@ -1600,6 +1601,7 @@ async fn test_exit_allowed_after_commit() {
 		result_store: crate::result_store::ResultStore::new(),
 		from_snippet_or_include: false,
 		initial_content: None,
+		last_edit_content: None,
 		write_mode_active_at: None,
 	}));
 
@@ -1672,6 +1674,7 @@ async fn test_exit_allowed_in_readonly_mode() {
 		result_store: crate::result_store::ResultStore::new(),
 		from_snippet_or_include: false,
 		initial_content: None,
+		last_edit_content: None,
 		write_mode_active_at: None,
 	}));
 


### PR DESCRIPTION
🤖 `\e` seeded the editor with the last history entry, so it unconditionally reopened the previous query — and could even seed the literal `\e` invocation itself.

Now the editor opens **empty**, except when the immediately-preceding command was also `\e`: then it reopens that edit's buffer, so back-to-back `\e` lets you keep refining the same text. The bare `\e` is never used as the seed.

Tracked via a new `ReplState::last_edit_content`, set by `handle_edit` when it produces content and cleared by any other command (including buffered incomplete input). The seed selection is factored into a small `editor_seed` helper with tests covering the empty default, the reopen-previous case, and the never-`\e` guard.
