### PR TITLE
feat(tamanu): add --ignore-unmatched to start/restart

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -2022,6 +2022,7 @@ the roll begins.
 
 ###### **Options:**
 
+* `--ignore-unmatched` — Don't error when a NAME matches no service in this deployment's expected set; warn and skip it instead. Lets an automated caller send a fixed service list (e.g. one that includes the patient portal or the FHIR worker) without knowing whether each is enabled on this host
 * `--cooldown <COOLDOWN>` — Sleep between each critical-instance roll when the HTTP probe is disabled (`--no-probe-http`). With probes enabled, the readiness probe is the signal — once a fresh instance responds, we move on to the next without waiting out the cooldown
 
   Default value: `30s`
@@ -2058,6 +2059,7 @@ watch startup.
 
 ###### **Options:**
 
+* `--ignore-unmatched` — Don't error when a NAME matches no service in this deployment's expected set; warn and skip it instead. Lets an automated caller send a fixed service list (e.g. one that includes the patient portal or the FHIR worker) without knowing whether each is enabled on this host
 * `--up-only` — Skip the stop/disable phase: only bring up missing Up services, leave any drifted Down services as-is. Useful when you want to avoid touching a service that's running but shouldn't be (e.g. because you're mid-investigation)
 * `--no-probe-http` — Skip the post-start HTTP readiness probe
 * `--probe-timeout <PROBE_TIMEOUT>` — How long to wait for started services to pass their readiness probe before bailing

--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -228,7 +228,7 @@ pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
 			.map(String::as_str)
 			.collect();
 		let up_owned: Vec<Expectation> = up_expectations.iter().map(|e| (*e).clone()).collect();
-		let m = services::match_names(&up_owned, &tamanu_name_refs)?;
+		let m = services::match_names(&up_owned, &tamanu_name_refs, false)?;
 		m.iter()
 			.map(|e| {
 				up_expectations

--- a/crates/bestool/src/actions/tamanu/restart.rs
+++ b/crates/bestool/src/actions/tamanu/restart.rs
@@ -37,6 +37,13 @@ pub struct RestartArgs {
 	/// No names = restart every running instance of every Up expectation.
 	pub names: Vec<String>,
 
+	/// Don't error when a NAME matches no service in this deployment's
+	/// expected set; warn and skip it instead. Lets an automated caller send
+	/// a fixed service list (e.g. one that includes the patient portal or the
+	/// FHIR worker) without knowing whether each is enabled on this host.
+	#[arg(long)]
+	pub ignore_unmatched: bool,
+
 	/// Sleep between each critical-instance roll when the HTTP probe is
 	/// disabled (`--no-probe-http`). With probes enabled, the readiness
 	/// probe is the signal — once a fresh instance responds, we move on
@@ -62,7 +69,7 @@ pub async fn run(args: RestartArgs, ctx: Context) -> Result<()> {
 	let (supervisor, expectations) =
 		lifecycle::config_and_expectations(tamanu, WaitForDb::No).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
-	let matched = services::match_names(&expectations, &names)?;
+	let matched = services::match_names(&expectations, &names, args.ignore_unmatched)?;
 	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor).await?;
 	let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -46,6 +46,13 @@ pub struct StartArgs {
 	/// No names = consider every expectation.
 	pub names: Vec<String>,
 
+	/// Don't error when a NAME matches no service in this deployment's
+	/// expected set; warn and skip it instead. Lets an automated caller send
+	/// a fixed service list (e.g. one that includes the patient portal or the
+	/// FHIR worker) without knowing whether each is enabled on this host.
+	#[arg(long)]
+	pub ignore_unmatched: bool,
+
 	/// Skip the stop/disable phase: only bring up missing Up services,
 	/// leave any drifted Down services as-is. Useful when you want to
 	/// avoid touching a service that's running but shouldn't be (e.g.
@@ -78,7 +85,7 @@ pub async fn run(args: StartArgs, ctx: Context) -> Result<()> {
 	let (supervisor, expectations) =
 		lifecycle::config_and_expectations(tamanu, WaitForDb::Yes).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
-	let matched = services::match_names(&expectations, &names)?;
+	let matched = services::match_names(&expectations, &names, args.ignore_unmatched)?;
 	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor).await?;
 	let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);

--- a/crates/bestool/src/actions/tamanu/status.rs
+++ b/crates/bestool/src/actions/tamanu/status.rs
@@ -56,7 +56,7 @@ pub async fn run(args: StatusArgs, ctx: Context) -> Result<()> {
 	let (supervisor, expectations) =
 		lifecycle::config_and_expectations(tamanu, WaitForDb::No).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
-	let matched = services::match_names(&expectations, &names)?;
+	let matched = services::match_names(&expectations, &names, false)?;
 	let discovered = lifecycle::discover(supervisor).await?;
 	let mut groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);
 	if matches!(supervisor, Supervisor::Systemd) {

--- a/crates/bestool/src/actions/tamanu/stop.rs
+++ b/crates/bestool/src/actions/tamanu/stop.rs
@@ -30,7 +30,7 @@ pub async fn run(args: StopArgs, ctx: Context) -> Result<()> {
 	let (supervisor, expectations) =
 		lifecycle::config_and_expectations(tamanu, WaitForDb::No).await?;
 	let names: Vec<&str> = args.names.iter().map(String::as_str).collect();
-	let matched = services::match_names(&expectations, &names)?;
+	let matched = services::match_names(&expectations, &names, false)?;
 	lifecycle::warn_unknown_expectations(&matched);
 	let discovered = lifecycle::discover(supervisor).await?;
 	let groups = lifecycle::group_by_expectation(supervisor, &matched, &discovered);

--- a/crates/tamanu/src/services.rs
+++ b/crates/tamanu/src/services.rs
@@ -332,11 +332,19 @@ pub fn expected(
 /// - Otherwise: an expectation matches if **any** name in `names` is a
 ///   substring of the expectation's name.
 ///
-/// Returns an error if any name in `names` matched zero expectations
-/// (typo safety in multi-name invocations).
+/// When a name in `names` matches zero expectations, the behaviour depends on
+/// `ignore_unmatched`:
+/// - `false` (the default for interactive use): returns an error naming the
+///   unmatched patterns and the available names (typo safety in multi-name
+///   invocations).
+/// - `true`: warns about the unmatched patterns and proceeds with whatever did
+///   match (possibly nothing). Lets an automated caller send a fixed list of
+///   services without knowing which are enabled on this particular host — e.g.
+///   the patient portal (central-only) or the FHIR worker (config-gated).
 pub fn match_names<'a>(
 	expectations: &'a [Expectation],
 	names: &[&str],
+	ignore_unmatched: bool,
 ) -> miette::Result<Vec<&'a Expectation>> {
 	use miette::bail;
 
@@ -350,12 +358,19 @@ pub fn match_names<'a>(
 		.filter(|name| !expectations.iter().any(|e| e.name.contains(name)))
 		.collect();
 	if !unmatched.is_empty() {
-		let available: Vec<&str> = expectations.iter().map(|e| e.name).collect();
-		bail!(
-			"no service matches: {}; available names are: {}",
-			unmatched.join(", "),
-			available.join(", "),
-		);
+		if ignore_unmatched {
+			tracing::warn!(
+				unmatched = unmatched.join(", "),
+				"ignoring service name(s) not in this deployment's expected set"
+			);
+		} else {
+			let available: Vec<&str> = expectations.iter().map(|e| e.name).collect();
+			bail!(
+				"no service matches: {}; available names are: {}",
+				unmatched.join(", "),
+				available.join(", "),
+			);
+		}
 	}
 
 	let matched: Vec<&Expectation> = expectations
@@ -794,14 +809,14 @@ mod tests {
 	#[test]
 	fn match_names_empty_returns_everything() {
 		let es = [exp("tamanu-api"), exp("tamanu-tasks"), exp("tamanu-sync")];
-		let m = match_names(&es, &[]).unwrap();
+		let m = match_names(&es, &[], false).unwrap();
 		assert_eq!(m.len(), 3);
 	}
 
 	#[test]
 	fn match_names_substring() {
 		let es = [exp("tamanu-central-api"), exp("tamanu-central-tasks")];
-		let m = match_names(&es, &["api"]).unwrap();
+		let m = match_names(&es, &["api"], false).unwrap();
 		assert_eq!(m.len(), 1);
 		assert_eq!(m[0].name, "tamanu-central-api");
 	}
@@ -813,14 +828,14 @@ mod tests {
 			exp("tamanu-central-tasks"),
 			exp("tamanu-central-fhir-resolve"),
 		];
-		let m = match_names(&es, &["api", "fhir"]).unwrap();
+		let m = match_names(&es, &["api", "fhir"], false).unwrap();
 		assert_eq!(m.len(), 2);
 	}
 
 	#[test]
 	fn match_names_zero_match_bails() {
 		let es = [exp("tamanu-api"), exp("tamanu-tasks")];
-		let err = match_names(&es, &["nope"]).unwrap_err();
+		let err = match_names(&es, &["nope"], false).unwrap_err();
 		let msg = format!("{err}");
 		assert!(msg.contains("nope"));
 		assert!(msg.contains("tamanu-api"));
@@ -829,8 +844,28 @@ mod tests {
 	#[test]
 	fn match_names_partial_typo_still_bails() {
 		let es = [exp("tamanu-api"), exp("tamanu-tasks")];
-		let err = match_names(&es, &["api", "nope"]).unwrap_err();
+		let err = match_names(&es, &["api", "nope"], false).unwrap_err();
 		assert!(format!("{err}").contains("nope"));
+	}
+
+	#[test]
+	fn match_names_ignore_unmatched_keeps_matched_and_skips_rest() {
+		// Automated callers send a fixed list; a name absent from this
+		// deployment's set (e.g. the central-only patient portal on a facility)
+		// is skipped rather than failing the whole invocation.
+		let es = [exp("tamanu-frontend"), exp("tamanu-facility-api")];
+		let m = match_names(&es, &["frontend", "patientportal"], true).unwrap();
+		assert_eq!(m.len(), 1);
+		assert_eq!(m[0].name, "tamanu-frontend");
+	}
+
+	#[test]
+	fn match_names_ignore_unmatched_all_absent_returns_empty() {
+		// Every requested name is absent → empty match (nothing to do), not the
+		// "no names = everything" path.
+		let es = [exp("tamanu-frontend"), exp("tamanu-facility-api")];
+		let m = match_names(&es, &["patientportal"], true).unwrap();
+		assert!(m.is_empty());
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Adds a `--ignore-unmatched` flag to `bestool tamanu start` and `bestool tamanu restart`.

When a NAME matches no service in the deployment's expected set, the flag turns the hard error into a warning and skips it, instead of failing the whole invocation. This lets an automated caller (e.g. an ansible rolling upgrade) send a fixed service list — like `tamanu-frontend tamanu-patientportal` — without knowing whether each service is enabled on a given host. The patient portal is central-only and FHIR workers are config-gated, so a blanket command would otherwise error on hosts where those aren't present.

Without the flag, behaviour is unchanged: an unmatched name still errors, naming the available services (typo safety). `status`, `stop`, and `logs` keep the strict behaviour.

Came out of an upgrade run where a facility roll issued `bestool tamanu restart tamanu-frontend tamanu-patientportal` and failed because the patient portal isn't a facility service.
