### PR TITLE
feat(canopy): backup capabilities + alertd backup trigger

### DIFF
--- a/crates/alertd/src/doctor.rs
+++ b/crates/alertd/src/doctor.rs
@@ -8,4 +8,4 @@ pub mod task;
 pub use sweep::{
 	SweepResult, SweepTamanu, overall_from_payload, perform_sweep, resolve_sweep_tamanu,
 };
-pub use task::DoctorTask;
+pub use task::{BackupDispatch, DoctorTask};

--- a/crates/alertd/src/doctor/task.rs
+++ b/crates/alertd/src/doctor/task.rs
@@ -15,6 +15,13 @@ use crate::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
 
 const DOCTOR_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Invoked with the `backup_now` list from canopy's status response.
+///
+/// alertd has no backup logic of its own; the bestool binary supplies this to
+/// run the in-process backup driver. Fire-and-forget: the callback spawns its
+/// own work and guards against overlapping runs.
+pub type BackupDispatch = Arc<dyn Fn(Vec<String>) + Send + Sync>;
+
 /// Periodic doctor sweep, plus on-demand `latest` / `recompute` HTTP endpoints.
 ///
 /// The outer struct just holds an `Arc<Inner>` so we can hand inner clones to
@@ -38,6 +45,9 @@ struct DoctorTaskInner {
 	/// HTTP endpoint so `bestool tamanu doctor` can read what the daemon
 	/// already computed instead of re-running the checks itself.
 	latest: Mutex<Option<LatestSweep>>,
+	/// Runs the backup driver for the types canopy asks for via `backup_now`.
+	/// `None` when backups aren't compiled in.
+	backup_dispatch: Option<BackupDispatch>,
 }
 
 #[derive(Clone)]
@@ -58,7 +68,20 @@ impl DoctorTask {
 					.expect("default canopy URL is valid"),
 				pg_version_cache: Mutex::new(None),
 				latest: Mutex::new(None),
+				backup_dispatch: None,
 			}),
+		}
+	}
+
+	/// Attach the backup dispatcher invoked when canopy requests a backup.
+	///
+	/// Call right after [`DoctorTask::new`] (before the task is shared).
+	pub fn with_backup_dispatch(self, dispatch: BackupDispatch) -> Self {
+		let mut inner =
+			Arc::try_unwrap(self.inner).unwrap_or_else(|_| panic!("DoctorTask already shared"));
+		inner.backup_dispatch = Some(dispatch);
+		Self {
+			inner: Arc::new(inner),
 		}
 	}
 }
@@ -117,13 +140,13 @@ impl DoctorTaskInner {
 			.map_err(|err| miette!("posting doctor status to canopy: {err}"))?;
 
 		if !backup_now.is_empty() {
-			// TODO(canopy-backup): dispatch each named type to the in-process
-			// backup driver (Layer 4 trigger), guarding against overlapping runs.
-			// Lands with the `bestool canopy backup` driver.
-			warn!(
-				?backup_now,
-				"canopy requested a backup but the backup driver is not wired yet"
-			);
+			match &self.backup_dispatch {
+				Some(dispatch) => dispatch(backup_now),
+				None => warn!(
+					?backup_now,
+					"canopy requested a backup but no backup dispatcher is configured"
+				),
+			}
 		}
 
 		Ok(())

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -159,6 +159,103 @@ pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 	}
 }
 
+/// Build the doctor task, wiring the canopy backup trigger when backups are
+/// compiled in.
+fn doctor_task(
+	version: String,
+	tamanu: Option<bestool_alertd::doctor::SweepTamanu>,
+) -> DoctorTask {
+	let task = DoctorTask::new(version, tamanu);
+	#[cfg(feature = "canopy-backup")]
+	let task = task.with_backup_dispatch(backup_dispatch());
+	task
+}
+
+/// Register the daemon's tasks, adding the backup-capabilities task when backups
+/// are compiled in.
+fn with_daemon_tasks(
+	config: bestool_alertd::DaemonConfig,
+	doctor: DoctorTask,
+) -> bestool_alertd::DaemonConfig {
+	let config = config.with_task(Arc::new(doctor));
+	#[cfg(feature = "canopy-backup")]
+	let config = config.with_task(Arc::new(backup::BackupCapabilitiesTask));
+	config
+}
+
+/// The in-process backup trigger: runs the driver for each type canopy requests
+/// via `backup_now`, skipping any type already in flight.
+#[cfg(feature = "canopy-backup")]
+fn backup_dispatch() -> bestool_alertd::doctor::BackupDispatch {
+	use std::collections::HashSet;
+
+	use tokio::sync::Mutex;
+
+	let in_flight = Arc::new(Mutex::new(HashSet::<String>::new()));
+	Arc::new(move |types: Vec<String>| {
+		for backup_type in types {
+			let in_flight = in_flight.clone();
+			tokio::spawn(async move {
+				// Overlap guard: skip a type whose previous run is still going
+				// (canopy re-emits idempotently until the report clears it).
+				if !in_flight.lock().await.insert(backup_type.clone()) {
+					return;
+				}
+				if let Err(err) =
+					crate::actions::canopy::backup::run_backup(&backup_type, None, None).await
+				{
+					tracing::error!("backup '{backup_type}' failed: {err}");
+				}
+				in_flight.lock().await.remove(&backup_type);
+			});
+		}
+	})
+}
+
+/// A background task that registers this server's backup capabilities with
+/// canopy (the types of every def in the backups directory).
+#[cfg(feature = "canopy-backup")]
+mod backup {
+	use std::time::Duration;
+
+	use futures::future::BoxFuture;
+	use miette::{IntoDiagnostic as _, Result};
+	use tracing::info;
+
+	use crate::actions::canopy::backup::config;
+
+	pub(super) struct BackupCapabilitiesTask;
+
+	impl bestool_alertd::BackgroundTask for BackupCapabilitiesTask {
+		fn name(&self) -> &'static str {
+			"backup-capabilities"
+		}
+
+		fn interval(&self) -> Duration {
+			// Re-register hourly so newly-dropped defs get picked up; the first
+			// tick fires at startup.
+			Duration::from_secs(3600)
+		}
+
+		fn run<'a>(&'a self, ctx: &'a bestool_alertd::TaskContext) -> BoxFuture<'a, Result<()>> {
+			Box::pin(async move {
+				let Some(client) = ctx.canopy_client.as_ref() else {
+					return Ok(());
+				};
+				let defs = config::load_dir(&config::backups_dir()).await?;
+				let types: Vec<String> = defs.into_iter().map(|d| d.r#type).collect();
+				if types.is_empty() {
+					return Ok(());
+				}
+				let base_url = bestool_canopy::DEFAULT_CANOPY_URL.parse().into_diagnostic()?;
+				client.backup_capabilities(&base_url, &types).await?;
+				info!(?types, "registered backup capabilities with canopy");
+				Ok(())
+			})
+		}
+	}
+}
+
 /// Build the daemon config, reading Tamanu's config files and DB for the
 /// database URL and (migrated) device key. Honours a `--root` when invoked via
 /// the `tamanu alert` alias; top-level `bestool alertd` probes the default
@@ -244,18 +341,16 @@ async fn build_config(ctx: &Context, daemon: DaemonArgs) -> Result<bestool_alert
 		.map(|t| t.version.to_string())
 		.unwrap_or_else(|| "0.0.0".into());
 
-	let mut daemon_config = bestool_alertd::DaemonConfig::new(
+	let base = bestool_alertd::DaemonConfig::new(
 		pg_pool.clone(),
 		tamanu.as_ref().map(|t| t.database_url.clone()),
 		tamanu_version,
 	)
 	.with_no_server(no_server)
 	.with_server_addrs(server_addr)
-	.with_watchdog_timeout(watchdog)
-	.with_task(Arc::new(DoctorTask::new(
-		env!("CARGO_PKG_VERSION").to_string(),
-		tamanu,
-	)));
+	.with_watchdog_timeout(watchdog);
+	let doctor = doctor_task(env!("CARGO_PKG_VERSION").to_string(), tamanu);
+	let mut daemon_config = with_daemon_tasks(base, doctor);
 
 	if let Some(pem) = device_key_pem {
 		daemon_config = daemon_config.with_device_key_pem(pem);
@@ -297,14 +392,12 @@ async fn build_config(_ctx: &Context, daemon: DaemonArgs) -> Result<bestool_aler
 
 	// Canopy requires a version on every request; `0.0.0` is the agreed
 	// sentinel for hosts with no Tamanu.
-	let mut daemon_config = bestool_alertd::DaemonConfig::new(None, None, "0.0.0".to_string())
+	let base = bestool_alertd::DaemonConfig::new(None, None, "0.0.0".to_string())
 		.with_no_server(no_server)
 		.with_server_addrs(server_addr)
-		.with_watchdog_timeout(watchdog)
-		.with_task(Arc::new(DoctorTask::new(
-			env!("CARGO_PKG_VERSION").to_string(),
-			None,
-		)));
+		.with_watchdog_timeout(watchdog);
+	let doctor = doctor_task(env!("CARGO_PKG_VERSION").to_string(), None);
+	let mut daemon_config = with_daemon_tasks(base, doctor);
 	if let Some(pem) = device_key_pem {
 		daemon_config = daemon_config.with_device_key_pem(pem);
 	}

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -332,7 +332,8 @@ fn parse_snapshot_output(stdout: &str) -> SnapshotResult {
 	SnapshotResult { id, bytes_uploaded }
 }
 
-fn base_url_of(reg: &Registration) -> Result<Url> {
+/// Resolve the canopy base URL from the registration (or the default).
+pub(super) fn base_url_of(reg: &Registration) -> Result<Url> {
 	reg.api_url
 		.as_deref()
 		.unwrap_or(DEFAULT_CANOPY_URL)
@@ -341,7 +342,8 @@ fn base_url_of(reg: &Registration) -> Result<Url> {
 		.wrap_err("parsing canopy api_url")
 }
 
-async fn build_client(device_key: &str) -> Result<Arc<CanopyClient>> {
+/// Build a canopy client for an already-enrolled host (tailscale, then mTLS).
+pub(super) async fn build_client(device_key: &str) -> Result<Arc<CanopyClient>> {
 	let version = env!("CARGO_PKG_VERSION");
 	let client = CanopyClient::new(version, Some(device_key), move || {
 		bestool_canopy::client_builder(version)
@@ -351,7 +353,8 @@ async fn build_client(device_key: &str) -> Result<Arc<CanopyClient>> {
 	Ok(Arc::new(client))
 }
 
-async fn load_registration(config: Option<&Path>) -> Result<Option<Registration>> {
+/// Load the registration, honouring an explicit `--config` dir.
+pub(super) async fn load_registration(config: Option<&Path>) -> Result<Option<Registration>> {
 	match config {
 		Some(dir) => bestool_canopy::registration::load_from(dir).await,
 		None => bestool_canopy::registration::load().await,


### PR DESCRIPTION
🤖 Stacked on #511. Wires the device into Canopy's "back up now" channel and lets it advertise what it can back up — completing the register → prompted → run → report loop for the `simple` method.

## What's here

- **`bestool canopy backup-capabilities`** — a standalone command that enumerates the `type`s of every def in `/etc/bestool/backups/*.toml` and POSTs them to Canopy's `/backup-capabilities`. A type is a capability iff a config file defines it.
- **alertd capability registration** — a background task that does the same on the daemon: registers the configured types with Canopy at startup (and hourly thereafter), so a freshly-provisioned host advertises itself without operator action.
- **alertd backup trigger** — the doctor task already posts status every ~60s; now that `post_status` returns `backup_now`, it dispatches each requested type to the in-process backup driver (`run_backup`), skipping any type already in flight (Canopy re-emits idempotently until the report clears it). The dispatcher is injected from the bestool binary, so `bestool-alertd` stays decoupled from the driver.

## Notes

- The in-flight set is an in-process overlap guard; a cross-process lockfile (for a standalone run racing the daemon) is a follow-up.
- The `postgresql` method is still stubbed — this PR exercises the full loop via the `simple` method. Physical postgres backups land next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
