### PR TITLE
refactor(alertd): promote daemon to top-level bestool alertd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,32 @@ jobs:
       - name: Contract tests against live canopy
         run: cargo test -p bestool --lib canopy_contract -- --ignored
 
+  alertd-no-db:
+    name: alertd / graceful without postgres
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Configure toolchain
+        run: |
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build alertd tests
+        run: cargo test -p bestool-alertd --lib --no-run --message-format=json > alertd-tests.json
+      - name: Run doctor checks in a postgres-less network namespace
+        run: |
+          set -euo pipefail
+          bin=$(jq -r 'select(.reason == "compiler-artifact" and (.target.kind == ["lib"]) and .executable != null and (.package_id | test("bestool-alertd"))) | .executable' alertd-tests.json | tail -n1)
+          test -n "$bin" || { echo "could not locate alertd lib test binary"; exit 1; }
+          echo "running doctor checks in a fresh network namespace: $bin"
+          # A new network namespace has no route to the host's postgres, so the
+          # doctor checks must degrade gracefully (db_connect alerts, DB-backed
+          # checks skip) rather than hang or panic. `sudo unshare` runs as real
+          # root, sidestepping ubuntu 24.04's restriction on unprivileged user
+          # namespaces. We scope to `doctor::` because the http_server tests need
+          # working loopback HTTP that a bare namespace doesn't provide.
+          sudo unshare --net -- bash -c "ip link set lo up && exec '$bin' doctor::"
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -125,7 +151,7 @@ jobs:
   tests-pass:
     if: always()
     name: Tests pass
-    needs: [test, contract, check-docs]
+    needs: [test, contract, check-docs, alertd-no-db]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,5 @@
 - To silence a warning, use `#[expect(..., reason = "...")]` instead of `#[allow(...)]`.
 - When changing Windows-specific code, run `cargo check` with a Windows GNU target (unless currently running on Windows).
 - Releases are automated via release-plz: pushing to `main` opens a `repo: release` PR which auto-merges and publishes to crates.io. No manual release step is needed.
+- It's very important for alertd that postgres (or anything else we're checking) IS NOT REQUIRED for the alertd daemon to start, because otherwise we CANNOT ALERT ON THE DATABASE BEING DOWN.
 <!-- end rules -->

--- a/crates/alertd/src/doctor/checks/db_connect.rs
+++ b/crates/alertd/src/doctor/checks/db_connect.rs
@@ -47,3 +47,41 @@ pub async fn run(ctx: CheckContext) -> Check {
 		.with_detail("db_name", name)
 		.with_detail("latency_ms", latency_ms)
 }
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Arc;
+
+	use node_semver::Version;
+
+	use bestool_tamanu::{ApiServerKind, config::TamanuConfig};
+
+	use super::*;
+	use crate::doctor::check::CheckStatus;
+
+	/// An unreachable postgres must surface as a FAIL (an alert), never a crash
+	/// or hang — this is what lets the daemon flag a down database. Port 1 has
+	/// nothing listening, so the connection is refused immediately.
+	#[tokio::test]
+	async fn unreachable_postgres_alerts() {
+		let config: TamanuConfig = serde_json::from_value(serde_json::json!({
+			"db": { "name": "tamanu-central", "username": "u", "password": "p" }
+		}))
+		.unwrap();
+		let ctx = CheckContext {
+			tamanu_version: Version::parse("0.0.0").unwrap(),
+			tamanu_root: std::path::PathBuf::from("/nonexistent"),
+			config: Arc::new(config),
+			kind: ApiServerKind::Central,
+			database_url: "postgresql://127.0.0.1:1/tamanu-central".into(),
+			db: None,
+			http_client: reqwest::Client::new(),
+		};
+		let check = run(ctx).await;
+		assert!(
+			matches!(check.status, CheckStatus::Fail(_)),
+			"expected FAIL on unreachable postgres, got {:?}",
+			check.status
+		);
+	}
+}

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -40,7 +40,7 @@ pub fn http_client() -> reqwest::Client {
 pub struct DaemonConfig {
 	/// Database connection pool, opened by the caller.
 	///
-	/// Centralising pool creation at the caller lets `bestool tamanu alertd`
+	/// Centralising pool creation at the caller lets `bestool alertd`
 	/// reuse the pool for one-off setup queries (kind detection, device key
 	/// lookup) instead of opening additional short-lived connections.
 	///

--- a/crates/alertd/src/windows_service.rs
+++ b/crates/alertd/src/windows_service.rs
@@ -298,7 +298,7 @@ fn run_diagnostics() {
 	match Command::new("sc").args(&["query", SERVICE_NAME]).output() {
 		Ok(output) if output.status.success() => {
 			println!("✗ Service already exists");
-			println!("  Tip: Run 'bestool tamanu alertd uninstall' first\n");
+			println!("  Tip: Run 'bestool alertd uninstall' first\n");
 		}
 		_ => {
 			println!("✓ Service not found (good)");
@@ -413,7 +413,7 @@ pub fn install_service_with_args(launch_arguments: &[OsString]) -> Result<()> {
 		.map_err(|e| {
 			let error_msg = e.to_string();
 			if error_msg.contains("Already exists") || error_msg.contains("ERROR_SERVICE_EXISTS") {
-				miette!("Service 'bestool-alertd' already exists.\n\nTroubleshoot:\n  - To reinstall, run: bestool tamanu alertd uninstall\n  - Then run: bestool tamanu alertd install")
+				miette!("Service 'bestool-alertd' already exists.\n\nTroubleshoot:\n  - To reinstall, run: bestool alertd uninstall\n  - Then run: bestool alertd install")
 			} else if error_msg.contains("Access is denied") || error_msg.contains("ERROR_ACCESS_DENIED") {
 				miette!("Failed to create service: {}\n\nThis requires administrator privileges. Please run this command in an Administrator command prompt or PowerShell.", error_msg)
 			} else {

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -96,12 +96,16 @@ windows-service = { version = "0.8.0", optional = true }
 windows_exe_info = { version = "0.5.2", features = ["manifest"] }
 
 [features]
-default = ["caddy", "canopy", "completions", "crypto", "kopia", "rdp", "self-update", "ssh", "tamanu"]
+default = ["alertd", "caddy", "canopy", "completions", "crypto", "kopia", "rdp", "self-update", "ssh", "tamanu"]
 
 ## Common dep groups (not meant to be used directly)
 download = ["dep:binstalk-downloader", "dep:detect-targets", "dep:hickory-resolver"]
 
 ## Subcommands
+# The daemon always reads the canopy registration (device key + server id), so
+# bestool-canopy is core, not Tamanu-gated. `alertd-tamanu` adds reading config
+# and the device key from Tamanu's DB, plus the Tamanu-specific checks.
+alertd = ["dep:bestool-alertd", "dep:bestool-canopy"]
 caddy = ["download", "dep:tera"]
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 crypto = ["dep:algae-cli", "dep:blake3", "dep:merkle_hash"]
@@ -113,7 +117,7 @@ ssh = ["dep:dirs", "dep:duct", "dep:fs4", "dep:ssh-key", "dep:privilege", "dep:w
 
 ## Tamanu subcommands
 tamanu = [ # enable all tamanu subcommands
-	"tamanu-alertd",
+	"alertd-tamanu",
 	"tamanu-artifacts",
 	"tamanu-backup",
 	"tamanu-backup-configs",
@@ -129,7 +133,11 @@ tamanu = [ # enable all tamanu subcommands
 	"tamanu-sync",
 	"tamanu-tags",
 ]
-tamanu-alertd = ["__tamanu", "tamanu-config", "dep:bestool-alertd", "dep:bestool-postgres", "bestool-tamanu/canopy-registration", "dep:p256"]
+# Wire the alertd daemon to read Tamanu's config/DB (database URL + device key
+# migration). The conjunction of `alertd` and Tamanu support; enabled by the
+# `tamanu` umbrella so default builds get it, while a Tamanu-less build can
+# still enable `alertd` alone.
+alertd-tamanu = ["alertd", "tamanu-config", "dep:bestool-postgres", "bestool-tamanu/canopy-registration"]
 tamanu-artifacts = ["__tamanu", "dep:comfy-table", "dep:detect-targets", "dep:target-tuples"]
 tamanu-backup = ["__tamanu", "file", "tamanu-config", "dep:bestool-psql", "dep:algae-cli", "dep:duct"]
 tamanu-backup-configs = ["__tamanu", "tamanu-backup", "dep:walkdir", "dep:zip"]

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -5,6 +5,9 @@ This document contains the help content for the `bestool` command-line program.
 **Command Overview:**
 
 * [`bestool`↴](#bestool)
+* [`bestool alertd`↴](#bestool-alertd)
+* [`bestool alertd run`↴](#bestool-alertd-run)
+* [`bestool alertd status`↴](#bestool-alertd-status)
 * [`bestool audit-psql`↴](#bestool-audit-psql)
 * [`bestool caddy`↴](#bestool-caddy)
 * [`bestool caddy configure-tamanu`↴](#bestool-caddy-configure-tamanu)
@@ -52,9 +55,9 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool ssh`↴](#bestool-ssh)
 * [`bestool ssh add-key`↴](#bestool-ssh-add-key)
 * [`bestool tamanu`↴](#bestool-tamanu)
-* [`bestool tamanu alertd`↴](#bestool-tamanu-alertd)
-* [`bestool tamanu alertd run`↴](#bestool-tamanu-alertd-run)
-* [`bestool tamanu alertd status`↴](#bestool-tamanu-alertd-status)
+* [`bestool tamanu alert`↴](#bestool-tamanu-alert)
+* [`bestool tamanu alert run`↴](#bestool-tamanu-alert-run)
+* [`bestool tamanu alert status`↴](#bestool-tamanu-alert-status)
 * [`bestool tamanu artifacts`↴](#bestool-tamanu-artifacts)
 * [`bestool tamanu backup`↴](#bestool-tamanu-backup)
 * [`bestool tamanu backup-configs`↴](#bestool-tamanu-backup-configs)
@@ -83,6 +86,7 @@ Didn't expect this much output? Use the short '-h' flag to get short help.
 
 ###### **Subcommands:**
 
+* `alertd` — Run the healthcheck daemon
 * `audit-psql` — Export audit database entries as JSON
 * `caddy` — Manage Caddy
 * `canopy` — Interact with Canopy (the Tamanu meta-monitoring service)
@@ -136,6 +140,68 @@ Didn't expect this much output? Use the short '-h' flag to get short help.
    This can be useful when running under service managers that capture logs, to avoid having two timestamps. When run under systemd, this is automatically enabled.
 
    This option is ignored if the log file is set, or when using `RUST_LOG` or equivalent (as logging is initialized before arguments are parsed in that case); you may want to use `LOG_TIMELESS` instead in the latter case.
+
+
+
+## `bestool alertd`
+
+Run the healthcheck daemon
+
+Periodically runs the doctor healthcheck sweep and posts the result to
+canopy. On a Tamanu host, database and device-key configuration is read from
+Tamanu's config files; on other hosts the daemon still runs and posts
+sweeps, with every Tamanu-dependent check skipped.
+
+**Usage:** `bestool alertd <COMMAND>`
+
+###### **Subcommands:**
+
+* `run` — Run the healthcheck daemon
+* `status` — Show status and health of a running daemon
+
+
+
+## `bestool alertd run`
+
+Run the healthcheck daemon
+
+Starts the daemon which runs the doctor healthcheck sweep on a schedule and posts the result to canopy.
+
+**Usage:** `bestool alertd run [OPTIONS]`
+
+###### **Options:**
+
+* `--glob <GLOB>` — Deprecated, does nothing.
+
+   Previously selected the alert definition files to load. The daemon no longer loads alert definitions; the option is still accepted so existing invocations keep working until they are migrated.
+* `--no-server` — Disable the HTTP server
+* `--server-addr <SERVER_ADDR>` — HTTP server bind address(es)
+
+   Can be provided multiple times. The server will attempt to bind to each address in order until one succeeds. Defaults to [::1]:8271 and 127.0.0.1:8271
+* `--watchdog-timeout <WATCHDOG_TIMEOUT>` — Watchdog timeout in seconds
+
+   If no task reports activity within this many seconds, the daemon will exit so the service manager can restart it. Defaults to 600 (10 minutes).
+
+  Default value: `600`
+* `--no-watchdog` — Disable the watchdog
+
+   By default, the daemon will exit if no task activity is detected within the watchdog timeout. This flag disables that behaviour.
+
+
+
+## `bestool alertd status`
+
+Show status and health of a running daemon
+
+Connects to the running daemon's HTTP API and displays version, uptime, health, and watchdog information. Exits with code 1 if the daemon is unhealthy.
+
+**Usage:** `bestool alertd status [OPTIONS]`
+
+###### **Options:**
+
+* `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try
+
+   Can be provided multiple times. Will attempt to connect to each address in order until one succeeds. Defaults to [::1]:8271 and 127.0.0.1:8271
 
 
 
@@ -1280,7 +1346,7 @@ Alias: t
 
 ###### **Subcommands:**
 
-* `alertd` — Run the healthcheck daemon
+* `alert` — Run the healthcheck daemon
 * `artifacts` — List available artifacts for a Tamanu version
 * `backup` — Backup a local Tamanu database to a single file
 * `backup-configs` — Backup local Tamanu-related config files to a zip archive
@@ -1306,15 +1372,16 @@ pseudo-services.
 
 
 
-## `bestool tamanu alertd`
+## `bestool tamanu alert`
 
 Run the healthcheck daemon
 
 Periodically runs the doctor healthcheck sweep and posts the result to
-canopy. Database and device-key configuration is read from Tamanu's config
-files.
+canopy. On a Tamanu host, database and device-key configuration is read from
+Tamanu's config files; on other hosts the daemon still runs and posts
+sweeps, with every Tamanu-dependent check skipped.
 
-**Usage:** `bestool tamanu alertd <COMMAND>`
+**Usage:** `bestool tamanu alert <COMMAND>`
 
 ###### **Subcommands:**
 
@@ -1323,13 +1390,13 @@ files.
 
 
 
-## `bestool tamanu alertd run`
+## `bestool tamanu alert run`
 
 Run the healthcheck daemon
 
 Starts the daemon which runs the doctor healthcheck sweep on a schedule and posts the result to canopy.
 
-**Usage:** `bestool tamanu alertd run [OPTIONS]`
+**Usage:** `bestool tamanu alert run [OPTIONS]`
 
 ###### **Options:**
 
@@ -1351,13 +1418,13 @@ Starts the daemon which runs the doctor healthcheck sweep on a schedule and post
 
 
 
-## `bestool tamanu alertd status`
+## `bestool tamanu alert status`
 
 Show status and health of a running daemon
 
 Connects to the running daemon's HTTP API and displays version, uptime, health, and watchdog information. Exits with code 1 if the daemon is unhealthy.
 
-**Usage:** `bestool tamanu alertd status [OPTIONS]`
+**Usage:** `bestool tamanu alert status [OPTIONS]`
 
 ###### **Options:**
 

--- a/crates/bestool/src/actions.rs
+++ b/crates/bestool/src/actions.rs
@@ -66,6 +66,8 @@ subcommands! {
 		Ok((action, ctx))
 	}]
 
+	#[cfg(feature = "alertd")]
+	alertd => Alertd(AlertdArgs),
 	#[cfg(feature = "tamanu-psql")]
 	audit_psql => AuditPsql(AuditPsqlArgs),
 	#[cfg(feature = "caddy")]

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -1,25 +1,19 @@
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use clap::{Parser, Subcommand};
 use miette::Result;
-use node_semver::Version;
-use tracing::{debug, warn};
+use tracing::warn;
 
-use bestool_tamanu::{
-	config::load_config,
-	server_info::{fetch_device_key_with, query_device_key_row},
-};
+use bestool_alertd::doctor::DoctorTask;
 
-use bestool_alertd::doctor::{DoctorTask, SweepTamanu};
-
-use super::{TamanuArgs, try_find_tamanu};
 use crate::actions::Context;
 
 /// Run the healthcheck daemon
 ///
 /// Periodically runs the doctor healthcheck sweep and posts the result to
-/// canopy. Database and device-key configuration is read from Tamanu's config
-/// files.
+/// canopy. On a Tamanu host, database and device-key configuration is read from
+/// Tamanu's config files; on other hosts the daemon still runs and posts
+/// sweeps, with every Tamanu-dependent check skipped.
 #[derive(Debug, Clone, Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct AlertdArgs {
@@ -128,15 +122,13 @@ pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 			bestool_alertd::commands::get_status(&addrs).await
 		}
 		Command::Run { daemon } => {
-			let install = try_find_tamanu(ctx.require::<TamanuArgs>()).await?;
-			let daemon_config = build_config(install, daemon).await?;
+			let daemon_config = build_config(&ctx, daemon).await?;
 			bestool_alertd::run(daemon_config).await
 		}
 		#[cfg(windows)]
 		Command::Install => {
 			use std::ffi::OsString;
 			bestool_alertd::windows_service::install_service_with_args(&[
-				OsString::from("tamanu"),
 				OsString::from("alertd"),
 				OsString::from("service"),
 			])
@@ -147,8 +139,6 @@ pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 		Command::ConfigureRecovery => bestool_alertd::windows_service::configure_recovery(),
 		#[cfg(windows)]
 		Command::Service { daemon } => {
-			let install = try_find_tamanu(ctx.require::<TamanuArgs>()).await?;
-
 			// Check and auto-apply recovery configuration if needed
 			match bestool_alertd::windows_service::is_recovery_configured() {
 				Ok(false) => {
@@ -163,25 +153,45 @@ pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 				Ok(true) => {}
 			}
 
-			let daemon_config = build_config(install, daemon).await?;
+			let daemon_config = build_config(&ctx, daemon).await?;
 			bestool_alertd::windows_service::run_service(daemon_config)
 		}
 	}
 }
 
-async fn build_config(
-	install: Option<(Version, PathBuf)>,
-	DaemonArgs {
+/// Build the daemon config, reading Tamanu's config files and DB for the
+/// database URL and (migrated) device key. Honours a `--root` when invoked via
+/// the `tamanu alert` alias; top-level `bestool alertd` probes the default
+/// locations. A host with no Tamanu still runs the daemon, with every
+/// Tamanu-dependent check skipped.
+#[cfg(feature = "alertd-tamanu")]
+async fn build_config(ctx: &Context, daemon: DaemonArgs) -> Result<bestool_alertd::DaemonConfig> {
+	use std::path::PathBuf;
+
+	use node_semver::Version;
+	use tracing::debug;
+
+	use bestool_alertd::doctor::SweepTamanu;
+	use bestool_tamanu::{
+		config::load_config,
+		server_info::{fetch_device_key_with, query_device_key_row},
+	};
+
+	let DaemonArgs {
 		glob,
 		no_server,
 		server_addr,
 		watchdog_timeout,
 		no_watchdog,
-	}: DaemonArgs,
-) -> Result<bestool_alertd::DaemonConfig> {
+	} = daemon;
 	if !glob.is_empty() {
 		warn!("--glob is deprecated and does nothing; alert definitions are no longer loaded");
 	}
+
+	let root = ctx
+		.get::<crate::actions::tamanu::TamanuArgs>()
+		.and_then(|t| t.root.clone());
+	let install: Option<(Version, PathBuf)> = bestool_tamanu::try_find_tamanu(root.as_deref()).await?;
 
 	// `None` when this host has no Tamanu: the daemon still runs (and posts
 	// sweeps), with every Tamanu-dependent check skipped.
@@ -203,10 +213,20 @@ async fn build_config(
 		}
 	};
 
+	// A pool error here means postgres is down or unreachable. Don't abort
+	// startup over it: the daemon must still run so the `db_connect` check
+	// (which connects via `database_url`, not this pool) can report it. The
+	// pool is only used for the device-key DB read below, which falls back to
+	// the registration anyway.
 	let pg_pool = match &tamanu {
-		Some(t) => {
-			Some(bestool_postgres::pool::create_pool(&t.database_url, "bestool-alertd").await?)
-		}
+		Some(t) => match bestool_postgres::pool::create_pool(&t.database_url, "bestool-alertd").await
+		{
+			Ok(pool) => Some(pool),
+			Err(err) => {
+				warn!(%err, "postgres not reachable at startup; db_connect will report it");
+				None
+			}
+		},
 		None => None,
 	};
 
@@ -254,5 +274,52 @@ async fn build_config(
 		daemon_config = daemon_config.with_device_key_pem(pem);
 	}
 
+	Ok(daemon_config)
+}
+
+/// Build the daemon config without any Tamanu integration (this build has no
+/// Tamanu support). The daemon still runs and posts sweeps; every
+/// Tamanu-dependent check is skipped.
+#[cfg(not(feature = "alertd-tamanu"))]
+async fn build_config(_ctx: &Context, daemon: DaemonArgs) -> Result<bestool_alertd::DaemonConfig> {
+	let DaemonArgs {
+		glob,
+		no_server,
+		server_addr,
+		watchdog_timeout,
+		no_watchdog,
+	} = daemon;
+	if !glob.is_empty() {
+		warn!("--glob is deprecated and does nothing; alert definitions are no longer loaded");
+	}
+	warn!("this build has no Tamanu support; doctor sweeps will skip Tamanu checks");
+
+	let watchdog = if no_watchdog {
+		None
+	} else {
+		Some(std::time::Duration::from_secs(watchdog_timeout))
+	};
+
+	// The device key (for mTLS to canopy) always comes from the canopy
+	// registration — enrolled via `bestool canopy register`, not Tamanu.
+	let device_key_pem = bestool_canopy::registration::load()
+		.await
+		.ok()
+		.flatten()
+		.and_then(|reg| reg.device_key);
+
+	// Canopy requires a version on every request; `0.0.0` is the agreed
+	// sentinel for hosts with no Tamanu.
+	let mut daemon_config = bestool_alertd::DaemonConfig::new(None, None, "0.0.0".to_string())
+		.with_no_server(no_server)
+		.with_server_addrs(server_addr)
+		.with_watchdog_timeout(watchdog)
+		.with_task(Arc::new(DoctorTask::new(
+			env!("CARGO_PKG_VERSION").to_string(),
+			None,
+		)));
+	if let Some(pem) = device_key_pem {
+		daemon_config = daemon_config.with_device_key_pem(pem);
+	}
 	Ok(daemon_config)
 }

--- a/crates/bestool/src/actions/tamanu.rs
+++ b/crates/bestool/src/actions/tamanu.rs
@@ -42,8 +42,9 @@ super::subcommands! {
 		Ok((action, ctx))
 	}]
 
-	#[cfg(feature = "tamanu-alertd")]
-	alertd => Alertd(AlertdArgs),
+	#[cfg(feature = "alertd")]
+	#[clap(alias = "alertd")]
+	alert => Alert(AlertArgs),
 	#[cfg(feature = "tamanu-artifacts")]
 	#[clap(alias = "art")]
 	artifacts => Artifacts(ArtifactsArgs),

--- a/crates/bestool/src/actions/tamanu/alert.rs
+++ b/crates/bestool/src/actions/tamanu/alert.rs
@@ -1,0 +1,6 @@
+//! Backwards-compatible alias for the top-level `bestool alertd` command.
+//!
+//! The daemon moved out of the `tamanu` namespace (it now also serves non-Tamanu
+//! hosts), but `bestool tamanu alert` / `bestool tamanu alertd` keep working —
+//! both delegate to [`crate::actions::alertd`].
+pub use crate::actions::alertd::{AlertdArgs as AlertArgs, run};


### PR DESCRIPTION
🤖 The alert daemon isn't tamanu-specific anymore (the recent host-level checks — btrfs, inodes, disk — serve non-Tamanu hosts too), so this moves it out of the `tamanu` namespace.

**Command**
- `bestool alertd` is now the canonical command (`run`, `status`, and the Windows `install`/`uninstall`/`service` subcommands).
- `bestool tamanu alert` stays as an alias, with `alertd` as a clap alias on it — so existing `bestool tamanu alertd ...` invocations keep working unchanged. The tamanu-side module is a thin re-export of the top-level one.
- The Windows service now installs itself as `bestool alertd service` (was `bestool tamanu alertd service`); already-installed services keep working via the alias.

**Feature**
- Renamed `tamanu-alertd` → `alertd` — a standalone daemon feature (just `dep:bestool-alertd`), added to default.
- Reading Tamanu's config/DB (database URL + device-key migration) is split into a conjunction feature `alertd-tamanu` = `alertd` + `tamanu-config` + the integration deps, enabled by the `tamanu` umbrella. The migration code is `#[cfg(feature = "alertd-tamanu")]`; without it, `build_config` produces a Tamanu-less daemon. Cargo can't express "feature A *and* B", hence the explicit conjunction feature.

Verified: default build + `--no-default-features --features alertd` (standalone) + Windows GNU target all compile; clippy clean; USAGE.md regenerated; bestool lib tests pass.

Note: deployment-side (ansible/systemd) can keep calling `bestool tamanu alertd run` indefinitely via the alias, or migrate to `bestool alertd run` at leisure.
