### PR TITLE
feat(canopy): bestool canopy restore (full postgres swap)

### DIFF
--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -18,6 +18,7 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool canopy import`↴](#bestool-canopy-import)
 * [`bestool canopy tags`↴](#bestool-canopy-tags)
 * [`bestool canopy backup`↴](#bestool-canopy-backup)
+* [`bestool canopy restore`↴](#bestool-canopy-restore)
 * [`bestool crypto`↴](#bestool-crypto)
 * [`bestool crypto decrypt`↴](#bestool-crypto-decrypt)
 * [`bestool crypto encrypt`↴](#bestool-crypto-encrypt)
@@ -296,6 +297,7 @@ Interact with Canopy (the Tamanu meta-monitoring service)
 * `import` — Import a canopy registration exported from another machine
 * `tags` — Fetch this device's tags from canopy.
 * `backup` — Run a configured backup, driving kopia and reporting to Canopy
+* `restore` — Restore a backup from Canopy's repository
 
 
 
@@ -405,6 +407,24 @@ Run a configured backup, driving kopia and reporting to Canopy
 
    Must have a definition in the backups directory (a `*.toml` whose `type` matches).
 * `--config <DIR>` — Override the registration directory (matching `register`/`export`)
+* `--backups-dir <DIR>` — Override the backups definition directory
+
+
+
+## `bestool canopy restore`
+
+Restore a backup from Canopy's repository
+
+**Usage:** `bestool canopy restore [OPTIONS] --type <TYPE>`
+
+###### **Options:**
+
+* `--type <TYPE>` — The backup type to restore (must have a def in the backups directory)
+* `--id <ID>` — Restore a specific snapshot id (a prefix is accepted)
+* `--latest` — Restore the most recent snapshot of this type
+* `--target <PATH>` — Override the destination (the simple method's path); postgresql always targets its configured cluster
+* `--clobber-existing-data-yes-i-am-sure` — Proceed even if the destination already contains data (non-interactive)
+* `--config <DIR>` — Override the registration directory
 * `--backups-dir <DIR>` — Override the backups definition directory
 
 

--- a/crates/bestool/src/actions/canopy.rs
+++ b/crates/bestool/src/actions/canopy.rs
@@ -37,7 +37,9 @@ super::subcommands! {
 	#[cfg(feature = "canopy-tags")]
 	tags => Tags(TagsArgs),
 	#[cfg(feature = "canopy-backup")]
-	backup => Backup(BackupArgs)
+	backup => Backup(BackupArgs),
+	#[cfg(feature = "canopy-restore")]
+	restore => Restore(RestoreArgs)
 }
 
 /// Load the registration for a command that takes an optional `--config <DIR>`.

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -74,10 +74,51 @@ struct SnapshotResult {
 
 /// The per-run kopia env values (loopback creds endpoint + repo password),
 /// owned so they outlive the borrow of the lease.
-struct LeaseEnv {
-	uri: String,
-	token: String,
-	password: String,
+pub(super) struct LeaseEnv {
+	pub uri: String,
+	pub token: String,
+	pub password: String,
+}
+
+/// Lease a creds token bound to a `(type, purpose)`, refreshed from Canopy.
+pub(super) fn make_lease(
+	server: &CredsServer,
+	client: Arc<CanopyClient>,
+	base_url: Url,
+	backup_type: String,
+	purpose: Purpose,
+) -> creds::CredsLease {
+	server.lease(Arc::new(move || {
+		let client = client.clone();
+		let base_url = base_url.clone();
+		let backup_type = backup_type.clone();
+		Box::pin(async move {
+			client
+				.backup_credentials(&base_url, &backup_type, purpose)
+				.await
+				.map_err(|err| format!("{err}"))
+		})
+	}))
+}
+
+/// Connect kopia to the canopy-managed repo (source host = server id).
+pub(super) async fn connect_repo(
+	kopia: &Path,
+	s3env: &S3KopiaEnv<'_>,
+	target: &bestool_canopy::BackupTarget,
+	server_id: &str,
+) -> Result<()> {
+	let mut connect = build_kopia_command_with_s3(kopia, s3env).map_err(|e| miette!("{e}"))?;
+	args_repository_connect_s3(
+		&mut connect,
+		&target.bucket,
+		&target.prefix,
+		&target.region,
+		"canopy",
+		server_id,
+	);
+	run_kopia(connect, "repository connect").await?;
+	Ok(())
 }
 
 /// Drive one backup run end-to-end.
@@ -133,22 +174,13 @@ pub async fn run_backup(
 	};
 
 	let creds_server = CredsServer::start().await?;
-	let lease = {
-		let client = client.clone();
-		let base_url = base_url.clone();
-		let backup_type = backup_type.to_owned();
-		creds_server.lease(Arc::new(move || {
-			let client = client.clone();
-			let base_url = base_url.clone();
-			let backup_type = backup_type.clone();
-			Box::pin(async move {
-				client
-					.backup_credentials(&base_url, &backup_type, Purpose::Backup)
-					.await
-					.map_err(|err| format!("{err}"))
-			})
-		}))
-	};
+	let lease = make_lease(
+		&creds_server,
+		client.clone(),
+		base_url.clone(),
+		backup_type.to_owned(),
+		Purpose::Backup,
+	);
 
 	let env = LeaseEnv {
 		uri: lease.uri().to_owned(),
@@ -238,16 +270,7 @@ async fn snapshot(
 		config_path: &config_path,
 	};
 
-	let mut connect = build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
-	args_repository_connect_s3(
-		&mut connect,
-		&target.bucket,
-		&target.prefix,
-		&target.region,
-		"canopy",
-		server_id,
-	);
-	run_kopia(connect, "repository connect").await?;
+	connect_repo(&kopia, &s3env, target, server_id).await?;
 
 	if !ignore.is_empty() {
 		let mut policy = build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
@@ -262,7 +285,7 @@ async fn snapshot(
 }
 
 /// Run a kopia command, returning its stdout on success.
-async fn run_kopia(cmd: std::process::Command, what: &str) -> Result<String> {
+pub(super) async fn run_kopia(cmd: std::process::Command, what: &str) -> Result<String> {
 	let output = tokio::process::Command::from(cmd)
 		.output()
 		.await

--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -6,9 +6,12 @@
 //! `post` hooks. `type` is just the Canopy-facing label; the method is what
 //! decides *how* to produce a consistent source.
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+	collections::BTreeMap,
+	path::{Path, PathBuf},
+};
 
-use miette::Result;
+use miette::{Result, bail};
 use serde::Deserialize;
 
 /// A source ready for kopia to snapshot, produced by [`Method::prepare`].
@@ -103,6 +106,103 @@ impl Method {
 			Teardown::Btrfs(mounts) => super::postgresql::btrfs::teardown(mounts).await,
 		}
 	}
+
+	/// A staging directory for the restore, colocated with the eventual target's
+	/// filesystem so the final move is an atomic rename. Falls back to the temp
+	/// dir if the target can't be resolved.
+	pub fn staging_dir(&self, target_override: Option<&Path>, pid: u32) -> PathBuf {
+		let parent = match self {
+			Method::Simple(config) => target_override
+				.map(Path::to_path_buf)
+				.unwrap_or_else(|| config.path.clone())
+				.parent()
+				.map(Path::to_path_buf),
+			Method::Postgresql(config) => super::postgresql::resolve::resolve_target(config)
+				.ok()
+				.and_then(|r| r.data_dir.parent().map(Path::to_path_buf)),
+		};
+		parent
+			.unwrap_or_else(std::env::temp_dir)
+			.join(format!(".bestool-restore.{pid}"))
+	}
+
+	/// Lay a restored snapshot (in `staging`) back down. Method-specific: the
+	/// simple method places files at its path; postgresql does the full
+	/// stop/swap/start.
+	pub async fn restore(&self, staging: &Path, opts: &RestoreOpts) -> Result<()> {
+		match self {
+			Method::Simple(config) => {
+				let target = opts.target.clone().unwrap_or_else(|| config.path.clone());
+				ensure_not_clobbering(&target, opts.clobber)?;
+				replace_dir(staging, &target).await
+			}
+			Method::Postgresql(config) => super::postgresql::restore(config, staging, opts).await,
+		}
+	}
+}
+
+/// Options controlling a restore.
+#[derive(Debug, Clone, Default)]
+pub struct RestoreOpts {
+	/// Override the destination (the simple method's path); ignored by postgresql,
+	/// which always targets the configured cluster.
+	pub target: Option<PathBuf>,
+	/// Proceed even when the destination already holds data.
+	pub clobber: bool,
+}
+
+/// Error unless `target` is safe to write (absent or empty) or `clobber` is set.
+pub fn ensure_not_clobbering(target: &Path, clobber: bool) -> Result<()> {
+	if clobber || !dir_has_entries(target) {
+		return Ok(());
+	}
+	bail!(
+		"{} already contains data; refusing to overwrite without confirmation \
+		 (pass --clobber-existing-data-yes-i-am-sure, or confirm interactively)",
+		target.display()
+	);
+}
+
+/// Whether `path` is a directory with at least one entry.
+pub fn dir_has_entries(path: &Path) -> bool {
+	std::fs::read_dir(path)
+		.map(|mut it| it.next().is_some())
+		.unwrap_or(false)
+}
+
+/// Move `staging` into place at `target`, keeping any existing `target` as
+/// `<target>.old`. Both must be on the same filesystem (atomic rename).
+pub(super) async fn replace_dir(staging: &Path, target: &Path) -> Result<()> {
+	use miette::{Context as _, IntoDiagnostic as _};
+
+	if target.exists() {
+		let backup = with_extension_suffix(target, "old");
+		if backup.exists() {
+			tokio::fs::remove_dir_all(&backup)
+				.await
+				.into_diagnostic()
+				.wrap_err_with(|| format!("removing stale {}", backup.display()))?;
+		}
+		tokio::fs::rename(target, &backup)
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("moving {} aside to {}", target.display(), backup.display()))?;
+	}
+	if let Some(parent) = target.parent() {
+		tokio::fs::create_dir_all(parent).await.ok();
+	}
+	tokio::fs::rename(staging, target)
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("moving restored data into {}", target.display()))
+}
+
+/// `/a/b` + `old` → `/a/b.old`.
+pub(super) fn with_extension_suffix(path: &Path, suffix: &str) -> PathBuf {
+	let mut name = path.file_name().unwrap_or_default().to_os_string();
+	name.push(".");
+	name.push(suffix);
+	path.with_file_name(name)
 }
 
 #[cfg(test)]
@@ -119,5 +219,47 @@ mod tests {
 		assert!(prepared.extra_tags.is_empty());
 		assert!(prepared.ignore.is_empty());
 		method.cleanup(prepared).await.unwrap();
+	}
+
+	#[test]
+	fn clobber_guard_blocks_occupied_dir_unless_forced() {
+		let tmp = tempfile::tempdir().unwrap();
+		let occupied = tmp.path().join("data");
+		std::fs::create_dir_all(&occupied).unwrap();
+		std::fs::write(occupied.join("PG_VERSION"), "16").unwrap();
+
+		assert!(ensure_not_clobbering(&occupied, false).is_err());
+		assert!(ensure_not_clobbering(&occupied, true).is_ok());
+
+		// Absent or empty targets are fine without forcing.
+		assert!(ensure_not_clobbering(&tmp.path().join("absent"), false).is_ok());
+		let empty = tmp.path().join("empty");
+		std::fs::create_dir_all(&empty).unwrap();
+		assert!(ensure_not_clobbering(&empty, false).is_ok());
+	}
+
+	#[test]
+	fn extension_suffix_appends() {
+		assert_eq!(
+			with_extension_suffix(Path::new("/var/lib/postgresql/16/main"), "old"),
+			PathBuf::from("/var/lib/postgresql/16/main.old")
+		);
+	}
+
+	#[tokio::test]
+	async fn replace_dir_keeps_old_and_moves_in() {
+		let tmp = tempfile::tempdir().unwrap();
+		let target = tmp.path().join("data");
+		std::fs::create_dir_all(&target).unwrap();
+		std::fs::write(target.join("old-marker"), "x").unwrap();
+		let staging = tmp.path().join("staging");
+		std::fs::create_dir_all(&staging).unwrap();
+		std::fs::write(staging.join("new-marker"), "y").unwrap();
+
+		replace_dir(&staging, &target).await.unwrap();
+
+		assert!(target.join("new-marker").exists());
+		assert!(!target.join("old-marker").exists());
+		assert!(tmp.path().join("data.old").join("old-marker").exists());
 	}
 }

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -10,9 +10,9 @@ pub mod btrfs;
 pub mod resolve;
 pub mod strategy;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::Path};
 
-use miette::{Result, bail};
+use miette::{Context as _, IntoDiagnostic as _, Result, bail};
 use tracing::{info, warn};
 
 use self::strategy::Strategy;
@@ -68,6 +68,106 @@ pub async fn prepare(config: &PostgresqlConfig, backup_type: &str) -> Result<Pre
 			"postgresql backup strategy {other:?} is not implemented yet (btrfs only for now)"
 		),
 	}
+}
+
+/// Restore a postgres cluster from a freshly-restored tree (`staging`): stop the
+/// cluster, swap the data directory into place (keeping the old one as
+/// `<data>.old`), start it via plain crash recovery, and verify.
+///
+/// Refuses to overwrite an existing data directory unless `opts.clobber` is set
+/// (the command sets it from the flag or an interactive confirmation).
+pub async fn restore(
+	config: &PostgresqlConfig,
+	staging: &Path,
+	opts: &super::method::RestoreOpts,
+) -> Result<()> {
+	let target = resolve::resolve_target(config)?;
+	let restored = resolve::locate_pgdata(staging)?;
+	info!(
+		cluster = %target.cluster,
+		version = %target.version,
+		data_dir = %target.data_dir.display(),
+		"restoring postgres cluster",
+	);
+
+	super::method::ensure_not_clobbering(&target.data_dir, opts.clobber)?;
+
+	stop_cluster(&target).await;
+
+	super::method::replace_dir(&restored, &target.data_dir).await?;
+	fix_ownership(&target.data_dir).await?;
+
+	if let Err(err) = start_cluster(&target).await {
+		warn!(
+			"cluster did not start cleanly ({err}); resetting WAL as a last resort \
+			 (this may indicate a non-clean backup)"
+		);
+		pg_resetwal(&target.data_dir).await?;
+		start_cluster(&target).await?;
+	}
+
+	verify(config).await;
+	info!("restore complete; run migrations / config sync as needed");
+	Ok(())
+}
+
+async fn stop_cluster(target: &resolve::ResolvedCluster) {
+	let unit = format!("postgresql@{}-{}", target.version, target.cluster);
+	if let Err(err) = run_status("systemctl", &["stop", &unit]).await {
+		warn!("stopping {unit} failed (continuing): {err}");
+	}
+}
+
+async fn start_cluster(target: &resolve::ResolvedCluster) -> Result<()> {
+	let unit = format!("postgresql@{}-{}", target.version, target.cluster);
+	run_status("systemctl", &["start", &unit]).await
+}
+
+async fn fix_ownership(data_dir: &Path) -> Result<()> {
+	run_status("chown", &["-R", "postgres:postgres", path(data_dir)]).await?;
+	run_status("chmod", &["0750", path(data_dir)]).await
+}
+
+async fn pg_resetwal(data_dir: &Path) -> Result<()> {
+	let bin = crate::find_postgres::find_postgres_bin("pg_resetwal")
+		.map(|p| p.to_string_lossy().into_owned())
+		.unwrap_or_else(|_| "pg_resetwal".to_owned());
+	run_status("sudo", &["-u", "postgres", &bin, "-f", path(data_dir)]).await
+}
+
+async fn verify(config: &PostgresqlConfig) {
+	let psql = crate::find_postgres::find_postgres_bin("psql")
+		.map(|p| p.to_string_lossy().into_owned())
+		.unwrap_or_else(|_| "psql".to_owned());
+	let mut cmd = tokio::process::Command::new("sudo");
+	cmd.args(["-u", "postgres", &psql, "-X", "-q", "-tAc", "SELECT 1"]);
+	if let Some(port) = config.port {
+		cmd.arg("-p").arg(port.to_string());
+	}
+	cmd.stdin(std::process::Stdio::null());
+	match cmd.status().await {
+		Ok(s) if s.success() => info!("restored cluster accepts connections"),
+		Ok(s) => warn!(%s, "post-restore verification query failed"),
+		Err(err) => warn!("could not run verification query: {err}"),
+	}
+}
+
+fn path(p: &Path) -> &str {
+	p.to_str().unwrap_or_default()
+}
+
+async fn run_status(program: &str, args: &[&str]) -> Result<()> {
+	let status = tokio::process::Command::new(program)
+		.args(args)
+		.stdin(std::process::Stdio::null())
+		.status()
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("spawning {program}"))?;
+	if !status.success() {
+		bail!("{program} {} failed ({status})", args.join(" "));
+	}
+	Ok(())
 }
 
 /// Best-effort `CHECKPOINT` as the postgres superuser over the local socket.

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -100,6 +100,75 @@ fn resolve_in(config: &PostgresqlConfig, base: &Path) -> Result<ResolvedCluster>
 	}
 }
 
+/// Resolve the *target* data directory for a restore.
+///
+/// Unlike [`resolve`], the directory need not exist yet (a fresh host): an
+/// explicit `data_dir` or `version` fully determines the path. With neither, it
+/// falls back to [`resolve`] (restoring over an already-present cluster).
+pub fn resolve_target(config: &PostgresqlConfig) -> Result<ResolvedCluster> {
+	resolve_target_in(config, Path::new(POSTGRES_BASE))
+}
+
+fn resolve_target_in(config: &PostgresqlConfig, base: &Path) -> Result<ResolvedCluster> {
+	if let Some(data_dir) = &config.data_dir {
+		let version = config
+			.version
+			.clone()
+			.or_else(|| dir_name(data_dir.parent()))
+			.unwrap_or_default();
+		return Ok(ResolvedCluster {
+			version,
+			cluster: config.cluster.clone(),
+			data_dir: data_dir.clone(),
+		});
+	}
+	if let Some(version) = &config.version {
+		return Ok(ResolvedCluster {
+			version: version.clone(),
+			cluster: config.cluster.clone(),
+			data_dir: base.join(version).join(&config.cluster),
+		});
+	}
+	resolve_in(config, base)
+}
+
+/// Find the data directory within a freshly-restored tree.
+///
+/// kopia restores the snapshot's source — for our backups that's the cluster
+/// directory itself (`PG_VERSION` at the root). Older/looser layouts may nest it
+/// under `<version>/<cluster>`, so search up to two levels deep.
+pub fn locate_pgdata(staging: &Path) -> Result<PathBuf> {
+	if is_data_dir(staging) {
+		return Ok(staging.to_path_buf());
+	}
+	for depth1 in read_subdirs(staging) {
+		if is_data_dir(&depth1) {
+			return Ok(depth1);
+		}
+		for depth2 in read_subdirs(&depth1) {
+			if is_data_dir(&depth2) {
+				return Ok(depth2);
+			}
+		}
+	}
+	bail!(
+		"no postgres data dir (PG_VERSION) found in restored tree {}",
+		staging.display()
+	)
+}
+
+fn read_subdirs(dir: &Path) -> Vec<PathBuf> {
+	let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
+		.into_iter()
+		.flatten()
+		.flatten()
+		.map(|e| e.path())
+		.filter(|p| p.is_dir())
+		.collect();
+	out.sort();
+	out
+}
+
 fn is_data_dir(path: &Path) -> bool {
 	path.join("PG_VERSION").is_file()
 }
@@ -165,6 +234,37 @@ mod tests {
 		make_cluster(tmp.path(), "16", "main");
 		let err = resolve_in(&config("other", None, None), tmp.path()).unwrap_err();
 		assert!(format!("{err}").contains("no cluster"));
+	}
+
+	#[test]
+	fn resolve_target_allows_missing_dir_with_version() {
+		let tmp = tempfile::tempdir().unwrap();
+		let resolved = resolve_target_in(&config("main", Some("16"), None), tmp.path()).unwrap();
+		assert_eq!(resolved.version, "16");
+		assert_eq!(resolved.data_dir, tmp.path().join("16").join("main"));
+		assert!(!resolved.data_dir.exists());
+	}
+
+	#[test]
+	fn locate_pgdata_at_root_and_nested() {
+		let tmp = tempfile::tempdir().unwrap();
+		// Root.
+		let root = tmp.path().join("root");
+		std::fs::create_dir_all(&root).unwrap();
+		std::fs::write(root.join("PG_VERSION"), "16").unwrap();
+		assert_eq!(locate_pgdata(&root).unwrap(), root);
+
+		// Nested <version>/<cluster>.
+		let nested = tmp.path().join("nested");
+		let inner = nested.join("16").join("main");
+		std::fs::create_dir_all(&inner).unwrap();
+		std::fs::write(inner.join("PG_VERSION"), "16").unwrap();
+		assert_eq!(locate_pgdata(&nested).unwrap(), inner);
+
+		// None.
+		let empty = tmp.path().join("empty");
+		std::fs::create_dir_all(&empty).unwrap();
+		assert!(locate_pgdata(&empty).is_err());
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -1,0 +1,282 @@
+//! `bestool canopy restore`: restore a backup, method-aware.
+//!
+//! Reads the def for `--type`, fetches restore-purpose creds, kopia-restores the
+//! selected snapshot into a staging dir, and dispatches to the method's restore
+//! (the `postgresql` method does the full stop/swap/start). Refuses to overwrite
+//! existing data unless `--clobber-existing-data-yes-i-am-sure` or an interactive
+//! confirmation is given.
+
+use std::{
+	io::{IsTerminal as _, Write as _},
+	path::PathBuf,
+};
+
+use bestool_canopy::{Purpose, TargetOutcome};
+use bestool_kopia::{
+	S3KopiaEnv, Snapshot, args_snapshot_list, args_snapshot_restore, build_kopia_command_with_s3,
+	find_kopia_binary,
+};
+use clap::Parser;
+use miette::{Context as _, IntoDiagnostic as _, Result, bail, miette};
+use tracing::info;
+
+use super::backup::{
+	base_url_of, build_client, config, connect_repo, creds::CredsServer, load_registration,
+	make_lease, method::RestoreOpts, run_kopia,
+};
+use crate::actions::Context;
+
+/// Restore a backup from Canopy's repository.
+#[derive(Debug, Clone, Parser)]
+pub struct RestoreArgs {
+	/// The backup type to restore (must have a def in the backups directory).
+	#[arg(long = "type", value_name = "TYPE")]
+	pub backup_type: String,
+
+	/// Restore a specific snapshot id (a prefix is accepted).
+	#[arg(long, value_name = "ID", conflicts_with = "latest")]
+	pub id: Option<String>,
+
+	/// Restore the most recent snapshot of this type.
+	#[arg(long)]
+	pub latest: bool,
+
+	/// Override the destination (the simple method's path); postgresql always
+	/// targets its configured cluster.
+	#[arg(long, value_name = "PATH")]
+	pub target: Option<PathBuf>,
+
+	/// Proceed even if the destination already contains data (non-interactive).
+	#[arg(long = "clobber-existing-data-yes-i-am-sure")]
+	pub clobber: bool,
+
+	/// Override the registration directory.
+	#[arg(long, value_name = "DIR")]
+	pub config: Option<PathBuf>,
+
+	/// Override the backups definition directory.
+	#[arg(long, value_name = "DIR")]
+	pub backups_dir: Option<PathBuf>,
+}
+
+pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
+	let dir = args
+		.backups_dir
+		.clone()
+		.unwrap_or_else(config::backups_dir);
+	let def = config::find_def(&dir, &args.backup_type)
+		.await?
+		.ok_or_else(|| {
+			miette!(
+				"no backup def for type '{}' in {}",
+				args.backup_type,
+				dir.display()
+			)
+		})?;
+
+	let reg = load_registration(args.config.as_deref())
+		.await?
+		.ok_or_else(|| miette!("not registered with canopy; run `bestool canopy register` first"))?;
+	let device_key = reg
+		.device_key
+		.clone()
+		.ok_or_else(|| miette!("registration has no device key"))?;
+	let server_id = reg
+		.server_id
+		.clone()
+		.ok_or_else(|| miette!("registration has no server id"))?;
+	let base_url = base_url_of(&reg)?;
+	let client = build_client(&device_key).await?;
+
+	let target = match client.backup_target(&base_url).await? {
+		TargetOutcome::Ready(target) => target,
+		TargetOutcome::Dormant => {
+			bail!("device is not authorised for this backup repository (cannot restore)")
+		}
+	};
+
+	// Read-only creds + connection (the restore purpose downscopes server-side).
+	let creds_server = CredsServer::start().await?;
+	let lease = make_lease(
+		&creds_server,
+		client.clone(),
+		base_url.clone(),
+		args.backup_type.clone(),
+		Purpose::Restore,
+	);
+	let config_dir = tempfile::tempdir()
+		.into_diagnostic()
+		.wrap_err("creating transient kopia config dir")?;
+	let s3env = S3KopiaEnv {
+		full_uri: lease.uri(),
+		token: lease.token(),
+		password: &target.repo_password.0,
+		config_path: &config_dir.path().join("repository.config"),
+	};
+	let kopia = find_kopia_binary(None).ok_or_else(|| miette!("could not find the kopia binary"))?;
+	connect_repo(&kopia, &s3env, &target, &server_id).await?;
+
+	// Select the snapshot to restore.
+	let snapshots = list_snapshots(&kopia, &s3env).await?;
+	let snapshot = select_snapshot(
+		&snapshots,
+		&args.backup_type,
+		&server_id,
+		args.id.as_deref(),
+		args.latest,
+	)?;
+	info!(
+		id = %snapshot.id,
+		taken = ?snapshot.end_time.or(snapshot.start_time),
+		"restoring snapshot",
+	);
+
+	// Restore into a staging dir colocated with the target's filesystem.
+	let staging = def
+		.method
+		.staging_dir(args.target.as_deref(), std::process::id());
+	if staging.exists() {
+		tokio::fs::remove_dir_all(&staging).await.ok();
+	}
+	let mut restore_cmd =
+		build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
+	args_snapshot_restore(&mut restore_cmd, &snapshot.id, &staging);
+	run_kopia(restore_cmd, "snapshot restore").await?;
+
+	let clobber = args.clobber || confirm_clobber_interactively(&args.backup_type)?;
+	let opts = RestoreOpts {
+		target: args.target.clone(),
+		clobber,
+	};
+	def.method.restore(&staging, &opts).await
+}
+
+async fn list_snapshots(kopia: &std::path::Path, s3env: &S3KopiaEnv<'_>) -> Result<Vec<Snapshot>> {
+	let mut cmd = build_kopia_command_with_s3(kopia, s3env).map_err(|e| miette!("{e}"))?;
+	args_snapshot_list(&mut cmd);
+	let stdout = run_kopia(cmd, "snapshot list").await?;
+	serde_json::from_str(stdout.trim())
+		.into_diagnostic()
+		.wrap_err("parsing kopia snapshot list")
+}
+
+/// Pick the snapshot to restore from the repo's list.
+fn select_snapshot<'a>(
+	snapshots: &'a [Snapshot],
+	backup_type: &str,
+	server_id: &str,
+	id: Option<&str>,
+	latest: bool,
+) -> Result<&'a Snapshot> {
+	let mut matching: Vec<&Snapshot> = snapshots
+		.iter()
+		.filter(|s| {
+			s.source.host == server_id
+				&& s.tags.get("canopy-type").map(String::as_str) == Some(backup_type)
+		})
+		.collect();
+	if matching.is_empty() {
+		bail!("no '{backup_type}' snapshots found for this server in the repository");
+	}
+
+	if let Some(id) = id {
+		let mut hits = matching.iter().filter(|s| s.id.starts_with(id));
+		let first = hits
+			.next()
+			.ok_or_else(|| miette!("no snapshot id matching '{id}' for type '{backup_type}'"))?;
+		if hits.next().is_some() {
+			bail!("snapshot id '{id}' is ambiguous; give more characters");
+		}
+		return Ok(first);
+	}
+
+	if latest {
+		// Newest by end time (falling back to start time).
+		matching.sort_by_key(|s| s.end_time.or(s.start_time));
+		return Ok(matching.last().unwrap());
+	}
+
+	bail!("specify which snapshot to restore with --latest or --id <ID>")
+}
+
+/// Interactive double-confirmation for a destructive restore. Returns `true`
+/// only when both prompts pass. With no TTY, returns `false` (the caller then
+/// relies on the explicit flag / the clobber guard).
+fn confirm_clobber_interactively(backup_type: &str) -> Result<bool> {
+	if !std::io::stdin().is_terminal() {
+		return Ok(false);
+	}
+	print!(
+		"This will OVERWRITE existing data for '{backup_type}'. Continue? [y/N] "
+	);
+	std::io::stdout().flush().ok();
+	if !read_line()?.trim().eq_ignore_ascii_case("y") {
+		return Ok(false);
+	}
+	print!("Type the backup type '{backup_type}' to confirm: ");
+	std::io::stdout().flush().ok();
+	Ok(read_line()?.trim() == backup_type)
+}
+
+fn read_line() -> Result<String> {
+	let mut buf = String::new();
+	std::io::stdin()
+		.read_line(&mut buf)
+		.into_diagnostic()
+		.wrap_err("reading confirmation")?;
+	Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+	use bestool_kopia::SnapshotSource;
+
+	use super::*;
+
+	fn snap(id: &str, host: &str, btype: &str, end: Option<&str>) -> Snapshot {
+		Snapshot {
+			id: id.into(),
+			source: SnapshotSource {
+				host: host.into(),
+				user_name: "canopy".into(),
+				path: "/x".into(),
+			},
+			description: String::new(),
+			start_time: None,
+			end_time: end.map(|t| t.parse().unwrap()),
+			tags: std::collections::BTreeMap::from([("canopy-type".into(), btype.into())]),
+			root_entry: None,
+		}
+	}
+
+	#[test]
+	fn selects_latest_for_type_and_server() {
+		let snaps = vec![
+			snap("aaa", "srv", "tamanu-postgres", Some("2026-01-01T00:00:00Z")),
+			snap("bbb", "srv", "tamanu-postgres", Some("2026-02-01T00:00:00Z")),
+			snap("ccc", "other", "tamanu-postgres", Some("2026-03-01T00:00:00Z")),
+			snap("ddd", "srv", "files", Some("2026-03-01T00:00:00Z")),
+		];
+		let chosen = select_snapshot(&snaps, "tamanu-postgres", "srv", None, true).unwrap();
+		assert_eq!(chosen.id, "bbb");
+	}
+
+	#[test]
+	fn selects_by_id_prefix() {
+		let snaps = vec![snap("abc123", "srv", "tamanu-postgres", None)];
+		let chosen = select_snapshot(&snaps, "tamanu-postgres", "srv", Some("abc"), false).unwrap();
+		assert_eq!(chosen.id, "abc123");
+	}
+
+	#[test]
+	fn errors_without_selector() {
+		let snaps = vec![snap("abc", "srv", "tamanu-postgres", None)];
+		assert!(select_snapshot(&snaps, "tamanu-postgres", "srv", None, false).is_err());
+	}
+
+	#[test]
+	fn errors_when_no_match() {
+		let snaps = vec![snap("abc", "other", "tamanu-postgres", None)];
+		assert!(select_snapshot(&snaps, "tamanu-postgres", "srv", None, true).is_err());
+	}
+}

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -313,6 +313,11 @@ pub fn args_snapshot_create(cmd: &mut Command, path: &Path, tags: &BTreeMap<Stri
 	cmd.arg(path);
 }
 
+/// Push `snapshot list --json --all` args (every snapshot, all sources).
+pub fn args_snapshot_list(cmd: &mut Command) {
+	cmd.args(["snapshot", "list", "--json", "--all"]);
+}
+
 /// Push `snapshot restore` args (restore a snapshot id into `dest`).
 pub fn args_snapshot_restore(cmd: &mut Command, snapshot_id: &str, dest: &Path) {
 	cmd.args(["snapshot", "restore", snapshot_id]).arg(dest);


### PR DESCRIPTION
🤖 Stacked on #513. Adds the operator-facing `bestool canopy restore` — the device-side restore tool (pgro remains the automated off-host verifier).

## Flow

`bestool canopy restore --type <type> (--latest | --id <ID>) [--target <path>]`

1. Read the def for `--type`, fetch **restore-purpose** creds (server-side downscoped to read-only), and connect to the repo over the loopback creds endpoint.
2. Select the snapshot — `--latest` or `--id <prefix>`, filtered to this server (`source.host == server-id`) and `canopy-type == <type>`.
3. kopia-restore it into a staging dir colocated with the target's filesystem (so the final move is an atomic rename).
4. Dispatch to the method's restore.

## Method behaviour

- **`postgresql`** — the full automated swap, encoding `docs/restore-process.txt`: stop the cluster, move the data dir aside to `<data>.old`, move the restored tree into place (handling `PG_VERSION`-at-root vs nested layouts), fix ownership/perms, start via plain crash recovery, and verify. `pg_resetwal -f` is a logged last resort, not the default path.
- **`simple`** — restores files to the def's `path` (or `--target`).

## Clobber guard (as requested)

Refuses to overwrite existing data by default. To proceed: pass `--clobber-existing-data-yes-i-am-sure` (non-interactive), or pass an interactive double-confirmation (confirm, then retype the backup type). No TTY and no flag over occupied data → it refuses and exits non-zero. The moved-aside `<data>.old` is the safety net regardless.

## Testing

Pure logic — snapshot selection, the clobber guard, data-dir layout detection, the move-aside swap — is unit-tested. The privileged stop/swap/start is verified on a real host per the plan.

## Still to come

thin-LVM / Windows VSS (Strategy A), `pg_basebackup` (Strategy B), and contract tests against the live Canopy spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
