### PR TITLE
feat(canopy): postgresql backup method (btrfs, crash-consistent)

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -13,6 +13,7 @@
 pub mod config;
 pub mod creds;
 pub mod method;
+pub mod postgresql;
 
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
@@ -21,8 +22,8 @@ use bestool_canopy::{
 	registration::Registration,
 };
 use bestool_kopia::{
-	S3KopiaEnv, args_repository_connect_s3, args_snapshot_create, build_kopia_command_with_s3,
-	find_kopia_binary,
+	S3KopiaEnv, args_policy_set_ignores, args_repository_connect_s3, args_snapshot_create,
+	build_kopia_command_with_s3, find_kopia_binary,
 };
 use clap::Parser;
 use miette::{Context as _, IntoDiagnostic as _, Result, bail, miette};
@@ -199,11 +200,11 @@ async fn run_kopia_backup(
 ) -> Result<SnapshotResult> {
 	run_hooks(&def.pre, true).await?;
 
-	let prepared = def.method.prepare().await?;
+	let prepared = def.method.prepare(&def.r#type).await?;
 	let source_path = prepared.path.clone();
 	let tags = assemble_tags(&def.tags, &prepared.extra_tags, device_id, run_id, &def.r#type);
 
-	let result = snapshot(target, env, &source_path, server_id, &tags).await;
+	let result = snapshot(target, env, &source_path, server_id, &tags, &prepared.ignore).await;
 
 	// Cleanup and post-hooks run regardless of the snapshot outcome.
 	let cleanup = def.method.cleanup(prepared).await;
@@ -221,6 +222,7 @@ async fn snapshot(
 	source_path: &Path,
 	server_id: &str,
 	tags: &BTreeMap<String, String>,
+	ignore: &[String],
 ) -> Result<SnapshotResult> {
 	let kopia = find_kopia_binary(None).ok_or_else(|| miette!("could not find the kopia binary"))?;
 
@@ -246,6 +248,12 @@ async fn snapshot(
 		server_id,
 	);
 	run_kopia(connect, "repository connect").await?;
+
+	if !ignore.is_empty() {
+		let mut policy = build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
+		args_policy_set_ignores(&mut policy, source_path, ignore);
+		run_kopia(policy, "policy set").await?;
+	}
 
 	let mut create = build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
 	args_snapshot_create(&mut create, source_path, tags);

--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -19,6 +19,20 @@ pub struct Prepared {
 	/// Extra tags the method contributes (merged with the canopy-* tags and the
 	/// def's own `[tags]`).
 	pub extra_tags: BTreeMap<String, String>,
+	/// kopia ignore globs the driver applies to the source before snapshotting
+	/// (e.g. postgres transient files).
+	pub ignore: Vec<String>,
+	/// Method-specific teardown, run by [`Method::cleanup`].
+	pub(super) teardown: Teardown,
+}
+
+/// What [`Method::cleanup`] has to undo for a prepared source.
+#[derive(Debug)]
+pub(super) enum Teardown {
+	/// Nothing to release (e.g. the simple method).
+	Nothing,
+	/// A btrfs snapshot + its mounts.
+	Btrfs(super::postgresql::btrfs::Mounts),
 }
 
 /// `[simple]` method: snapshot a path verbatim.
@@ -32,10 +46,6 @@ pub struct SimpleConfig {
 ///
 /// Driven entirely by this table — generic postgres, no Tamanu coupling.
 #[derive(Debug, Clone, Deserialize)]
-#[expect(
-	dead_code,
-	reason = "fields are read by the postgresql snapshot machinery, implemented next"
-)]
 pub struct PostgresqlConfig {
 	/// The cluster name (e.g. `main`); resolves the data dir / connection.
 	pub cluster: String,
@@ -72,28 +82,25 @@ impl Method {
 		}
 	}
 
-	/// Produce the source kopia will snapshot.
-	pub async fn prepare(&self) -> Result<Prepared> {
+	/// Produce the source kopia will snapshot. `backup_type` is the def's label,
+	/// used by methods that key stable paths on it (e.g. btrfs mount points).
+	pub async fn prepare(&self, backup_type: &str) -> Result<Prepared> {
 		match self {
 			Method::Simple(config) => Ok(Prepared {
 				path: config.path.clone(),
 				extra_tags: BTreeMap::new(),
+				ignore: Vec::new(),
+				teardown: Teardown::Nothing,
 			}),
-			Method::Postgresql(_config) => {
-				// Implemented in the postgresql submodule (btrfs first); wired
-				// here once the snapshot machinery lands.
-				Err(miette::miette!(
-					"the postgresql backup method is not implemented yet"
-				))
-			}
+			Method::Postgresql(config) => super::postgresql::prepare(config, backup_type).await,
 		}
 	}
 
 	/// Release whatever `prepare` set up (snapshot, mount, staging dir).
-	pub async fn cleanup(&self, _prepared: Prepared) -> Result<()> {
-		match self {
-			Method::Simple(_) => Ok(()),
-			Method::Postgresql(_) => Ok(()),
+	pub async fn cleanup(&self, prepared: Prepared) -> Result<()> {
+		match prepared.teardown {
+			Teardown::Nothing => Ok(()),
+			Teardown::Btrfs(mounts) => super::postgresql::btrfs::teardown(mounts).await,
 		}
 	}
 }
@@ -107,22 +114,10 @@ mod tests {
 		let method = Method::Simple(SimpleConfig {
 			path: PathBuf::from("/data/custom"),
 		});
-		let prepared = method.prepare().await.unwrap();
+		let prepared = method.prepare("custom").await.unwrap();
 		assert_eq!(prepared.path, PathBuf::from("/data/custom"));
 		assert!(prepared.extra_tags.is_empty());
+		assert!(prepared.ignore.is_empty());
 		method.cleanup(prepared).await.unwrap();
-	}
-
-	#[tokio::test]
-	async fn postgresql_prepare_is_not_yet_implemented() {
-		let method = Method::Postgresql(PostgresqlConfig {
-			cluster: "main".into(),
-			data_dir: None,
-			version: None,
-			port: None,
-			socket: None,
-			strategy: None,
-		});
-		assert!(method.prepare().await.is_err());
 	}
 }

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -1,0 +1,129 @@
+//! The `postgresql` backup method: physical, crash-consistent cluster snapshots.
+//!
+//! Generic postgres (no Tamanu coupling): driven by the `[postgresql]` config
+//! table. Resolves the cluster's data directory, issues a best-effort
+//! `CHECKPOINT` to bound WAL replay on restore, detects the storage backend, and
+//! captures it. btrfs is implemented; thin-LVM / Windows VSS / `pg_basebackup`
+//! land in follow-ups.
+
+pub mod btrfs;
+pub mod resolve;
+pub mod strategy;
+
+use std::collections::BTreeMap;
+
+use miette::{Result, bail};
+use tracing::{info, warn};
+
+use self::strategy::Strategy;
+use super::method::{PostgresqlConfig, Prepared, Teardown};
+
+/// Transient files safe to exclude from the snapshot. Never `pg_wal`, `pg_xact`,
+/// `pg_control`, `global`, or tablespaces — those are required for recovery.
+fn ignore_globs() -> Vec<String> {
+	["postmaster.pid", "*.log", "pg_stat_tmp/*", "lost+found"]
+		.into_iter()
+		.map(String::from)
+		.collect()
+}
+
+/// Snapshot metadata carried as kopia tags (drives observability + restore).
+fn metadata_tags(resolved: &resolve::ResolvedCluster, strategy: Strategy) -> BTreeMap<String, String> {
+	BTreeMap::from([
+		("pg-version".to_owned(), resolved.version.clone()),
+		("pg-cluster".to_owned(), resolved.cluster.clone()),
+		("pg-strategy".to_owned(), format!("{strategy:?}").to_lowercase()),
+	])
+}
+
+/// Prepare a crash-consistent source for kopia.
+pub async fn prepare(config: &PostgresqlConfig, backup_type: &str) -> Result<Prepared> {
+	let resolved = resolve::resolve(config)?;
+	let strategy = strategy::detect(config.strategy.as_deref(), &resolved.data_dir)?;
+	info!(
+		cluster = %resolved.cluster,
+		version = %resolved.version,
+		?strategy,
+		data_dir = %resolved.data_dir.display(),
+		"preparing postgresql backup",
+	);
+
+	// An explicit CHECKPOINT just before the snapshot bounds how much WAL
+	// recovery replays on restore. It's an optimisation, not a correctness
+	// requirement — the snapshot is crash-consistent regardless — so a failure
+	// here must not fail the backup.
+	checkpoint(config).await;
+
+	match strategy {
+		Strategy::Btrfs => {
+			let (source, mounts) = btrfs::prepare(&resolved, backup_type).await?;
+			Ok(Prepared {
+				path: source,
+				extra_tags: metadata_tags(&resolved, strategy),
+				ignore: ignore_globs(),
+				teardown: Teardown::Btrfs(mounts),
+			})
+		}
+		other => bail!(
+			"postgresql backup strategy {other:?} is not implemented yet (btrfs only for now)"
+		),
+	}
+}
+
+/// Best-effort `CHECKPOINT` as the postgres superuser over the local socket.
+async fn checkpoint(config: &PostgresqlConfig) {
+	let psql = crate::find_postgres::find_postgres_bin("psql")
+		.map(|p| p.to_string_lossy().into_owned())
+		.unwrap_or_else(|_| "psql".to_owned());
+
+	// Run as the `postgres` OS user (peer auth) since the backup runs elevated.
+	let mut cmd = tokio::process::Command::new("sudo");
+	cmd.args(["-u", "postgres", &psql, "-X", "-q"]);
+	if let Some(socket) = &config.socket {
+		cmd.arg("-h").arg(socket);
+	}
+	if let Some(port) = config.port {
+		cmd.arg("-p").arg(port.to_string());
+	}
+	cmd.args(["-c", "CHECKPOINT;"]);
+	cmd.stdin(std::process::Stdio::null());
+
+	match cmd.status().await {
+		Ok(status) if status.success() => info!("issued CHECKPOINT before snapshot"),
+		Ok(status) => warn!(
+			%status,
+			"CHECKPOINT failed; snapshot is still crash-consistent, recovery may just replay more WAL"
+		),
+		Err(err) => warn!("could not run CHECKPOINT (continuing): {err}"),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ignore_globs_never_include_required_dirs() {
+		let globs = ignore_globs();
+		assert!(globs.contains(&"postmaster.pid".to_owned()));
+		for required in ["pg_wal", "pg_xact", "pg_control", "global"] {
+			assert!(
+				!globs.iter().any(|g| g.contains(required)),
+				"{required} must never be ignored"
+			);
+		}
+	}
+
+	#[test]
+	fn metadata_tags_carry_version_cluster_strategy() {
+		let resolved = resolve::ResolvedCluster {
+			data_dir: "/var/lib/postgresql/16/main".into(),
+			version: "16".into(),
+			cluster: "main".into(),
+		};
+		let tags = metadata_tags(&resolved, Strategy::Btrfs);
+		assert_eq!(tags.get("pg-version").map(String::as_str), Some("16"));
+		assert_eq!(tags.get("pg-cluster").map(String::as_str), Some("main"));
+		assert_eq!(tags.get("pg-strategy").map(String::as_str), Some("btrfs"));
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -1,0 +1,351 @@
+//! Crash-consistent btrfs snapshot of a postgres cluster.
+//!
+//! Mirrors the proven `kopia-backup-postgres-btrfs.sh` approach: take an atomic,
+//! read-only btrfs snapshot of the subvolume the data directory lives on (which
+//! includes `pg_wal`), mount it read-only at a **stable** path (so kopia's
+//! snapshot history/dedup attribute to one source), and hand kopia the cluster
+//! directory within. No `pg_backup_start`/`backup_label` — the snapshot restores
+//! by plain crash recovery.
+//!
+//! The privileged steps (mount, `btrfs subvolume snapshot`, id lookups) can't run
+//! in unit tests; the pure helpers (names, idmap, paths) are tested and the whole
+//! flow is verified on a real btrfs host per the plan.
+
+use std::{
+	path::{Path, PathBuf},
+	process::Stdio,
+};
+
+use miette::{Context as _, IntoDiagnostic as _, Result, bail};
+use tracing::{info, warn};
+
+use super::resolve::ResolvedCluster;
+
+/// Where the reaper looks for / makes per-run top-level mounts.
+const TOPLEVEL_MOUNT_PREFIX: &str = "/mnt/bestool-btrfs-toplevel";
+
+/// Infix marking our ephemeral snapshot subvolumes, so the reaper's glob can
+/// never match a live subvolume.
+const SNAPSHOT_INFIX: &str = "bestool-kopia-";
+
+/// Teardown state for a prepared btrfs snapshot, released by [`teardown`].
+#[derive(Debug)]
+pub struct Mounts {
+	/// The top-level (subvolid=5) mount the snapshot subvolume lives under.
+	toplevel_mount: PathBuf,
+	/// The ephemeral snapshot subvolume's path (under `toplevel_mount`).
+	snapshot_path: PathBuf,
+	/// The stable read-only mount kopia reads from.
+	kopia_mount: PathBuf,
+}
+
+/// The stable mount path for a backup type — fixed across runs so kopia sees one
+/// source. The version/cluster suffix in the source path (added by the caller)
+/// is the only part that moves, and only across a major-version upgrade.
+fn stable_kopia_mount(backup_type: &str) -> PathBuf {
+	PathBuf::from("/var/lib/kopia/bestool-backup").join(backup_type)
+}
+
+/// Name for this run's ephemeral snapshot subvolume.
+fn snapshot_name(pid: u32) -> String {
+	format!("{SNAPSHOT_INFIX}{pid}")
+}
+
+/// This run's top-level mount path.
+fn toplevel_mount(pid: u32) -> PathBuf {
+	PathBuf::from(format!("{TOPLEVEL_MOUNT_PREFIX}.{pid}"))
+}
+
+/// The btrfs `X-mount.idmap` mapping postgres's uid/gid to kopia's, so the kopia
+/// user can read the postgres-owned files in the read-only snapshot.
+fn idmap(postgres_uid: u32, kopia_uid: u32, postgres_gid: u32, kopia_gid: u32) -> String {
+	format!("u:{postgres_uid}:{kopia_uid}:1 g:{postgres_gid}:{kopia_gid}:1")
+}
+
+/// The cluster directory's path relative to the filesystem mountpoint.
+fn relative_data_path(data_dir: &Path, base_mount: &Path) -> Result<PathBuf> {
+	data_dir
+		.strip_prefix(base_mount)
+		.map(Path::to_path_buf)
+		.map_err(|_| {
+			miette::miette!(
+				"data dir {} is not under its mountpoint {}",
+				data_dir.display(),
+				base_mount.display()
+			)
+		})
+}
+
+/// Take the snapshot and mount it; returns the kopia source path and the
+/// teardown state. Caller must always pass the result to [`teardown`].
+pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(PathBuf, Mounts)> {
+	let pid = std::process::id();
+	let base_mount = findmnt_target(&resolved.data_dir).await?;
+	let rel = relative_data_path(&resolved.data_dir, &base_mount)?;
+	let fsdev = format!(
+		"/dev/disk/by-uuid/{}",
+		findmnt_field("UUID", &resolved.data_dir).await?
+	);
+
+	let map = idmap(
+		uid_of("postgres").await?,
+		uid_of("kopia").await?,
+		gid_of("postgres").await?,
+		gid_of("kopia").await?,
+	);
+
+	let kopia_mount = stable_kopia_mount(backup_type);
+	reap_stale(&fsdev, &kopia_mount).await;
+
+	let toplevel_mount = toplevel_mount(pid);
+	let snapshot_name = snapshot_name(pid);
+	let snapshot_path = toplevel_mount.join(&snapshot_name);
+
+	// Build the teardown state up front so a failure mid-prepare still cleans up.
+	let mut mounts = Mounts {
+		toplevel_mount: toplevel_mount.clone(),
+		snapshot_path: PathBuf::new(),
+		kopia_mount: PathBuf::new(),
+	};
+
+	mkdir(&toplevel_mount).await?;
+	run_ok("mount", &["-o", "subvolid=5", &fsdev, path(&toplevel_mount)]).await?;
+
+	info!(snapshot = %snapshot_path.display(), "creating read-only btrfs snapshot");
+	run_ok(
+		"btrfs",
+		&[
+			"subvolume",
+			"snapshot",
+			"-r",
+			path(&base_mount),
+			path(&snapshot_path),
+		],
+	)
+	.await?;
+	mounts.snapshot_path = snapshot_path.clone();
+
+	mkdir(&kopia_mount).await?;
+	run_ok(
+		"mount",
+		&[
+			&fsdev,
+			path(&kopia_mount),
+			"-o",
+			&format!("subvol={snapshot_name},X-mount.idmap={map}"),
+		],
+	)
+	.await?;
+	mounts.kopia_mount = kopia_mount.clone();
+
+	let source = kopia_mount.join(rel);
+	Ok((source, mounts))
+}
+
+/// Release a prepared snapshot: unmount the kopia mount, delete the snapshot
+/// subvolume, unmount and remove the top-level mount. Best-effort throughout.
+pub async fn teardown(mounts: Mounts) -> Result<()> {
+	if !mounts.kopia_mount.as_os_str().is_empty() {
+		umount(&mounts.kopia_mount).await;
+		rmdir(&mounts.kopia_mount).await;
+	}
+	if !mounts.snapshot_path.as_os_str().is_empty() {
+		let _ = run_ok(
+			"btrfs",
+			&["subvolume", "delete", path(&mounts.snapshot_path)],
+		)
+		.await
+		.inspect_err(|err| warn!("deleting snapshot subvolume failed: {err}"));
+	}
+	if !mounts.toplevel_mount.as_os_str().is_empty() {
+		umount(&mounts.toplevel_mount).await;
+		rmdir(&mounts.toplevel_mount).await;
+	}
+	Ok(())
+}
+
+/// Sweep leftovers from a previously crashed run (hard reboot skips teardown):
+/// the stable kopia mount, stray top-level mounts, and orphaned `bestool-kopia-*`
+/// snapshot subvolumes. All best-effort.
+async fn reap_stale(fsdev: &str, kopia_mount: &Path) {
+	umount(kopia_mount).await;
+
+	if let Ok(entries) = glob_prefix("/mnt", "bestool-btrfs-toplevel.") {
+		for stale in entries {
+			umount(&stale).await;
+			rmdir(&stale).await;
+		}
+	}
+
+	let reap_mount = PathBuf::from(format!("{TOPLEVEL_MOUNT_PREFIX}-reap.{}", std::process::id()));
+	if mkdir(&reap_mount).await.is_ok()
+		&& run_ok("mount", &["-o", "subvolid=5", fsdev, path(&reap_mount)])
+			.await
+			.is_ok()
+	{
+		if let Ok(subs) = glob_prefix(path(&reap_mount), SNAPSHOT_INFIX) {
+			for sub in subs {
+				let _ = run_ok("btrfs", &["subvolume", "delete", path(&sub)]).await;
+			}
+		}
+		umount(&reap_mount).await;
+	}
+	rmdir(&reap_mount).await;
+}
+
+// --- thin command wrappers -------------------------------------------------
+
+fn path(p: &Path) -> &str {
+	p.to_str().unwrap_or_default()
+}
+
+async fn run_ok(program: &str, args: &[&str]) -> Result<()> {
+	let output = tokio::process::Command::new(program)
+		.args(args)
+		.stdin(Stdio::null())
+		.output()
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("spawning {program}"))?;
+	if !output.status.success() {
+		bail!(
+			"{program} {} failed: {}",
+			args.join(" "),
+			String::from_utf8_lossy(&output.stderr).trim()
+		);
+	}
+	Ok(())
+}
+
+async fn capture(program: &str, args: &[&str]) -> Result<String> {
+	let output = tokio::process::Command::new(program)
+		.args(args)
+		.stdin(Stdio::null())
+		.output()
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("spawning {program}"))?;
+	if !output.status.success() {
+		bail!(
+			"{program} {} failed: {}",
+			args.join(" "),
+			String::from_utf8_lossy(&output.stderr).trim()
+		);
+	}
+	Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+async fn findmnt_target(data_dir: &Path) -> Result<PathBuf> {
+	Ok(PathBuf::from(findmnt_field("TARGET", data_dir).await?))
+}
+
+async fn findmnt_field(field: &str, data_dir: &Path) -> Result<String> {
+	capture("findmnt", &["-no", field, "--target", path(data_dir)]).await
+}
+
+async fn uid_of(user: &str) -> Result<u32> {
+	parse_id(&capture("id", &["-u", user]).await?, user)
+}
+
+async fn gid_of(user: &str) -> Result<u32> {
+	parse_id(&capture("id", &["-g", user]).await?, user)
+}
+
+fn parse_id(out: &str, user: &str) -> Result<u32> {
+	out.trim()
+		.parse()
+		.into_diagnostic()
+		.wrap_err_with(|| format!("parsing id for {user}: {out:?}"))
+}
+
+async fn mkdir(dir: &Path) -> Result<()> {
+	tokio::fs::create_dir_all(dir)
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("creating {}", dir.display()))
+}
+
+async fn umount(dir: &Path) {
+	if is_mountpoint(dir).await {
+		let _ = run_ok("umount", &[path(dir)]).await;
+	}
+}
+
+async fn rmdir(dir: &Path) {
+	let _ = tokio::fs::remove_dir(dir).await;
+}
+
+async fn is_mountpoint(dir: &Path) -> bool {
+	tokio::process::Command::new("mountpoint")
+		.arg("-q")
+		.arg(dir)
+		.stdin(Stdio::null())
+		.status()
+		.await
+		.map(|s| s.success())
+		.unwrap_or(false)
+}
+
+/// Directory entries whose file name starts with `prefix`.
+fn glob_prefix(dir: impl AsRef<Path>, prefix: &str) -> Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	for entry in std::fs::read_dir(dir.as_ref()).into_diagnostic()? {
+		let entry = entry.into_diagnostic()?;
+		if entry
+			.file_name()
+			.to_string_lossy()
+			.starts_with(prefix)
+		{
+			out.push(entry.path());
+		}
+	}
+	Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn snapshot_name_carries_reaper_infix() {
+		let name = snapshot_name(4242);
+		assert_eq!(name, "bestool-kopia-4242");
+		assert!(name.starts_with(SNAPSHOT_INFIX));
+	}
+
+	#[test]
+	fn idmap_format() {
+		assert_eq!(idmap(114, 997, 120, 995), "u:114:997:1 g:120:995:1");
+	}
+
+	#[test]
+	fn relative_data_path_strips_mountpoint() {
+		let rel = relative_data_path(
+			Path::new("/var/lib/postgresql/16/main"),
+			Path::new("/var/lib/postgresql"),
+		)
+		.unwrap();
+		assert_eq!(rel, PathBuf::from("16/main"));
+	}
+
+	#[test]
+	fn relative_data_path_rejects_outside() {
+		assert!(relative_data_path(Path::new("/srv/pg"), Path::new("/var/lib/postgresql")).is_err());
+	}
+
+	#[test]
+	fn stable_mount_is_per_type_and_fixed() {
+		assert_eq!(
+			stable_kopia_mount("tamanu-postgres"),
+			PathBuf::from("/var/lib/kopia/bestool-backup/tamanu-postgres")
+		);
+	}
+
+	#[test]
+	fn toplevel_mount_path() {
+		assert_eq!(
+			toplevel_mount(7),
+			PathBuf::from("/mnt/bestool-btrfs-toplevel.7")
+		);
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -1,0 +1,180 @@
+//! Resolve a postgres cluster's data directory from its `[postgresql]` config.
+//!
+//! Generic over the standard Debian/Ubuntu layout
+//! (`/var/lib/postgresql/<version>/<cluster>`), with explicit overrides for
+//! anything non-standard. No Tamanu coupling.
+
+use std::path::{Path, PathBuf};
+
+use miette::{Result, bail};
+
+use crate::actions::canopy::backup::method::PostgresqlConfig;
+
+/// The standard base directory clusters live under on Debian/Ubuntu.
+pub const POSTGRES_BASE: &str = "/var/lib/postgresql";
+
+/// A resolved cluster: where its data directory is, and its version + name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCluster {
+	pub data_dir: PathBuf,
+	pub version: String,
+	pub cluster: String,
+}
+
+/// Resolve the cluster against the standard base directory.
+pub fn resolve(config: &PostgresqlConfig) -> Result<ResolvedCluster> {
+	resolve_in(config, Path::new(POSTGRES_BASE))
+}
+
+/// Resolve against a given base directory (the seam tests inject a temp tree at).
+fn resolve_in(config: &PostgresqlConfig, base: &Path) -> Result<ResolvedCluster> {
+	// An explicit data dir wins; derive version/cluster from it (or the config).
+	if let Some(data_dir) = &config.data_dir {
+		if !is_data_dir(data_dir) {
+			bail!("{} is not a postgres data dir (no PG_VERSION)", data_dir.display());
+		}
+		let version = config
+			.version
+			.clone()
+			.or_else(|| dir_name(data_dir.parent()))
+			.unwrap_or_default();
+		return Ok(ResolvedCluster {
+			version,
+			cluster: config.cluster.clone(),
+			data_dir: data_dir.clone(),
+		});
+	}
+
+	// With a version, the path is fully determined.
+	if let Some(version) = &config.version {
+		let data_dir = base.join(version).join(&config.cluster);
+		if !is_data_dir(&data_dir) {
+			bail!(
+				"cluster '{}' version {} not found at {}",
+				config.cluster,
+				version,
+				data_dir.display()
+			);
+		}
+		return Ok(ResolvedCluster {
+			version: version.clone(),
+			cluster: config.cluster.clone(),
+			data_dir,
+		});
+	}
+
+	// Otherwise scan <base>/<version>/<cluster> for the one matching cluster.
+	let mut matches: Vec<(String, PathBuf)> = Vec::new();
+	let entries = std::fs::read_dir(base)
+		.map_err(|e| miette::miette!("reading {}: {e}", base.display()))?;
+	for entry in entries.flatten() {
+		let version_dir = entry.path();
+		let candidate = version_dir.join(&config.cluster);
+		if is_data_dir(&candidate) {
+			matches.push((
+				dir_name(Some(&version_dir)).unwrap_or_default(),
+				candidate,
+			));
+		}
+	}
+	matches.sort();
+	match matches.len() {
+		0 => bail!(
+			"no cluster '{}' found under {}; set `version` or `data_dir`",
+			config.cluster,
+			base.display()
+		),
+		1 => {
+			let (version, data_dir) = matches.into_iter().next().unwrap();
+			Ok(ResolvedCluster {
+				version,
+				cluster: config.cluster.clone(),
+				data_dir,
+			})
+		}
+		_ => bail!(
+			"cluster '{}' is ambiguous across versions {:?}; set `version`",
+			config.cluster,
+			matches.iter().map(|(v, _)| v).collect::<Vec<_>>()
+		),
+	}
+}
+
+fn is_data_dir(path: &Path) -> bool {
+	path.join("PG_VERSION").is_file()
+}
+
+fn dir_name(path: Option<&Path>) -> Option<String> {
+	path.and_then(|p| p.file_name())
+		.map(|n| n.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn config(cluster: &str, version: Option<&str>, data_dir: Option<PathBuf>) -> PostgresqlConfig {
+		PostgresqlConfig {
+			cluster: cluster.to_owned(),
+			data_dir,
+			version: version.map(str::to_owned),
+			port: None,
+			socket: None,
+			strategy: None,
+		}
+	}
+
+	fn make_cluster(base: &Path, version: &str, cluster: &str) {
+		let dir = base.join(version).join(cluster);
+		std::fs::create_dir_all(&dir).unwrap();
+		std::fs::write(dir.join("PG_VERSION"), version).unwrap();
+	}
+
+	#[test]
+	fn resolves_unique_cluster_by_scan() {
+		let tmp = tempfile::tempdir().unwrap();
+		make_cluster(tmp.path(), "16", "main");
+		let resolved = resolve_in(&config("main", None, None), tmp.path()).unwrap();
+		assert_eq!(resolved.version, "16");
+		assert_eq!(resolved.cluster, "main");
+		assert_eq!(resolved.data_dir, tmp.path().join("16").join("main"));
+	}
+
+	#[test]
+	fn version_pins_the_path() {
+		let tmp = tempfile::tempdir().unwrap();
+		make_cluster(tmp.path(), "15", "main");
+		make_cluster(tmp.path(), "16", "main");
+		let resolved = resolve_in(&config("main", Some("15"), None), tmp.path()).unwrap();
+		assert_eq!(resolved.version, "15");
+		assert_eq!(resolved.data_dir, tmp.path().join("15").join("main"));
+	}
+
+	#[test]
+	fn ambiguous_without_version_errors() {
+		let tmp = tempfile::tempdir().unwrap();
+		make_cluster(tmp.path(), "15", "main");
+		make_cluster(tmp.path(), "16", "main");
+		let err = resolve_in(&config("main", None, None), tmp.path()).unwrap_err();
+		assert!(format!("{err}").contains("ambiguous"));
+	}
+
+	#[test]
+	fn missing_cluster_errors() {
+		let tmp = tempfile::tempdir().unwrap();
+		make_cluster(tmp.path(), "16", "main");
+		let err = resolve_in(&config("other", None, None), tmp.path()).unwrap_err();
+		assert!(format!("{err}").contains("no cluster"));
+	}
+
+	#[test]
+	fn explicit_data_dir_derives_version() {
+		let tmp = tempfile::tempdir().unwrap();
+		make_cluster(tmp.path(), "16", "main");
+		let data_dir = tmp.path().join("16").join("main");
+		let resolved =
+			resolve_in(&config("main", None, Some(data_dir.clone())), tmp.path()).unwrap();
+		assert_eq!(resolved.version, "16");
+		assert_eq!(resolved.data_dir, data_dir);
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/strategy.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/strategy.rs
@@ -1,0 +1,105 @@
+//! Pick the snapshot strategy for a cluster's storage backend.
+//!
+//! btrfs is implemented here; thin-LVM, Windows VSS, and the `pg_basebackup`
+//! fallback land in follow-up PRs. Detection walks from the data directory to
+//! its filesystem type; an explicit `strategy =` in the config overrides it (for
+//! testing).
+
+use std::{path::Path, process::Command};
+
+use miette::{Result, bail};
+
+/// How a cluster's data directory is captured for backup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Strategy {
+	/// Crash-consistent btrfs subvolume snapshot.
+	Btrfs,
+	/// Crash-consistent thin-LVM snapshot — not yet implemented.
+	ThinLvm,
+	/// Crash-consistent Windows VSS shadow copy — not yet implemented.
+	Vss,
+	/// `pg_basebackup` base backup — not yet implemented.
+	BaseBackup,
+}
+
+impl Strategy {
+	fn parse(name: &str) -> Result<Self> {
+		Ok(match name {
+			"btrfs" => Strategy::Btrfs,
+			"thin-lvm" | "thinlvm" | "lvm" => Strategy::ThinLvm,
+			"vss" => Strategy::Vss,
+			"basebackup" | "base-backup" | "pg_basebackup" => Strategy::BaseBackup,
+			other => bail!("unknown backup strategy override '{other}'"),
+		})
+	}
+}
+
+/// Map a filesystem type to its strategy.
+///
+/// btrfs takes the cheap snapshot path; everything else (thick LV, ext4/xfs,
+/// …) falls back to `pg_basebackup`, which is always correct. (Thin-LVM
+/// detection — distinguishing it from thick — is a separate step added with the
+/// thin-LVM strategy.)
+fn fstype_to_strategy(fstype: &str) -> Strategy {
+	match fstype {
+		"btrfs" => Strategy::Btrfs,
+		_ => Strategy::BaseBackup,
+	}
+}
+
+/// Detect the strategy for `data_dir`, honouring a config override.
+pub fn detect(strategy_override: Option<&str>, data_dir: &Path) -> Result<Strategy> {
+	if let Some(name) = strategy_override {
+		return Strategy::parse(name);
+	}
+	if cfg!(windows) {
+		return Ok(Strategy::Vss);
+	}
+	let fstype = findmnt_fstype(data_dir)?;
+	Ok(fstype_to_strategy(&fstype))
+}
+
+/// `findmnt -no FSTYPE --target <path>` — the filesystem type backing `path`.
+fn findmnt_fstype(path: &Path) -> Result<String> {
+	let output = Command::new("findmnt")
+		.args(["-no", "FSTYPE", "--target"])
+		.arg(path)
+		.output()
+		.map_err(|e| miette::miette!("running findmnt for {}: {e}", path.display()))?;
+	if !output.status.success() {
+		bail!(
+			"findmnt failed for {}: {}",
+			path.display(),
+			String::from_utf8_lossy(&output.stderr).trim()
+		);
+	}
+	Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn fstype_mapping() {
+		assert_eq!(fstype_to_strategy("btrfs"), Strategy::Btrfs);
+		assert_eq!(fstype_to_strategy("ext4"), Strategy::BaseBackup);
+		assert_eq!(fstype_to_strategy("xfs"), Strategy::BaseBackup);
+	}
+
+	#[test]
+	fn override_parsing() {
+		assert_eq!(Strategy::parse("btrfs").unwrap(), Strategy::Btrfs);
+		assert_eq!(Strategy::parse("basebackup").unwrap(), Strategy::BaseBackup);
+		assert!(Strategy::parse("nonsense").is_err());
+	}
+
+	#[test]
+	fn override_takes_precedence() {
+		// A bogus path is never touched when the override is set.
+		assert_eq!(
+			detect(Some("btrfs"), Path::new("/nonexistent")).unwrap(),
+			Strategy::Btrfs
+		);
+	}
+}

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -230,10 +230,7 @@ impl S3KopiaEnv<'_> {
 	/// The (key, value) pairs this env sets on a kopia process.
 	fn vars(&self) -> [(&'static str, std::ffi::OsString); 4] {
 		[
-			(
-				"AWS_CONTAINER_CREDENTIALS_FULL_URI",
-				self.full_uri.into(),
-			),
+			("AWS_CONTAINER_CREDENTIALS_FULL_URI", self.full_uri.into()),
 			("AWS_CONTAINER_AUTHORIZATION_TOKEN", self.token.into()),
 			("KOPIA_PASSWORD", self.password.into()),
 			("KOPIA_CONFIG_PATH", self.config_path.as_os_str().to_owned()),
@@ -319,6 +316,15 @@ pub fn args_snapshot_create(cmd: &mut Command, path: &Path, tags: &BTreeMap<Stri
 /// Push `snapshot restore` args (restore a snapshot id into `dest`).
 pub fn args_snapshot_restore(cmd: &mut Command, snapshot_id: &str, dest: &Path) {
 	cmd.args(["snapshot", "restore", snapshot_id]).arg(dest);
+}
+
+/// Push `policy set --add-ignore=… <path>` args (ignore transient files at a source).
+pub fn args_policy_set_ignores(cmd: &mut Command, path: &Path, ignores: &[String]) {
+	cmd.args(["policy", "set"]);
+	for glob in ignores {
+		cmd.arg(format!("--add-ignore={glob}"));
+	}
+	cmd.arg(path);
 }
 
 /// A single kopia snapshot, as emitted by `kopia snapshot list --json`.
@@ -790,6 +796,26 @@ mod tests {
 		assert_eq!(
 			args_of(&cmd),
 			vec!["snapshot", "restore", "abc123", "/restore/here"]
+		);
+	}
+
+	#[test]
+	fn policy_set_ignores_args() {
+		let mut cmd = Command::new("kopia");
+		args_policy_set_ignores(
+			&mut cmd,
+			Path::new("/data/pg"),
+			&["postmaster.pid".to_owned(), "*.log".to_owned()],
+		);
+		assert_eq!(
+			args_of(&cmd),
+			vec![
+				"policy",
+				"set",
+				"--add-ignore=postmaster.pid",
+				"--add-ignore=*.log",
+				"/data/pg",
+			]
 		);
 	}
 


### PR DESCRIPTION
🤖 Stacked on #512. Implements the `postgresql` backup method — the first real consumer of the backup machinery — producing clean, restorable physical postgres backups.

This is **generic postgres**, not Tamanu-specific: it's driven entirely by the `[postgresql]` config table (`cluster`, with optional `data_dir` / `version` / `port` / `socket` / `strategy` overrides). A `tamanu-postgres` backup is just a def naming this method with `cluster = "main"`.

## What's here

- **resolve** — finds the cluster's data directory under the standard Debian/Ubuntu layout (`/var/lib/postgresql/<version>/<cluster>`), or via the overrides; errors clearly when ambiguous.
- **strategy detection** — walks from the data dir to its filesystem type and picks a snapshot strategy. **btrfs is implemented**; thin-LVM, Windows VSS, and the `pg_basebackup` fallback are routed but land in follow-ups.
- **btrfs (Strategy A)** — an atomic, read-only subvolume snapshot (which includes `pg_wal`), mounted idmapped for the kopia user at a **stable** path so kopia's history/dedup attribute to one source. A reaper sweeps leftovers from a crashed run. This mirrors the proven `kopia-backup-postgres-btrfs.sh`.
- No `pg_backup_start` / `backup_label` — the snapshot restores by plain crash recovery, which is the whole point: it's what stops the downstream `pg_resetwal` + forced-REINDEX that corrupts restores today.
- A best-effort `CHECKPOINT` before the snapshot (bounds WAL replay), transient files excluded via a kopia ignore policy, and PG version/cluster/strategy recorded as snapshot tags.

## Testing

The privileged btrfs steps (mount, `btrfs subvolume snapshot`, id lookups) can't run in CI; they're verified on a real btrfs host per the plan. The pure logic — cluster resolution, strategy mapping, idmap, snapshot/mount paths, kopia argv — is unit-tested.

## Still to come

thin-LVM and Windows VSS (Strategy A), `pg_basebackup` (Strategy B), restore, and contract tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
