### PR TITLE
feat(tamanu): rework doctor UI and add --only-failing mode

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/.workhorse/.gitignore
+++ b/.workhorse/.gitignore
@@ -1,0 +1,1 @@
+inbuilt/

--- a/.workhorse/plans/a1/plan.md
+++ b/.workhorse/plans/a1/plan.md
@@ -20,7 +20,9 @@ This keeps the "least severe at top, most severe at bottom" theme: the most urge
 
 ### TUI
 
-Built on ratatui + crossterm in alternate-screen mode. The check list takes the bulk of the screen, with a footer line showing `<spinner> <completed> / <total> complete`.
+Built on crossterm in alternate-screen mode. The check list takes the bulk of the screen, with a footer line showing `<spinner> <completed> / <total> complete`.
+
+We initially used ratatui but ratatui 0.29.0 pins `unicode-width = "=0.2.0"` which conflicts with rustyline 18.0.0's `^0.2.2` requirement (used transitively by bestool-psql). Driving crossterm directly keeps the same screen layout without the dep conflict.
 
 Each row tracks its own state (Pending → Running → Completed(Check)) and renders accordingly:
 
@@ -49,7 +51,7 @@ The spec drops the `Tamanu doctor (server-id: …)` header line from human-reada
 
 ### Dependencies
 
-Add `ratatui` to bestool's `tamanu-doctor` feature. Pair with `crossterm` (already a transitive via psql but added explicitly here for terminal lifecycle handling — Ctrl+C raw mode, alt-screen entry/exit).
+Add `crossterm` to bestool's `tamanu-doctor` feature. It's already a transitive via bestool-psql, so adding it explicitly here doesn't change the lockfile — it just lets us drive the alternate-screen TUI directly (Ctrl+C raw mode, alt-screen entry/exit, styled rendering).
 
 ### Module split
 
@@ -62,7 +64,7 @@ Add `ratatui` to bestool's `tamanu-doctor` feature. Pair with `crossterm` (alrea
 
 ## Checklist
 
-- [x] Add `ratatui` and `crossterm` deps to bestool (`tamanu-doctor` feature)
+- [x] Add `crossterm` dep to bestool (`tamanu-doctor` feature)
 - [x] Add `DoctorArgs::only_failing` field with `--only-failing` / `-F`
 - [x] Add ordering module (group key + sort + filter helper)
 - [x] Add plain render module (grouped, with -F support, source note, no server-id header)

--- a/.workhorse/plans/a1/plan.md
+++ b/.workhorse/plans/a1/plan.md
@@ -1,0 +1,75 @@
+# A1: --only-failing + TUI for `bestool tamanu doctor`
+
+Implements spec `DOC` (see `.workhorse/specs/tamanu/doctor.md`). Two coupled changes:
+
+1. Add `--only-failing` / `-F` flag that filters out pass/skip outcomes.
+2. Replace the line-rewriting live render with a ratatui alternate-screen TUI; reorder all output (live, replay, non-TTY) into the new severity-grouped layout.
+
+## Design notes
+
+### Ordering
+
+A single sort key per row:
+
+- group_order: pending=0, running=1, pass=2, skip=3, warning=4, broken=5, fail=6
+- within group: alphabetical by check name
+
+Final rendered output (and non-TTY output): same key, but pending/running can't appear (sweep has finished). Under `-F`, rows with status pass or skip are hidden.
+
+This keeps the "least severe at top, most severe at bottom" theme: the most urgent rows sit nearest the result line (and shell prompt) where the eye lands.
+
+### TUI
+
+Built on ratatui + crossterm in alternate-screen mode. The check list takes the bulk of the screen, with a footer line showing `<spinner> <completed> / <total> complete`.
+
+Each row tracks its own state (Pending → Running → Completed(Check)) and renders accordingly:
+
+- Pending: dim `····` indicator + check name
+- Running: spinner glyph (animated) + check name
+- Completed: coloured outcome tag (PASS/SKIP/WARN/BRKN/FAIL) + check name + summary; reason as a dim continuation line for non-pass outcomes
+
+A dimmed source note sits below the result line in the final render. In the TUI, it appears at the top of the screen (dimmed) so the operator sees it while the sweep is running.
+
+Tick at ~10Hz to drive spinner animation and drain incoming progress events from the existing mpsc channel.
+
+On completion (or Ctrl+C), restore the terminal and replay the same rendered output to stdout via the plain renderer so it persists in scrollback.
+
+### Filter under -F
+
+The TUI always shows pending/running rows for every selected check (progress would be invisible otherwise). When a check completes:
+
+- If the outcome would survive the filter (warning/broken/fail under -F, or anything without -F), the row moves to its grouped-and-ordered position.
+- If the outcome is hidden by the filter (pass/skip under -F), the row is removed from the displayed list.
+
+Footer count tracks completion against the full selected set, not the filtered displayed list.
+
+### Server-id removed
+
+The spec drops the `Tamanu doctor (server-id: …)` header line from human-readable output. Server-id still flows through the JSON wire payload — only the human render changes.
+
+### Dependencies
+
+Add `ratatui` to bestool's `tamanu-doctor` feature. Pair with `crossterm` (already a transitive via psql but added explicitly here for terminal lifecycle handling — Ctrl+C raw mode, alt-screen entry/exit).
+
+### Module split
+
+`crates/bestool/src/actions/tamanu/doctor.rs` grows enough to warrant splitting:
+
+- `doctor.rs` — `DoctorArgs`, `run()`, orchestration
+- `doctor/order.rs` — group ordering / sort helpers
+- `doctor/render.rs` — plain text rendering for non-TTY and replay
+- `doctor/tui.rs` — ratatui live TUI
+
+## Checklist
+
+- [x] Add `ratatui` and `crossterm` deps to bestool (`tamanu-doctor` feature)
+- [x] Add `DoctorArgs::only_failing` field with `--only-failing` / `-F`
+- [x] Add ordering module (group key + sort + filter helper)
+- [x] Add plain render module (grouped, with -F support, source note, no server-id header)
+- [x] Add TUI module with row-state model, spinner, footer count, source note
+- [x] Hook Ctrl+C into TUI teardown so partial results still replay to scrollback
+- [x] Wire `run()` to choose TUI vs plain based on TTY + JSON
+- [x] Update JSON path to ignore `--only-failing`
+- [x] Remove old `render_live`, `render`, `write_check_line`, `truncate_to_width`, etc.
+- [x] Refresh tests: drop server-id assertions, add grouped-ordering tests, add only-failing tests
+- [ ] Run `cargo clippy` and `cargo fmt` (needs external cargo run)

--- a/.workhorse/skills/.gitignore
+++ b/.workhorse/skills/.gitignore
@@ -1,0 +1,1 @@
+inbuilt/

--- a/.workhorse/specs/tamanu/doctor.md
+++ b/.workhorse/specs/tamanu/doctor.md
@@ -8,79 +8,54 @@ The `bestool tamanu doctor` command gathers server facts and runs a set of healt
 
 ## Checks and outcomes
 
-- [ ] The command runs a fixed registry of named checks covering both host-level concerns (disk, memory, time sync, etc.) and Tamanu-specific concerns (database, HTTP, services, certificates, sync state, and so on)
-- [ ] Each check resolves to exactly one of five outcomes: pass, skip, warning, broken, or fail
-- [ ] A check produces a one-line summary; checks with a skip, warning, broken, or fail outcome also carry a reason
-- [ ] The overall outcome of the sweep is failing if any check failed, degraded if any check warned or broke without any failing, and healthy otherwise — skipped checks do not degrade the overall outcome
+The command runs a fixed registry of named checks covering both host-level concerns (disk, memory, time sync, and so on) and Tamanu-specific concerns (database, HTTP, services, certificates, sync state). Each check resolves to exactly one of five outcomes: pass, skip, warning, broken, or fail. Every check produces a one-line summary; checks with a skip, warning, broken, or fail outcome also carry a reason.
+
+The overall outcome of the sweep is failing if any check failed, degraded if any check warned or broke without any failing, and healthy otherwise. Skipped checks do not degrade the overall outcome.
 
 ## Selecting checks
 
-- [ ] `--check NAME` restricts the sweep to the named check; the flag is repeatable to select several
-- [ ] `--skip NAME` excludes the named check; the flag is repeatable and applies after `--check`
-- [ ] With no selection flags, every check in the registry runs
-- [ ] An unknown check name in either flag is a fatal error that lists the known check names
+`--check NAME` restricts the sweep to the named check and is repeatable to select several. `--skip NAME` excludes the named check, is repeatable, and applies after `--check`. With no selection flags, every check in the registry runs. An unknown check name in either flag is a fatal error that lists the known check names.
 
 ## Tamanu install context
 
-- [ ] When a Tamanu install is present on the host, the sweep runs against it: install-dependent checks (configuration, local HTTP, services, certificates, backup) and database-dependent checks both run
-- [ ] When no install is present but a Tamanu database URL is configured via the environment, the sweep runs against that database: database-dependent checks run, install-dependent checks skip
-- [ ] When neither is present, only host-level checks run and the command warns that no Tamanu was found on this host
+When a Tamanu install is present on the host, the sweep runs against it: install-dependent checks (configuration, local HTTP, services, certificates, backup) and database-dependent checks both run. When no install is present but a Tamanu database URL is configured via the environment, the sweep runs against that database — database-dependent checks run and install-dependent checks skip. When neither is present, only host-level checks run and the command warns that no Tamanu was found on this host.
 
 ## Sweep source
 
-- [ ] By default, the command reads the most recent sweep cached by the alertd daemon on the same host
-- [ ] `--fresh` asks the daemon to recompute and streams the per-check results back as they complete
-- [ ] `--no-daemon` skips the daemon integration and computes the sweep locally
-- [ ] If the daemon cannot be reached or returns an error, the command falls back to computing the sweep locally
-- [ ] A source note in both the live display and the final rendered output identifies whether the data was computed locally, streamed from the daemon, or read from the daemon's last cached sweep, and how long ago a cached sweep was computed
+By default, the command reads the most recent sweep cached by the alertd daemon on the same host. `--fresh` asks the daemon to recompute and streams the per-check results back as they complete. `--no-daemon` skips the daemon integration and computes the sweep locally. If the daemon cannot be reached or returns an error, the command falls back to computing the sweep locally.
+
+A source note in both the live display and the final rendered output identifies whether the data was computed locally, streamed from the daemon, or read from the daemon's last cached sweep, and how long ago a cached sweep was computed.
 
 ## Grouping and ordering
 
-- [ ] Checks are grouped by outcome
-- [ ] Groups appear top-to-bottom in increasing severity: passing, skipped, warning, broken, failing — so the most urgent checks sit closest to the result line and the shell prompt
-- [ ] Within each group, checks are ordered alphabetically by name
-- [ ] The same grouping and ordering apply during the live sweep and in the final rendered output
+Checks are grouped by outcome. Groups appear top-to-bottom in increasing severity: passing, skipped, warning, broken, failing — so the most urgent checks sit closest to the result line and the shell prompt. Within each group, checks are ordered alphabetically by name. The same grouping and ordering apply during the live sweep and in the final rendered output.
 
 ## Live execution in an interactive terminal
 
-- [ ] When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep
-- [ ] Every selected check appears as a row in the list from the start of the sweep, in a pending state
-- [ ] A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary
-- [ ] As each check completes, its row moves to its grouped-and-ordered position
-- [ ] A footer line shows an animated spinner together with a running count of how many checks have completed out of the total
-- [ ] The source note appears in the TUI as dimmed text
-- [ ] On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits
-- [ ] If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit
+When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep. Every selected check appears as a row in the list from the start of the sweep, in a pending state. A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary. As each check completes, its row moves to its grouped-and-ordered position.
+
+A footer line shows an animated spinner together with a running count of how many checks have completed out of the total. The source note appears in the TUI as dimmed text.
+
+On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits. If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit.
 
 ## Final rendered output
 
-- [ ] The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position
-- [ ] A blank line separates the check list from the result line
-- [ ] The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks
-- [ ] The source note appears as dimmed text below the result line
-- [ ] The result line is always shown, even when the displayed check list is empty
+The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position. A blank line separates the check list from the result line. The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks. The source note appears as dimmed text below the result line. The result line is always shown, even when the displayed check list is empty.
 
 ## Only-failing filter
 
-- [ ] The command accepts `--only-failing` and its short form `-F`
-- [ ] With the filter set, only checks with warning, broken, or failing outcomes appear in the displayed list and the final output
-- [ ] The grouping and ordering rules still apply, so displayed checks are ordered warning, then broken, then failing
-- [ ] In the live TUI under the filter, pending and running rows remain visible for every selected check; once a check's outcome is known, it stays in the list only if it warned, broke, or failed
-- [ ] The footer count under the filter still tracks completion against the full set of selected checks
-- [ ] When every selected check passes or is skipped, the displayed list is empty and the result line is shown on its own
+The command accepts `--only-failing` and its short form `-F`. With the filter set, only checks with warning, broken, or failing outcomes appear in the displayed list and the final output. The grouping and ordering rules still apply, so displayed checks are ordered warning, then broken, then failing.
+
+In the live TUI under the filter, pending and running rows remain visible for every selected check; once a check's outcome is known, it stays in the list only if it warned, broke, or failed. The footer count under the filter still tracks completion against the full set of selected checks. When every selected check passes or is skipped, the displayed list is empty and the result line is shown on its own.
 
 ## Non-interactive output
 
-- [ ] When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner
-- [ ] Non-interactive output follows the same grouping, ordering, source note, result line, and only-failing filter rules
+When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner. Non-interactive output follows the same grouping, ordering, source note, result line, and only-failing filter rules.
 
 ## JSON output
 
-- [ ] When JSON output is requested, the command emits a machine-readable payload and suppresses the human-readable rendering
-- [ ] The payload contains the sweep's wire data, a source field naming where the data came from, and a computed-at timestamp when the source is the daemon's last cached sweep
-- [ ] The only-failing filter does not affect JSON output: every selected check is included
+When JSON output is requested, the command emits a machine-readable payload and suppresses the human-readable rendering. The payload contains the sweep's wire data, a source field naming where the data came from, and a computed-at timestamp when the source is the daemon's last cached sweep. The only-failing filter does not affect JSON output: every selected check is included.
 
 ## Exit code
 
-- [ ] The command exits non-zero when the overall outcome is failing, and zero otherwise
-- [ ] An exit caused by user interruption is non-zero regardless of partial results
+The command exits non-zero when the overall outcome is failing, and zero otherwise. An exit caused by user interruption is non-zero regardless of partial results.

--- a/.workhorse/specs/tamanu/doctor.md
+++ b/.workhorse/specs/tamanu/doctor.md
@@ -2,9 +2,37 @@
 id: DOC
 ---
 
-# Tamanu doctor output
+# Tamanu doctor
 
-The `bestool tamanu doctor` command runs a set of health checks against a Tamanu install and renders the outcome. Each check resolves to one of five outcomes: pass, skip, warning, broken (the check itself errored), or fail. This spec describes how the command displays results during the sweep, in the final rendered output, and when the only-failing filter is applied.
+The `bestool tamanu doctor` command gathers server facts and runs a set of health checks against a Tamanu install, then renders the outcome for a human operator or as a machine-readable payload. Checks may pass, be skipped, warn, fail, or be broken (the check itself errored). This spec describes how the command selects checks, where the sweep data comes from, and how results are displayed.
+
+## Checks and outcomes
+
+- [ ] The command runs a fixed registry of named checks covering both host-level concerns (disk, memory, time sync, etc.) and Tamanu-specific concerns (database, HTTP, services, certificates, sync state, and so on)
+- [ ] Each check resolves to exactly one of five outcomes: pass, skip, warning, broken, or fail
+- [ ] A check produces a one-line summary; checks with a skip, warning, broken, or fail outcome also carry a reason
+- [ ] The overall outcome of the sweep is failing if any check failed, degraded if any check warned or broke without any failing, and healthy otherwise — skipped checks do not degrade the overall outcome
+
+## Selecting checks
+
+- [ ] `--check NAME` restricts the sweep to the named check; the flag is repeatable to select several
+- [ ] `--skip NAME` excludes the named check; the flag is repeatable and applies after `--check`
+- [ ] With no selection flags, every check in the registry runs
+- [ ] An unknown check name in either flag is a fatal error that lists the known check names
+
+## Tamanu install context
+
+- [ ] When a Tamanu install is present on the host, the sweep runs against it: install-dependent checks (configuration, local HTTP, services, certificates, backup) and database-dependent checks both run
+- [ ] When no install is present but a Tamanu database URL is configured via the environment, the sweep runs against that database: database-dependent checks run, install-dependent checks skip
+- [ ] When neither is present, only host-level checks run and the command warns that no Tamanu was found on this host
+
+## Sweep source
+
+- [ ] By default, the command reads the most recent sweep cached by the alertd daemon on the same host
+- [ ] `--fresh` asks the daemon to recompute and streams the per-check results back as they complete
+- [ ] `--no-daemon` skips the daemon integration and computes the sweep locally
+- [ ] If the daemon cannot be reached or returns an error, the command falls back to computing the sweep locally
+- [ ] A source note in both the live display and the final rendered output identifies whether the data was computed locally, streamed from the daemon, or read from the daemon's last cached sweep, and how long ago a cached sweep was computed
 
 ## Grouping and ordering
 
@@ -20,7 +48,7 @@ The `bestool tamanu doctor` command runs a set of health checks against a Tamanu
 - [ ] A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary
 - [ ] As each check completes, its row moves to its grouped-and-ordered position
 - [ ] A footer line shows an animated spinner together with a running count of how many checks have completed out of the total
-- [ ] A dimmed source note in the TUI identifies whether the data is being computed locally, streamed from the alertd daemon, or read from the daemon's last cached sweep
+- [ ] The source note appears in the TUI as dimmed text
 - [ ] On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits
 - [ ] If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit
 
@@ -29,7 +57,7 @@ The `bestool tamanu doctor` command runs a set of health checks against a Tamanu
 - [ ] The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position
 - [ ] A blank line separates the check list from the result line
 - [ ] The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks
-- [ ] A dimmed source note states whether the data was computed locally, streamed from the alertd daemon, or read from the daemon's last cached sweep, including how long ago a cached sweep was computed
+- [ ] The source note appears as dimmed text below the result line
 - [ ] The result line is always shown, even when the displayed check list is empty
 
 ## Only-failing filter
@@ -48,7 +76,8 @@ The `bestool tamanu doctor` command runs a set of health checks against a Tamanu
 
 ## JSON output
 
-- [ ] When JSON output is requested, the command emits the full machine-readable sweep payload and suppresses the human-readable rendering
+- [ ] When JSON output is requested, the command emits a machine-readable payload and suppresses the human-readable rendering
+- [ ] The payload contains the sweep's wire data, a source field naming where the data came from, and a computed-at timestamp when the source is the daemon's last cached sweep
 - [ ] The only-failing filter does not affect JSON output: every selected check is included
 
 ## Exit code

--- a/.workhorse/specs/tamanu/doctor.md
+++ b/.workhorse/specs/tamanu/doctor.md
@@ -1,0 +1,57 @@
+---
+id: DOC
+---
+
+# Tamanu doctor output
+
+The `bestool tamanu doctor` command runs a set of health checks against a Tamanu install and renders the outcome. Each check resolves to one of five outcomes: pass, skip, warning, broken (the check itself errored), or fail. This spec describes how the command displays results during the sweep, in the final rendered output, and when the only-failing filter is applied.
+
+## Grouping and ordering
+
+- [ ] Checks are grouped by outcome
+- [ ] Groups appear top-to-bottom in increasing severity: passing, skipped, warning, broken, failing — so the most urgent checks sit closest to the result line and the shell prompt
+- [ ] Within each group, checks are ordered alphabetically by name
+- [ ] The same grouping and ordering apply during the live sweep and in the final rendered output
+
+## Live execution in an interactive terminal
+
+- [ ] When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep
+- [ ] Every selected check appears as a row in the list from the start of the sweep, in a pending state
+- [ ] A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary
+- [ ] As each check completes, its row moves to its grouped-and-ordered position
+- [ ] A footer line shows an animated spinner together with a running count of how many checks have completed out of the total
+- [ ] A dimmed source note in the TUI identifies whether the data is being computed locally, streamed from the alertd daemon, or read from the daemon's last cached sweep
+- [ ] On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits
+- [ ] If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit
+
+## Final rendered output
+
+- [ ] The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position
+- [ ] A blank line separates the check list from the result line
+- [ ] The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks
+- [ ] A dimmed source note states whether the data was computed locally, streamed from the alertd daemon, or read from the daemon's last cached sweep, including how long ago a cached sweep was computed
+- [ ] The result line is always shown, even when the displayed check list is empty
+
+## Only-failing filter
+
+- [ ] The command accepts `--only-failing` and its short form `-F`
+- [ ] With the filter set, only checks with warning, broken, or failing outcomes appear in the displayed list and the final output
+- [ ] The grouping and ordering rules still apply, so displayed checks are ordered warning, then broken, then failing
+- [ ] In the live TUI under the filter, pending and running rows remain visible for every selected check; once a check's outcome is known, it stays in the list only if it warned, broke, or failed
+- [ ] The footer count under the filter still tracks completion against the full set of selected checks
+- [ ] When every selected check passes or is skipped, the displayed list is empty and the result line is shown on its own
+
+## Non-interactive output
+
+- [ ] When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner
+- [ ] Non-interactive output follows the same grouping, ordering, source note, result line, and only-failing filter rules
+
+## JSON output
+
+- [ ] When JSON output is requested, the command emits the full machine-readable sweep payload and suppresses the human-readable rendering
+- [ ] The only-failing filter does not affect JSON output: every selected check is included
+
+## Exit code
+
+- [ ] The command exits non-zero when the overall outcome is failing, and zero otherwise
+- [ ] An exit caused by user interruption is non-zero regardless of partial results

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -59,6 +59,7 @@ p256 = { version = "0.13.2", features = ["pkcs8", "pem"], optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
 privilege = { version = "0.3.0", optional = true }
 quick-xml = { version = "0.40.1", features = ["serialize"], optional = true }
+ratatui = { version = "0.29.0", optional = true }
 regex = { version = "1.11.2", optional = true }
 reqwest = { workspace = true }
 rpi-st7789v2-driver = { version = "0.3.13", path = "../rpi-st7789v2-driver", features = ["miette"], optional = true }
@@ -71,7 +72,6 @@ sysinfo = { workspace = true }
 target-tuples = { version = "0.16.1", optional = true }
 tempfile = "3.21.0"
 tera = { version = "1.19.1", optional = true }
-terminal_size = { version = "0.4.4", optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-uuid-1"], optional = true }
@@ -148,7 +148,7 @@ tamanu-doctor = [
 	"dep:bestool-psql",
 	"dep:owo-colors",
 	"dep:p256",
-	"dep:terminal_size",
+	"dep:ratatui",
 	"dep:tokio-postgres",
 ]
 tamanu-url = ["__tamanu", "tamanu-config", "dep:percent-encoding"]

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -33,6 +33,7 @@ clap = { workspace = true, features = ["env", "unicode", "string"] }
 clap_complete = { version = "4.6.3", optional = true }
 clap-markdown = "0.1.5"
 comfy-table = { version = "7.2.0", optional = true }
+crossterm = { version = "0.29.0", optional = true }
 ctrlc = { version = "3.5.0", optional = true }
 detect-targets = { version = "0.1.84", optional = true }
 dirs = { version = "6.0.0", optional = true }
@@ -59,7 +60,6 @@ p256 = { version = "0.13.2", features = ["pkcs8", "pem"], optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
 privilege = { version = "0.3.0", optional = true }
 quick-xml = { version = "0.40.1", features = ["serialize"], optional = true }
-ratatui = { version = "0.29.0", optional = true }
 regex = { version = "1.11.2", optional = true }
 reqwest = { workspace = true }
 rpi-st7789v2-driver = { version = "0.3.13", path = "../rpi-st7789v2-driver", features = ["miette"], optional = true }
@@ -146,9 +146,9 @@ tamanu-doctor = [
 	"dep:bestool-canopy",
 	"dep:bestool-postgres",
 	"dep:bestool-psql",
+	"dep:crossterm",
 	"dep:owo-colors",
 	"dep:p256",
-	"dep:ratatui",
 	"dep:tokio-postgres",
 ]
 tamanu-url = ["__tamanu", "tamanu-config", "dep:percent-encoding"]

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1752,7 +1752,7 @@ from it and rendered, with a note saying when those checks were actually
 computed. Otherwise — or with `--fresh` / `--no-daemon` — the checks are
 run locally.
 
-Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING.
+Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING, 130 on interrupt.
 
 **Usage:** `bestool tamanu doctor [OPTIONS]`
 
@@ -1761,6 +1761,7 @@ Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING.
 * `--json` — Emit the JSON wire payload instead of the human-readable render
 * `--check <NAME>` — Run only the named check(s). Repeatable. Defaults to all
 * `--skip <NAME>` — Skip the named check(s). Repeatable. Applied after `--check`
+* `-F`, `--only-failing` — Hide passing and skipped checks; show only warning, broken, and failing
 * `--fresh` — Force a fresh sweep. With alertd running, asks the daemon to recompute and streams the results back as they come in; without alertd, runs the checks locally exactly like before
 * `--no-daemon` — Skip the alertd integration entirely and always compute locally.
 

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -2,7 +2,6 @@ use std::io::{IsTerminal as _, Write};
 
 use clap::Parser;
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
-use owo_colors::OwoColorize;
 use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -12,12 +11,16 @@ use bestool_alertd::doctor::{
 	check::{Check, CheckStatus, OverallResult},
 	checks,
 	overall_from_payload, perform_sweep,
-	progress::DoctorEvent,
+	progress::ProgressSender,
 	resolve_sweep_tamanu,
 };
 
 use super::{TamanuArgs, try_find_tamanu};
 use crate::actions::Context;
+
+mod order;
+mod render;
+mod tui;
 
 /// Gather server info + healthchecks for a Tamanu install
 ///
@@ -27,7 +30,7 @@ use crate::actions::Context;
 /// computed. Otherwise — or with `--fresh` / `--no-daemon` — the checks are
 /// run locally.
 ///
-/// Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING.
+/// Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING, 130 on interrupt.
 #[derive(Debug, Clone, Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct DoctorArgs {
@@ -43,6 +46,10 @@ pub struct DoctorArgs {
 	#[arg(long = "skip", value_name = "NAME")]
 	pub skip: Vec<String>,
 
+	/// Hide passing and skipped checks; show only warning, broken, and failing.
+	#[arg(long = "only-failing", short = 'F')]
+	pub only_failing: bool,
+
 	/// Force a fresh sweep. With alertd running, asks the daemon to recompute
 	/// and streams the results back as they come in; without alertd, runs the
 	/// checks locally exactly like before.
@@ -57,8 +64,8 @@ pub struct DoctorArgs {
 }
 
 /// Where the displayed sweep came from.
-enum SweepSource {
-	/// Daemon's last periodic sweep — include `computed_at` so we can warn how
+pub enum SweepSource {
+	/// Daemon's last periodic sweep — include `computed_at` so we can note how
 	/// old it is in the rendered output.
 	DaemonCached { computed_at: jiff::Timestamp },
 	/// Daemon-driven fresh recompute, streamed back over the task endpoint.
@@ -73,193 +80,240 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	let tamanu = ctx.require::<TamanuArgs>();
 	let use_colours = tamanu.use_colours;
 
-	// A real install, a DB-only context synthesised from `TAMANU_DATABASE_URL`,
-	// or `None` (host-level checks only).
 	let install = resolve_sweep_tamanu(try_find_tamanu(tamanu).await?)?;
 	if install.is_none() {
 		warn!("no Tamanu on this host; running host-level checks only");
 	}
 	let http_client = crate::http::client();
 
-	let (sweep, source) = if args.no_daemon {
-		(
-			run_local_sweep(install.clone(), http_client.clone(), &args, use_colours).await?,
-			SweepSource::Local,
-		)
+	let live_tty = !args.json && std::io::stdout().is_terminal();
+
+	let (sweep, source, interrupted) = if args.no_daemon {
+		let outcome = run_local_sweep(install.clone(), http_client.clone(), &args, live_tty).await?;
+		(outcome.sweep, SweepSource::Local, outcome.interrupted)
 	} else if args.fresh {
-		match run_daemon_recompute(&http_client, &args, use_colours).await {
-			Ok(sweep) => (sweep, SweepSource::DaemonStreamed),
+		match run_daemon_recompute(&http_client, &args, live_tty).await {
+			Ok(outcome) => (outcome.sweep, SweepSource::DaemonStreamed, outcome.interrupted),
 			Err(err) => {
 				debug!(%err, "daemon recompute unavailable, falling back to local");
-				(
-					run_local_sweep(install.clone(), http_client.clone(), &args, use_colours)
-						.await?,
-					SweepSource::Local,
-				)
+				let outcome =
+					run_local_sweep(install.clone(), http_client.clone(), &args, live_tty).await?;
+				(outcome.sweep, SweepSource::Local, outcome.interrupted)
 			}
 		}
 	} else {
 		match fetch_daemon_latest(&http_client).await {
-			Ok((sweep, computed_at)) => (sweep, SweepSource::DaemonCached { computed_at }),
+			Ok((sweep, computed_at)) => (sweep, SweepSource::DaemonCached { computed_at }, false),
 			Err(err) => {
 				debug!(%err, "daemon latest unavailable, falling back to local");
-				(
-					run_local_sweep(install.clone(), http_client.clone(), &args, use_colours)
-						.await?,
-					SweepSource::Local,
-				)
+				let outcome =
+					run_local_sweep(install.clone(), http_client.clone(), &args, live_tty).await?;
+				(outcome.sweep, SweepSource::Local, outcome.interrupted)
 			}
 		}
 	};
 
-	render_final(&args, &sweep, &source, use_colours)?;
+	emit_output(&args, &sweep, &source, use_colours)?;
 
+	if interrupted {
+		std::process::exit(130);
+	}
 	if sweep.overall == OverallResult::Failing {
 		std::process::exit(1);
 	}
 	Ok(())
 }
 
+struct SweepOutcome {
+	sweep: SweepResult,
+	interrupted: bool,
+}
+
 async fn run_local_sweep(
 	install: Option<SweepTamanu>,
 	http_client: reqwest::Client,
 	args: &DoctorArgs,
-	use_colours: bool,
-) -> Result<SweepResult> {
-	let live = !args.json && std::io::stdout().is_terminal();
-	let selected_names = selected_names_for_render(&args.only, &args.skip)?;
-	let renderer = if live {
-		let (tx, rx) = mpsc::unbounded_channel();
-		let names = selected_names.clone();
-		let handle = tokio::task::spawn_blocking(move || {
-			let stdout = std::io::stdout();
-			let mut out = stdout.lock();
-			let _ = render_live(&mut out, &names, rx, use_colours);
-		});
-		Some((tx, handle))
+	live_tty: bool,
+) -> Result<SweepOutcome> {
+	let selected_names = selected_names(&args.only, &args.skip)?;
+	let (progress, tui_handle) = setup_progress(live_tty, &selected_names, args, SweepSource::Local);
+
+	let sweep_args_only = args.only.clone();
+	let sweep_args_skip = args.skip.clone();
+	let sweep_handle = tokio::spawn(async move {
+		perform_sweep(
+			env!("CARGO_PKG_VERSION"),
+			install,
+			http_client,
+			&sweep_args_only,
+			&sweep_args_skip,
+			None,
+			progress,
+		)
+		.await
+	});
+
+	let interrupted = if let Some(handle) = tui_handle {
+		let outcome = handle.await.into_diagnostic()??;
+		if outcome.interrupted {
+			sweep_handle.abort();
+			let mut synthetic = synthetic_sweep(outcome.results);
+			synthetic.payload = serde_json::Value::Object(Default::default());
+			return Ok(SweepOutcome {
+				sweep: synthetic,
+				interrupted: true,
+			});
+		}
+		false
 	} else {
-		None
+		false
 	};
 
-	let progress = renderer.as_ref().map(|(tx, _)| tx.clone());
-	let sweep = perform_sweep(
-		env!("CARGO_PKG_VERSION"),
-		install,
-		http_client,
-		&args.only,
-		&args.skip,
-		None,
-		progress,
-	)
-	.await?;
-
-	if let Some((tx, handle)) = renderer {
-		drop(tx);
-		let _ = handle.await;
-	}
-
-	Ok(sweep)
+	let sweep = sweep_handle.await.into_diagnostic()??;
+	Ok(SweepOutcome { sweep, interrupted })
 }
 
-fn render_final(
+/// Drive a fresh sweep on the daemon and stream the per-check results back.
+async fn run_daemon_recompute(
+	http: &reqwest::Client,
 	args: &DoctorArgs,
-	sweep: &SweepResult,
-	source: &SweepSource,
-	use_colours: bool,
-) -> Result<()> {
-	let stdout = std::io::stdout();
-	let mut out = stdout.lock();
-	let live = !args.json && std::io::stdout().is_terminal();
+	live_tty: bool,
+) -> Result<SweepOutcome> {
+	let url = format!("{DAEMON_BASE}/tasks/doctor/recompute");
+	let response = http
+		.get(&url)
+		.timeout(std::time::Duration::from_secs(5))
+		.send()
+		.await
+		.into_diagnostic()
+		.wrap_err("contacting local alertd")?;
 
-	if args.json {
-		// Embed source info alongside the payload so JSON consumers can tell
-		// where the data came from. The original payload becomes the inner
-		// `wire` field; cached daemon reads also carry `computedAt`.
-		let mut wrapped = serde_json::Map::new();
-		wrapped.insert("wire".into(), sweep.payload.clone());
-		match source {
-			SweepSource::Local => {
-				wrapped.insert("source".into(), Value::String("local".into()));
-			}
-			SweepSource::DaemonStreamed => {
-				wrapped.insert("source".into(), Value::String("daemon-streamed".into()));
-			}
-			SweepSource::DaemonCached { computed_at } => {
-				wrapped.insert("source".into(), Value::String("daemon-cached".into()));
-				wrapped.insert("computedAt".into(), Value::String(computed_at.to_string()));
-			}
-		}
-		serde_json::to_writer_pretty(&mut out, &Value::Object(wrapped)).into_diagnostic()?;
-		writeln!(out).into_diagnostic()?;
-		return Ok(());
+	if !response.status().is_success() {
+		return Err(miette!(
+			"alertd /tasks/doctor/recompute returned {}",
+			response.status()
+		));
 	}
 
-	if live {
-		// In live mode the per-check render already happened. Just append the
-		// summary + source note.
-		write_source_note(&mut out, source, use_colours).into_diagnostic()?;
-		render_summary(
-			&mut out,
-			sweep.server_id.as_deref(),
-			&sweep.results,
-			sweep.overall,
-			use_colours,
-		)
-		.into_diagnostic()?;
+	let selected_names = selected_names(&args.only, &args.skip)?;
+	let (progress, tui_handle) = setup_progress(
+		live_tty,
+		&selected_names,
+		args,
+		SweepSource::DaemonStreamed,
+	);
+
+	let stream_handle = tokio::spawn(drain_recompute_stream(response, progress));
+
+	let interrupted = if let Some(handle) = tui_handle {
+		let outcome = handle.await.into_diagnostic()??;
+		if outcome.interrupted {
+			stream_handle.abort();
+			return Ok(SweepOutcome {
+				sweep: synthetic_sweep(outcome.results),
+				interrupted: true,
+			});
+		}
+		false
 	} else {
-		render(
-			&mut out,
-			sweep.server_id.as_deref(),
-			&sweep.results,
-			sweep.overall,
-			use_colours,
-		)
-		.into_diagnostic()?;
-		write_source_note(&mut out, source, use_colours).into_diagnostic()?;
-	}
-	Ok(())
-}
-
-fn write_source_note<W: Write>(
-	out: &mut W,
-	source: &SweepSource,
-	use_colours: bool,
-) -> std::io::Result<()> {
-	let line = match source {
-		SweepSource::Local => return Ok(()),
-		SweepSource::DaemonStreamed => "Source: alertd daemon (just now, on demand)".to_string(),
-		SweepSource::DaemonCached { computed_at } => {
-			let age = humanise_age_since(*computed_at);
-			format!("Source: alertd daemon (computed {age} ago, at {computed_at})")
-		}
+		false
 	};
-	if use_colours {
-		writeln!(out, "{}", line.dimmed())
-	} else {
-		writeln!(out, "{line}")
-	}
+
+	let streamed = stream_handle.await.into_diagnostic()??;
+	let overall = overall_from_payload(&streamed.payload);
+	Ok(SweepOutcome {
+		sweep: SweepResult {
+			server_id: streamed.server_id,
+			results: streamed.results,
+			overall,
+			payload: streamed.payload,
+			pg_version: None,
+		},
+		interrupted,
+	})
 }
 
-fn humanise_age_since(then: jiff::Timestamp) -> String {
-	let now = jiff::Timestamp::now();
-	let secs = now.as_second().saturating_sub(then.as_second()).max(0) as u64;
-	if secs < 60 {
-		format!("{secs}s")
-	} else if secs < 3600 {
-		format!("{}m {}s", secs / 60, secs % 60)
-	} else {
-		format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+struct StreamedSweep {
+	payload: Value,
+	server_id: Option<String>,
+	results: Vec<(Check, bool)>,
+}
+
+async fn drain_recompute_stream(
+	response: reqwest::Response,
+	progress: Option<ProgressSender>,
+) -> Result<StreamedSweep> {
+	use bestool_alertd::doctor::progress::DoctorEvent;
+	use futures::StreamExt as _;
+
+	let registry = checks::all();
+	let resolve_name = |s: &str| registry.iter().find(|e| e.name == s).map(|e| e.name);
+
+	let mut stream = response.bytes_stream();
+	let mut buffer = Vec::<u8>::new();
+	let mut final_payload: Option<Value> = None;
+	let mut server_id: Option<String> = None;
+	let mut results: Vec<(Check, bool)> = Vec::new();
+
+	while let Some(chunk) = stream.next().await {
+		let chunk = chunk
+			.into_diagnostic()
+			.wrap_err("reading alertd recompute stream")?;
+		buffer.extend_from_slice(&chunk);
+		while let Some(nl) = buffer.iter().position(|&b| b == b'\n') {
+			let line: Vec<u8> = buffer.drain(..=nl).collect();
+			let line = &line[..line.len() - 1];
+			if line.is_empty() {
+				continue;
+			}
+			let value: Value = match serde_json::from_slice(line) {
+				Ok(v) => v,
+				Err(err) => {
+					warn!(%err, "could not parse alertd recompute line");
+					continue;
+				}
+			};
+			match value.get("event").and_then(Value::as_str) {
+				Some("check") => {
+					if let Some(check_json) = value.get("check")
+						&& let Some(check) = Check::from_streaming_json(check_json, resolve_name)
+					{
+						if let Some(tx) = progress.as_ref() {
+							let _ = tx.send(DoctorEvent::Completed(check.clone()));
+						}
+						results.push((check, true));
+					}
+				}
+				Some("done") => {
+					final_payload = value.get("payload").cloned();
+					server_id = value
+						.get("serverId")
+						.and_then(Value::as_str)
+						.map(str::to_string);
+				}
+				Some("error") => {
+					let msg = value
+						.get("message")
+						.and_then(Value::as_str)
+						.unwrap_or("unknown");
+					return Err(miette!("alertd recompute reported error: {msg}"));
+				}
+				_ => {}
+			}
+		}
 	}
+
+	let payload = final_payload
+		.ok_or_else(|| miette!("alertd recompute stream ended without a done event"))?;
+	Ok(StreamedSweep {
+		payload,
+		server_id,
+		results,
+	})
 }
 
 /// Read the alertd daemon's most recent sweep over `/tasks/doctor/latest`.
-///
-/// The short timeout is intentional: this is run on every `tamanu doctor`
-/// invocation, and if alertd isn't on this host (or its HTTP server is
-/// missing) we want to bail out fast and fall back to a local sweep.
-async fn fetch_daemon_latest(
-	http: &reqwest::Client,
-) -> Result<(SweepResult, jiff::Timestamp)> {
+async fn fetch_daemon_latest(http: &reqwest::Client) -> Result<(SweepResult, jiff::Timestamp)> {
 	let url = format!("{DAEMON_BASE}/tasks/doctor/latest");
 	let response = http
 		.get(&url)
@@ -299,10 +353,11 @@ async fn fetch_daemon_latest(
 		.map(str::to_string);
 
 	let overall = overall_from_payload(&inner);
+	let results = results_from_wire(&inner);
 	Ok((
 		SweepResult {
 			server_id,
-			results: Vec::new(),
+			results,
 			overall,
 			payload: inner,
 			pg_version: None,
@@ -311,125 +366,79 @@ async fn fetch_daemon_latest(
 	))
 }
 
-/// Drive a fresh sweep on the daemon and stream the per-check results back.
-///
-/// Each NDJSON line is a `{"event": ...}` object; check events feed the same
-/// live renderer that local sweeps use, the final `done` event carries the
-/// full payload to render the summary off.
-async fn run_daemon_recompute(
-	http: &reqwest::Client,
-	args: &DoctorArgs,
-	use_colours: bool,
-) -> Result<SweepResult> {
-	let url = format!("{DAEMON_BASE}/tasks/doctor/recompute");
-	let response = http
-		.get(&url)
-		.timeout(std::time::Duration::from_secs(5))
-		.send()
-		.await
-		.into_diagnostic()
-		.wrap_err("contacting local alertd")?;
-
-	if !response.status().is_success() {
-		return Err(miette!(
-			"alertd /tasks/doctor/recompute returned {}",
-			response.status()
-		));
-	}
-
-	let live = !args.json && std::io::stdout().is_terminal();
-	let selected_names = selected_names_for_render(&args.only, &args.skip)?;
-	let renderer = if live {
-		let (tx, rx) = mpsc::unbounded_channel();
-		let names = selected_names.clone();
-		let handle = tokio::task::spawn_blocking(move || {
-			let stdout = std::io::stdout();
-			let mut out = stdout.lock();
-			let _ = render_live(&mut out, &names, rx, use_colours);
-		});
-		Some((tx, handle))
-	} else {
-		None
+/// Reconstruct per-check entries from the daemon's wire payload so the cached
+/// path can render the check list and accurate result-line counts. The wire
+/// format drops summaries and reasons, so reconstructed entries have empty
+/// strings for those fields.
+fn results_from_wire(payload: &Value) -> Vec<(Check, bool)> {
+	let Some(health) = payload.get("health").and_then(Value::as_array) else {
+		return Vec::new();
 	};
-
 	let registry = checks::all();
-	let resolve_name = |s: &str| {
-		registry
-			.iter()
-			.find(|e| e.name == s)
-			.map(|e| e.name)
-	};
-
-	let mut stream = response.bytes_stream();
-	let mut buffer = Vec::<u8>::new();
-	let mut final_payload: Option<Value> = None;
-	let mut server_id: Option<String> = None;
-
-	use futures::StreamExt as _;
-	while let Some(chunk) = stream.next().await {
-		let chunk = chunk
-			.into_diagnostic()
-			.wrap_err("reading alertd recompute stream")?;
-		buffer.extend_from_slice(&chunk);
-		while let Some(nl) = buffer.iter().position(|&b| b == b'\n') {
-			let line: Vec<u8> = buffer.drain(..=nl).collect();
-			let line = &line[..line.len() - 1];
-			if line.is_empty() {
-				continue;
-			}
-			let value: Value = match serde_json::from_slice(line) {
-				Ok(v) => v,
-				Err(err) => {
-					warn!(%err, "could not parse alertd recompute line");
-					continue;
-				}
+	health
+		.iter()
+		.filter_map(|entry| {
+			let name = entry.get("check").and_then(Value::as_str)?;
+			let result = entry.get("result").and_then(Value::as_str)?;
+			let name_static = registry.iter().find(|e| e.name == name)?.name;
+			let status = match result {
+				"passed" => CheckStatus::Pass,
+				"skipped" => CheckStatus::Skip(String::new()),
+				"warning" => CheckStatus::Warning(String::new()),
+				"failed" => CheckStatus::Fail(String::new()),
+				"broken" => CheckStatus::Broken(String::new()),
+				_ => return None,
 			};
-			match value.get("event").and_then(Value::as_str) {
-				Some("check") => {
-					if let Some(check_json) = value.get("check")
-						&& let Some(check) = Check::from_streaming_json(check_json, resolve_name)
-						&& let Some((tx, _)) = &renderer
-					{
-						let _ = tx.send(DoctorEvent::Completed(check));
-					}
-				}
-				Some("done") => {
-					final_payload = value.get("payload").cloned();
-					server_id = value
-						.get("serverId")
-						.and_then(Value::as_str)
-						.map(str::to_string);
-				}
-				Some("error") => {
-					let msg = value
-						.get("message")
-						.and_then(Value::as_str)
-						.unwrap_or("unknown");
-					return Err(miette!("alertd recompute reported error: {msg}"));
-				}
-				_ => {}
-			}
-		}
-	}
-
-	if let Some((tx, handle)) = renderer {
-		drop(tx);
-		let _ = handle.await;
-	}
-
-	let payload = final_payload
-		.ok_or_else(|| miette!("alertd recompute stream ended without a done event"))?;
-	let overall = overall_from_payload(&payload);
-	Ok(SweepResult {
-		server_id,
-		results: Vec::new(),
-		overall,
-		payload,
-		pg_version: None,
-	})
+			Some((
+				Check {
+					name: name_static,
+					status,
+					summary: String::new(),
+					details: serde_json::Map::new(),
+					payload_extras: serde_json::Map::new(),
+				},
+				true,
+			))
+		})
+		.collect()
 }
 
-fn selected_names_for_render(only: &[String], skip: &[String]) -> Result<Vec<&'static str>> {
+/// Set up the progress channel and (when running in a TTY) the live TUI task.
+/// The TUI task ends either when every selected check has reported a result or
+/// when the user interrupts. When `live_tty` is false (non-interactive output
+/// or JSON), no TUI is spawned and the sweep simply runs silently.
+fn setup_progress(
+	live_tty: bool,
+	selected_names: &[&'static str],
+	args: &DoctorArgs,
+	source: SweepSource,
+) -> (
+	Option<ProgressSender>,
+	Option<tokio::task::JoinHandle<Result<tui::TuiOutcome>>>,
+) {
+	if !live_tty {
+		return (None, None);
+	}
+	let (tx, rx) = mpsc::unbounded_channel();
+	let names = selected_names.to_vec();
+	let only_failing = args.only_failing;
+	let handle = tokio::spawn(tui::run_tui(names, only_failing, source, rx));
+	(Some(tx), Some(handle))
+}
+
+fn synthetic_sweep(results: Vec<(Check, bool)>) -> SweepResult {
+	let overall =
+		OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+	SweepResult {
+		server_id: None,
+		results,
+		overall,
+		payload: Value::Object(Default::default()),
+		pg_version: None,
+	}
+}
+
+fn selected_names(only: &[String], skip: &[String]) -> Result<Vec<&'static str>> {
 	let registry = checks::all();
 	let known: Vec<&str> = registry.iter().map(|e| e.name).collect();
 	if let Some(unknown) = only.iter().find(|n| !known.contains(&n.as_str())) {
@@ -452,334 +461,68 @@ fn selected_names_for_render(only: &[String], skip: &[String]) -> Result<Vec<&'s
 		.collect())
 }
 
-fn render<W: Write>(
-	out: &mut W,
-	server_id: Option<&str>,
-	results: &[(Check, bool)],
-	overall: OverallResult,
+fn emit_output(
+	args: &DoctorArgs,
+	sweep: &SweepResult,
+	source: &SweepSource,
 	use_colours: bool,
-) -> std::io::Result<()> {
-	write_header(out, server_id)?;
+) -> Result<()> {
+	let stdout = std::io::stdout();
+	let mut out = stdout.lock();
 
-	let name_width = results
-		.iter()
-		.map(|(c, _)| c.name.len())
-		.max()
-		.unwrap_or(0);
-
-	for (check, _) in results {
-		write_check_line(out, check, name_width, use_colours)?;
-	}
-
-	writeln!(out)?;
-	write_result_line(out, results, overall, use_colours)?;
-	Ok(())
-}
-
-fn write_header<W: Write>(out: &mut W, server_id: Option<&str>) -> std::io::Result<()> {
-	let server_id = server_id.unwrap_or("unknown");
-	writeln!(out, "Tamanu doctor (server-id: {server_id})")?;
-	writeln!(out)
-}
-
-fn write_check_line<W: Write>(
-	out: &mut W,
-	check: &Check,
-	name_width: usize,
-	use_colours: bool,
-) -> std::io::Result<()> {
-	let tag_coloured = match &check.status {
-		CheckStatus::Pass => colour_pass(use_colours, "PASS"),
-		CheckStatus::Skip(_) => colour_skip(use_colours, "SKIP"),
-		CheckStatus::Warning(_) => colour_warn(use_colours, "WARN"),
-		CheckStatus::Fail(_) => colour_fail(use_colours, "FAIL"),
-		CheckStatus::Broken(_) => colour_broken(use_colours, "BRKN"),
-	};
-	writeln!(
-		out,
-		"  {tag_coloured}    {name:<width$}   {summary}",
-		name = check.name,
-		width = name_width,
-		summary = check.summary,
-	)?;
-	if let CheckStatus::Skip(r)
-	| CheckStatus::Warning(r)
-	| CheckStatus::Fail(r)
-	| CheckStatus::Broken(r) = &check.status
-	{
-		let dim = if use_colours {
-			format!("{}", r.dimmed())
-		} else {
-			r.clone()
-		};
-		writeln!(
-			out,
-			"          {empty:<width$}     {dim}",
-			empty = "",
-			width = name_width
-		)?;
-	}
-	Ok(())
-}
-
-fn write_result_line<W: Write>(
-	out: &mut W,
-	results: &[(Check, bool)],
-	overall: OverallResult,
-	use_colours: bool,
-) -> std::io::Result<()> {
-	let (mut warnings, mut fails, mut skips, mut brokens) = (0usize, 0usize, 0usize, 0usize);
-	for (check, _) in results {
-		match &check.status {
-			CheckStatus::Pass => {}
-			CheckStatus::Skip(_) => skips += 1,
-			CheckStatus::Warning(_) => warnings += 1,
-			CheckStatus::Fail(_) => fails += 1,
-			CheckStatus::Broken(_) => brokens += 1,
-		}
-	}
-	let label = overall.label();
-	let label_coloured = match overall {
-		OverallResult::Healthy => colour_pass(use_colours, label),
-		OverallResult::Degraded => colour_warn(use_colours, label),
-		OverallResult::Failing => colour_fail(use_colours, label),
-	};
-	let broken_suffix = if brokens > 0 {
-		format!(", {brokens} broken")
-	} else {
-		String::new()
-	};
-	let skip_suffix = if skips > 0 {
-		format!(", {skips} skipped")
-	} else {
-		String::new()
-	};
-	writeln!(
-		out,
-		"Result: {label_coloured} ({fails} failed, {warnings} warning{plural}{broken_suffix}{skip_suffix})",
-		plural = if warnings == 1 { "" } else { "s" },
-	)
-}
-
-/// Streams check results to `out` as they come in over `rx`, with a rewriting
-/// "Outstanding: ..." line below the printed results. The outstanding line is
-/// truncated to the terminal width so `\r\x1b[2K` reliably erases it on the
-/// next update; without that, terminal wrapping leaves orphaned rows behind
-/// as the cursor only sits on the last wrapped row.
-fn render_live<W: Write>(
-	out: &mut W,
-	selected_names: &[&'static str],
-	mut rx: mpsc::UnboundedReceiver<DoctorEvent>,
-	use_colours: bool,
-) -> std::io::Result<()> {
-	let name_width = selected_names.iter().map(|n| n.len()).max().unwrap_or(0);
-	let term_width = terminal_size::terminal_size()
-		.map(|(terminal_size::Width(w), _)| w)
-		.unwrap_or(80);
-	let mut outstanding: Vec<&'static str> = selected_names.to_vec();
-
-	write_outstanding(out, &outstanding, term_width, use_colours)?;
-	out.flush()?;
-
-	while let Some(event) = rx.blocking_recv() {
-		match event {
-			DoctorEvent::Completed(check) => {
-				clear_current_line(out)?;
-				write_check_line(out, &check, name_width, use_colours)?;
-				outstanding.retain(|n| *n != check.name);
-				write_outstanding(out, &outstanding, term_width, use_colours)?;
-				out.flush()?;
+	if args.json {
+		let mut wrapped = serde_json::Map::new();
+		wrapped.insert("wire".into(), sweep.payload.clone());
+		match source {
+			SweepSource::Local => {
+				wrapped.insert("source".into(), Value::String("local".into()));
+			}
+			SweepSource::DaemonStreamed => {
+				wrapped.insert("source".into(), Value::String("daemon-streamed".into()));
+			}
+			SweepSource::DaemonCached { computed_at } => {
+				wrapped.insert("source".into(), Value::String("daemon-cached".into()));
+				wrapped.insert("computedAt".into(), Value::String(computed_at.to_string()));
 			}
 		}
-	}
-
-	clear_current_line(out)?;
-	out.flush()
-}
-
-fn render_summary<W: Write>(
-	out: &mut W,
-	server_id: Option<&str>,
-	results: &[(Check, bool)],
-	overall: OverallResult,
-	use_colours: bool,
-) -> std::io::Result<()> {
-	writeln!(out)?;
-	let server_id = server_id.unwrap_or("unknown");
-	writeln!(out, "Server: {server_id}")?;
-	write_result_line(out, results, overall, use_colours)
-}
-
-fn write_outstanding<W: Write>(
-	out: &mut W,
-	outstanding: &[&'static str],
-	term_width: u16,
-	use_colours: bool,
-) -> std::io::Result<()> {
-	if outstanding.is_empty() {
+		serde_json::to_writer_pretty(&mut out, &Value::Object(wrapped)).into_diagnostic()?;
+		writeln!(out).into_diagnostic()?;
 		return Ok(());
 	}
-	let plain = format!("Outstanding: {}", outstanding.join(", "));
-	let truncated = truncate_to_width(&plain, term_width);
-	if use_colours {
-		write!(out, "{}", truncated.dimmed())
-	} else {
-		write!(out, "{truncated}")
-	}
-}
 
-/// Truncate `s` to fit within `width` display columns, appending `…` when the
-/// string is cut. Treats each char as one column — fine for the ASCII-only
-/// check names this is used with.
-fn truncate_to_width(s: &str, width: u16) -> String {
-	let width = width as usize;
-	if width == 0 {
-		return String::new();
-	}
-	if s.chars().count() <= width {
-		return s.to_string();
-	}
-	if width == 1 {
-		return "…".to_string();
-	}
-	let take = width - 1;
-	let mut out: String = s.chars().take(take).collect();
-	out.push('…');
-	out
-}
-
-fn clear_current_line<W: Write>(out: &mut W) -> std::io::Result<()> {
-	// CR brings cursor to col 0; \x1b[2K erases the whole line.
-	write!(out, "\r\x1b[2K")
-}
-
-fn colour_pass(use_colours: bool, s: &str) -> String {
-	if use_colours {
-		format!("{}", s.green().bold())
-	} else {
-		s.to_string()
-	}
-}
-
-fn colour_skip(use_colours: bool, s: &str) -> String {
-	if use_colours {
-		format!("{}", s.dimmed().bold())
-	} else {
-		s.to_string()
-	}
-}
-
-fn colour_warn(use_colours: bool, s: &str) -> String {
-	if use_colours {
-		format!("{}", s.yellow().bold())
-	} else {
-		s.to_string()
-	}
-}
-
-fn colour_fail(use_colours: bool, s: &str) -> String {
-	if use_colours {
-		format!("{}", s.red().bold())
-	} else {
-		s.to_string()
-	}
-}
-
-fn colour_broken(use_colours: bool, s: &str) -> String {
-	if use_colours {
-		format!("{}", s.magenta().bold())
-	} else {
-		s.to_string()
-	}
+	let displayed = order::filter_and_sort(&sweep.results, args.only_failing);
+	render::render_plain(&mut out, &displayed, sweep.overall, source, use_colours)
+		.into_diagnostic()?;
+	Ok(())
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 
-	fn pass(name: &'static str) -> (Check, bool) {
-		(Check::pass(name, "ok"), true)
-	}
-	fn warn(name: &'static str) -> (Check, bool) {
-		(Check::warning(name, "deg", "reason"), true)
-	}
-	fn fail(name: &'static str) -> (Check, bool) {
-		(Check::fail(name, "bad", "reason"), true)
-	}
-	fn skip(name: &'static str) -> (Check, bool) {
-		(Check::skip(name, "not run", "reason"), true)
-	}
-
-	#[test]
-	fn render_plain_contains_summary_line() {
-		let results = vec![pass("a"), warn("b")];
-		let overall =
-			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
-		let mut buf = Vec::new();
-		render(&mut buf, Some("sid-1"), &results, overall, false).unwrap();
-		let out = String::from_utf8(buf).unwrap();
-		assert!(out.contains("sid-1"));
-		assert!(out.contains("PASS"));
-		assert!(out.contains("WARN"));
-		assert!(out.contains("DEGRADED"));
-		assert!(out.contains("1 warning"));
-	}
-
-	#[test]
-	fn skip_renders_as_skip_and_doesnt_degrade_overall() {
-		// A skipped check should appear with the SKIP tag, not be counted as
-		// a warning or failure, and keep the overall result HEALTHY.
-		let results = vec![pass("a"), skip("b")];
-		let overall =
-			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
-		assert_eq!(overall, OverallResult::Healthy);
-
-		let mut buf = Vec::new();
-		render(&mut buf, Some("sid"), &results, overall, false).unwrap();
-		let out = String::from_utf8(buf).unwrap();
-		assert!(out.contains("SKIP"));
-		assert!(out.contains("HEALTHY"));
-		assert!(out.contains("1 skipped"));
-		// Skip should NOT bump the warning count
-		assert!(!out.contains("1 warning"));
-	}
-
-	#[test]
-	fn render_failing_summary() {
-		let results = vec![fail("a")];
-		let overall =
-			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
-		let mut buf = Vec::new();
-		render(&mut buf, None, &results, overall, false).unwrap();
-		let out = String::from_utf8(buf).unwrap();
-		assert!(out.contains("FAILING"));
-		assert!(out.contains("1 failed"));
-	}
-
 	#[test]
 	fn selected_names_default_returns_full_registry() {
-		let names = selected_names_for_render(&[], &[]).unwrap();
+		let names = selected_names(&[], &[]).unwrap();
 		let registry: Vec<&str> = checks::all().iter().map(|e| e.name).collect();
 		assert_eq!(names, registry);
 	}
 
 	#[test]
 	fn selected_names_only_filters_to_listed() {
-		let names =
-			selected_names_for_render(&["db_connect".into(), "memory".into()], &[]).unwrap();
+		let names = selected_names(&["db_connect".into(), "memory".into()], &[]).unwrap();
 		assert_eq!(names, vec!["db_connect", "memory"]);
 	}
 
 	#[test]
 	fn selected_names_skip_excludes_listed() {
-		let names = selected_names_for_render(&[], &["tailscale".into()]).unwrap();
+		let names = selected_names(&[], &["tailscale".into()]).unwrap();
 		assert!(!names.contains(&"tailscale"));
 		assert!(names.contains(&"db_connect"));
 	}
 
 	#[test]
 	fn selected_names_only_and_skip_compose() {
-		let names = selected_names_for_render(
+		let names = selected_names(
 			&["db_connect".into(), "memory".into(), "tailscale".into()],
 			&["tailscale".into()],
 		)
@@ -789,71 +532,57 @@ mod tests {
 
 	#[test]
 	fn selected_names_unknown_skip_is_error() {
-		let err = selected_names_for_render(&[], &["does_not_exist".into()]).unwrap_err();
+		let err = selected_names(&[], &["does_not_exist".into()]).unwrap_err();
 		assert!(format!("{err}").contains("does_not_exist"));
 	}
 
 	#[test]
-	fn truncate_to_width_pads_short_strings_unchanged() {
-		assert_eq!(truncate_to_width("abc", 10), "abc");
+	fn synthetic_sweep_marks_overall_from_results() {
+		let results = vec![(Check::fail("a", "bad", "r"), true)];
+		let sweep = synthetic_sweep(results);
+		assert_eq!(sweep.overall, OverallResult::Failing);
 	}
 
 	#[test]
-	fn truncate_to_width_chops_with_ellipsis() {
-		assert_eq!(truncate_to_width("abcdefghij", 5), "abcd…");
+	fn doctor_args_only_failing_short_flag() {
+		use clap::Parser;
+		let parsed = DoctorArgs::parse_from(["doctor", "-F"]);
+		assert!(parsed.only_failing);
 	}
 
 	#[test]
-	fn truncate_to_width_handles_exact_fit() {
-		assert_eq!(truncate_to_width("abcde", 5), "abcde");
+	fn doctor_args_only_failing_long_flag() {
+		use clap::Parser;
+		let parsed = DoctorArgs::parse_from(["doctor", "--only-failing"]);
+		assert!(parsed.only_failing);
 	}
 
 	#[test]
-	fn write_outstanding_truncates_to_one_terminal_row() {
-		let mut buf = Vec::new();
-		let names = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
-		write_outstanding(&mut buf, &names, 30, false).unwrap();
-		let out = String::from_utf8(buf).unwrap();
-		assert_eq!(out.chars().count(), 30);
-		assert!(out.ends_with('…'));
-		assert!(out.starts_with("Outstanding: "));
+	fn doctor_args_default_is_no_filter() {
+		use clap::Parser;
+		let parsed = DoctorArgs::parse_from(["doctor"]);
+		assert!(!parsed.only_failing);
 	}
 
 	#[test]
-	fn render_live_streams_results_and_clears_outstanding() {
-		let (tx, rx) = mpsc::unbounded_channel();
-		let names = vec!["alpha", "beta"];
-		let handle = std::thread::spawn(move || {
-			let mut buf = Vec::new();
-			render_live(&mut buf, &names, rx, false).unwrap();
-			String::from_utf8(buf).unwrap()
+	fn results_from_wire_reconstructs_per_check_entries() {
+		let registry = checks::all();
+		let known = registry[0].name;
+		let payload = serde_json::json!({
+			"health": [
+				{ "check": known, "result": "passed" },
+				{ "check": "unknown_check_name", "result": "failed" },
+			]
 		});
-		tx.send(DoctorEvent::Completed(Check::pass("alpha", "ok-a")))
-			.unwrap();
-		tx.send(DoctorEvent::Completed(Check::warning(
-			"beta", "deg", "reason",
-		)))
-		.unwrap();
-		drop(tx);
-		let out = handle.join().unwrap();
-		assert!(out.contains("PASS"));
-		assert!(out.contains("alpha"));
-		assert!(out.contains("ok-a"));
-		assert!(out.contains("WARN"));
-		assert!(out.contains("beta"));
-		assert!(out.contains("Outstanding:"));
+		let results = results_from_wire(&payload);
+		assert_eq!(results.len(), 1);
+		assert_eq!(results[0].0.name, known);
+		assert!(matches!(results[0].0.status, CheckStatus::Pass));
 	}
 
 	#[test]
-	fn render_summary_includes_server_and_result() {
-		let results = vec![pass("a"), warn("b")];
-		let overall =
-			OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
-		let mut buf = Vec::new();
-		render_summary(&mut buf, Some("sid-9"), &results, overall, false).unwrap();
-		let out = String::from_utf8(buf).unwrap();
-		assert!(out.contains("Server: sid-9"));
-		assert!(out.contains("DEGRADED"));
-		assert!(out.contains("1 warning"));
+	fn results_from_wire_empty_when_no_health_array() {
+		let payload = serde_json::json!({});
+		assert!(results_from_wire(&payload).is_empty());
 	}
 }

--- a/crates/bestool/src/actions/tamanu/doctor/order.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/order.rs
@@ -1,0 +1,136 @@
+use bestool_alertd::doctor::check::{Check, CheckStatus};
+
+/// Severity order key for grouping completed checks: lower value = less severe,
+/// renders nearer the top of the list and further from the result line.
+pub fn severity_key(status: &CheckStatus) -> u8 {
+	match status {
+		CheckStatus::Pass => 0,
+		CheckStatus::Skip(_) => 1,
+		CheckStatus::Warning(_) => 2,
+		CheckStatus::Broken(_) => 3,
+		CheckStatus::Fail(_) => 4,
+	}
+}
+
+/// Whether a completed check should appear in human-readable output under the
+/// given `only_failing` filter. The filter hides pass and skip outcomes.
+pub fn keep_under_filter(status: &CheckStatus, only_failing: bool) -> bool {
+	if !only_failing {
+		return true;
+	}
+	matches!(
+		status,
+		CheckStatus::Warning(_) | CheckStatus::Broken(_) | CheckStatus::Fail(_)
+	)
+}
+
+/// Sort `results` into severity-grouped, alphabetical-within-group order.
+pub fn sort_grouped(results: &mut [(Check, bool)]) {
+	results.sort_by(|a, b| {
+		severity_key(&a.0.status)
+			.cmp(&severity_key(&b.0.status))
+			.then_with(|| a.0.name.cmp(b.0.name))
+	});
+}
+
+/// Filter `results` by the `only_failing` flag, leaving them sorted.
+pub fn filter_and_sort(results: &[(Check, bool)], only_failing: bool) -> Vec<(Check, bool)> {
+	let mut out: Vec<(Check, bool)> = results
+		.iter()
+		.filter(|(c, _)| keep_under_filter(&c.status, only_failing))
+		.cloned()
+		.collect();
+	sort_grouped(&mut out);
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn pass(name: &'static str) -> (Check, bool) {
+		(Check::pass(name, "ok"), true)
+	}
+	fn warn(name: &'static str) -> (Check, bool) {
+		(Check::warning(name, "deg", "reason"), true)
+	}
+	fn broken(name: &'static str) -> (Check, bool) {
+		(Check::broken(name, "broke", "reason"), true)
+	}
+	fn fail(name: &'static str) -> (Check, bool) {
+		(Check::fail(name, "bad", "reason"), true)
+	}
+	fn skip(name: &'static str) -> (Check, bool) {
+		(Check::skip(name, "not run", "reason"), true)
+	}
+
+	#[test]
+	fn severity_key_orders_least_to_most() {
+		assert!(severity_key(&CheckStatus::Pass) < severity_key(&CheckStatus::Skip("".into())));
+		assert!(
+			severity_key(&CheckStatus::Skip("".into()))
+				< severity_key(&CheckStatus::Warning("".into()))
+		);
+		assert!(
+			severity_key(&CheckStatus::Warning("".into()))
+				< severity_key(&CheckStatus::Broken("".into()))
+		);
+		assert!(
+			severity_key(&CheckStatus::Broken("".into()))
+				< severity_key(&CheckStatus::Fail("".into()))
+		);
+	}
+
+	#[test]
+	fn sort_grouped_pass_skip_warn_broken_fail_alphabetical() {
+		let mut results = vec![
+			fail("zebra"),
+			pass("delta"),
+			warn("alpha"),
+			broken("beta"),
+			skip("gamma"),
+			pass("charlie"),
+			fail("apple"),
+			warn("yak"),
+		];
+		sort_grouped(&mut results);
+		let names: Vec<&str> = results.iter().map(|(c, _)| c.name).collect();
+		assert_eq!(
+			names,
+			vec!["charlie", "delta", "gamma", "alpha", "yak", "beta", "apple", "zebra"]
+		);
+	}
+
+	#[test]
+	fn keep_under_filter_hides_pass_and_skip() {
+		assert!(!keep_under_filter(&CheckStatus::Pass, true));
+		assert!(!keep_under_filter(&CheckStatus::Skip("".into()), true));
+		assert!(keep_under_filter(&CheckStatus::Warning("".into()), true));
+		assert!(keep_under_filter(&CheckStatus::Broken("".into()), true));
+		assert!(keep_under_filter(&CheckStatus::Fail("".into()), true));
+	}
+
+	#[test]
+	fn keep_under_filter_off_keeps_everything() {
+		assert!(keep_under_filter(&CheckStatus::Pass, false));
+		assert!(keep_under_filter(&CheckStatus::Skip("".into()), false));
+		assert!(keep_under_filter(&CheckStatus::Warning("".into()), false));
+		assert!(keep_under_filter(&CheckStatus::Broken("".into()), false));
+		assert!(keep_under_filter(&CheckStatus::Fail("".into()), false));
+	}
+
+	#[test]
+	fn filter_and_sort_with_only_failing_drops_pass_and_skip() {
+		let input = vec![
+			pass("a"),
+			warn("b"),
+			skip("c"),
+			fail("d"),
+			broken("e"),
+			pass("f"),
+		];
+		let out = filter_and_sort(&input, true);
+		let names: Vec<&str> = out.iter().map(|(c, _)| c.name).collect();
+		assert_eq!(names, vec!["b", "e", "d"]);
+	}
+}

--- a/crates/bestool/src/actions/tamanu/doctor/render.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/render.rs
@@ -1,0 +1,294 @@
+use std::io::{self, Write};
+
+use owo_colors::OwoColorize;
+
+use bestool_alertd::doctor::check::{Check, CheckStatus, OverallResult};
+
+use super::SweepSource;
+
+/// Width to pad check names to within a rendered list.
+fn name_width(results: &[(Check, bool)]) -> usize {
+	results.iter().map(|(c, _)| c.name.len()).max().unwrap_or(0)
+}
+
+/// Render the full human-readable output: grouped check list, blank line,
+/// result line, and dimmed source note. The check list may be empty (under the
+/// `--only-failing` filter on a clean sweep); the result line is shown
+/// regardless.
+pub fn render_plain<W: Write>(
+	out: &mut W,
+	results: &[(Check, bool)],
+	overall: OverallResult,
+	source: &SweepSource,
+	use_colours: bool,
+) -> io::Result<()> {
+	let width = name_width(results);
+	for (check, _) in results {
+		write_check_line(out, check, width, use_colours)?;
+	}
+	if !results.is_empty() {
+		writeln!(out)?;
+	}
+	write_result_line(out, results, overall, use_colours)?;
+	write_source_note(out, source, use_colours)?;
+	Ok(())
+}
+
+pub fn write_check_line<W: Write>(
+	out: &mut W,
+	check: &Check,
+	name_width: usize,
+	use_colours: bool,
+) -> io::Result<()> {
+	let tag = match &check.status {
+		CheckStatus::Pass => colour_pass(use_colours, "PASS"),
+		CheckStatus::Skip(_) => colour_skip(use_colours, "SKIP"),
+		CheckStatus::Warning(_) => colour_warn(use_colours, "WARN"),
+		CheckStatus::Fail(_) => colour_fail(use_colours, "FAIL"),
+		CheckStatus::Broken(_) => colour_broken(use_colours, "BRKN"),
+	};
+	writeln!(
+		out,
+		"  {tag}    {name:<width$}   {summary}",
+		name = check.name,
+		width = name_width,
+		summary = check.summary,
+	)?;
+	if let CheckStatus::Skip(r)
+	| CheckStatus::Warning(r)
+	| CheckStatus::Fail(r)
+	| CheckStatus::Broken(r) = &check.status
+	{
+		let dim = if use_colours {
+			format!("{}", r.dimmed())
+		} else {
+			r.clone()
+		};
+		writeln!(
+			out,
+			"          {empty:<width$}     {dim}",
+			empty = "",
+			width = name_width,
+		)?;
+	}
+	Ok(())
+}
+
+pub fn write_result_line<W: Write>(
+	out: &mut W,
+	results: &[(Check, bool)],
+	overall: OverallResult,
+	use_colours: bool,
+) -> io::Result<()> {
+	let (mut warnings, mut fails, mut skips, mut brokens) = (0usize, 0usize, 0usize, 0usize);
+	for (check, _) in results {
+		match &check.status {
+			CheckStatus::Pass => {}
+			CheckStatus::Skip(_) => skips += 1,
+			CheckStatus::Warning(_) => warnings += 1,
+			CheckStatus::Fail(_) => fails += 1,
+			CheckStatus::Broken(_) => brokens += 1,
+		}
+	}
+	let label = overall.label();
+	let label_coloured = match overall {
+		OverallResult::Healthy => colour_pass(use_colours, label),
+		OverallResult::Degraded => colour_warn(use_colours, label),
+		OverallResult::Failing => colour_fail(use_colours, label),
+	};
+	let broken_suffix = if brokens > 0 {
+		format!(", {brokens} broken")
+	} else {
+		String::new()
+	};
+	let skip_suffix = if skips > 0 {
+		format!(", {skips} skipped")
+	} else {
+		String::new()
+	};
+	writeln!(
+		out,
+		"Result: {label_coloured} ({fails} failed, {warnings} warning{plural}{broken_suffix}{skip_suffix})",
+		plural = if warnings == 1 { "" } else { "s" },
+	)
+}
+
+pub fn write_source_note<W: Write>(
+	out: &mut W,
+	source: &SweepSource,
+	use_colours: bool,
+) -> io::Result<()> {
+	let line = match source {
+		SweepSource::Local => return Ok(()),
+		SweepSource::DaemonStreamed => "Source: alertd daemon (just now, on demand)".to_string(),
+		SweepSource::DaemonCached { computed_at } => {
+			let age = humanise_age_since(*computed_at);
+			format!("Source: alertd daemon (computed {age} ago, at {computed_at})")
+		}
+	};
+	if use_colours {
+		writeln!(out, "{}", line.dimmed())
+	} else {
+		writeln!(out, "{line}")
+	}
+}
+
+pub fn humanise_age_since(then: jiff::Timestamp) -> String {
+	let now = jiff::Timestamp::now();
+	let secs = now.as_second().saturating_sub(then.as_second()).max(0) as u64;
+	if secs < 60 {
+		format!("{secs}s")
+	} else if secs < 3600 {
+		format!("{}m {}s", secs / 60, secs % 60)
+	} else {
+		format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+	}
+}
+
+fn colour_pass(use_colours: bool, s: &str) -> String {
+	if use_colours {
+		format!("{}", s.green().bold())
+	} else {
+		s.to_string()
+	}
+}
+
+fn colour_skip(use_colours: bool, s: &str) -> String {
+	if use_colours {
+		format!("{}", s.dimmed().bold())
+	} else {
+		s.to_string()
+	}
+}
+
+fn colour_warn(use_colours: bool, s: &str) -> String {
+	if use_colours {
+		format!("{}", s.yellow().bold())
+	} else {
+		s.to_string()
+	}
+}
+
+fn colour_fail(use_colours: bool, s: &str) -> String {
+	if use_colours {
+		format!("{}", s.red().bold())
+	} else {
+		s.to_string()
+	}
+}
+
+fn colour_broken(use_colours: bool, s: &str) -> String {
+	if use_colours {
+		format!("{}", s.magenta().bold())
+	} else {
+		s.to_string()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::actions::tamanu::doctor::order::filter_and_sort;
+
+	fn pass(name: &'static str) -> (Check, bool) {
+		(Check::pass(name, "ok"), true)
+	}
+	fn warn(name: &'static str) -> (Check, bool) {
+		(Check::warning(name, "deg", "reason"), true)
+	}
+	fn fail(name: &'static str) -> (Check, bool) {
+		(Check::fail(name, "bad", "reason"), true)
+	}
+	fn skip(name: &'static str) -> (Check, bool) {
+		(Check::skip(name, "not run", "reason"), true)
+	}
+	fn broken(name: &'static str) -> (Check, bool) {
+		(Check::broken(name, "broke", "reason"), true)
+	}
+
+	#[test]
+	fn render_plain_lists_results_in_severity_order() {
+		let raw = vec![fail("z-fail"), pass("a-pass"), warn("m-warn")];
+		let sorted = filter_and_sort(&raw, false);
+		let overall = OverallResult::from_checks(&sorted.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let mut buf = Vec::new();
+		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		let pass_pos = out.find("a-pass").unwrap();
+		let warn_pos = out.find("m-warn").unwrap();
+		let fail_pos = out.find("z-fail").unwrap();
+		assert!(pass_pos < warn_pos);
+		assert!(warn_pos < fail_pos);
+		assert!(out.contains("FAILING"));
+		assert!(out.contains("1 failed"));
+	}
+
+	#[test]
+	fn render_plain_only_failing_shows_just_result_line_when_clean() {
+		let raw = vec![pass("a"), pass("b"), skip("c")];
+		let sorted = filter_and_sort(&raw, true);
+		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let mut buf = Vec::new();
+		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert!(!out.contains("PASS"));
+		assert!(!out.contains("SKIP"));
+		assert!(out.contains("HEALTHY"));
+	}
+
+	#[test]
+	fn render_plain_only_failing_keeps_warn_broken_fail() {
+		let raw = vec![pass("a"), warn("b"), broken("c"), fail("d"), skip("e")];
+		let sorted = filter_and_sort(&raw, true);
+		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let mut buf = Vec::new();
+		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert!(out.contains("WARN"));
+		assert!(out.contains("BRKN"));
+		assert!(out.contains("FAIL"));
+		assert!(!out.contains("PASS"));
+		assert!(!out.contains("SKIP"));
+		// Order: warn (b), broken (c), fail (d)
+		let warn_pos = out.find("WARN").unwrap();
+		let broken_pos = out.find("BRKN").unwrap();
+		let fail_pos = out.find("FAIL").unwrap();
+		assert!(warn_pos < broken_pos);
+		assert!(broken_pos < fail_pos);
+	}
+
+	#[test]
+	fn render_plain_no_server_id_header() {
+		let raw = vec![pass("a")];
+		let sorted = filter_and_sort(&raw, false);
+		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let mut buf = Vec::new();
+		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert!(!out.contains("server-id"));
+		assert!(!out.contains("Server:"));
+	}
+
+	#[test]
+	fn render_plain_includes_source_note_for_daemon_streamed() {
+		let raw = vec![pass("a")];
+		let sorted = filter_and_sort(&raw, false);
+		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let mut buf = Vec::new();
+		render_plain(&mut buf, &sorted, overall, &SweepSource::DaemonStreamed, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert!(out.contains("alertd daemon"));
+	}
+
+	#[test]
+	fn result_line_lists_broken_and_skipped_counts() {
+		let results = vec![broken("a"), skip("b"), pass("c")];
+		let overall = OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
+		let mut buf = Vec::new();
+		write_result_line(&mut buf, &results, overall, false).unwrap();
+		let out = String::from_utf8(buf).unwrap();
+		assert!(out.contains("1 broken"));
+		assert!(out.contains("1 skipped"));
+		assert!(out.contains("DEGRADED"));
+	}
+}

--- a/crates/bestool/src/actions/tamanu/doctor/tui.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/tui.rs
@@ -1,22 +1,19 @@
 use std::{
-	io::{self, Stdout},
+	io::{self, Stdout, Write},
 	time::Duration,
 };
 
-use miette::{IntoDiagnostic, Result};
-use ratatui::{
-	Terminal,
-	backend::CrosstermBackend,
-	crossterm::{
-		event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
-		execute,
-		terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+use crossterm::{
+	cursor::{Hide, MoveTo, Show},
+	event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+	execute, queue,
+	style::{Attribute, Color, ResetColor, SetAttribute, SetForegroundColor},
+	terminal::{
+		Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
+		enable_raw_mode,
 	},
-	layout::{Constraint, Direction, Layout},
-	style::{Color, Modifier, Style},
-	text::{Line, Span},
-	widgets::Paragraph,
 };
+use miette::{IntoDiagnostic, Result};
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use bestool_alertd::doctor::{
@@ -48,27 +45,59 @@ pub struct TuiOutcome {
 	pub interrupted: bool,
 }
 
+/// A single styled segment within a rendered line.
+#[derive(Clone, Debug)]
+struct Segment {
+	text: String,
+	style: SegStyle,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SegStyle {
+	Plain,
+	Dim,
+	BoldFg(Color),
+}
+
+type StyledLine = Vec<Segment>;
+
+fn plain<S: Into<String>>(s: S) -> Segment {
+	Segment {
+		text: s.into(),
+		style: SegStyle::Plain,
+	}
+}
+fn dim<S: Into<String>>(s: S) -> Segment {
+	Segment {
+		text: s.into(),
+		style: SegStyle::Dim,
+	}
+}
+fn bold_fg<S: Into<String>>(s: S, c: Color) -> Segment {
+	Segment {
+		text: s.into(),
+		style: SegStyle::BoldFg(c),
+	}
+}
+
 /// RAII guard that restores the terminal on drop (including on panic).
 struct TerminalGuard {
-	terminal: Terminal<CrosstermBackend<Stdout>>,
+	stdout: Stdout,
 }
 
 impl TerminalGuard {
 	fn new() -> io::Result<Self> {
 		let mut stdout = io::stdout();
 		enable_raw_mode()?;
-		execute!(stdout, EnterAlternateScreen)?;
-		let backend = CrosstermBackend::new(stdout);
-		let terminal = Terminal::new(backend)?;
-		Ok(Self { terminal })
+		execute!(stdout, EnterAlternateScreen, Hide)?;
+		Ok(Self { stdout })
 	}
 }
 
 impl Drop for TerminalGuard {
 	fn drop(&mut self) {
+		let _ = execute!(self.stdout, Show, LeaveAlternateScreen);
 		let _ = disable_raw_mode();
-		let _ = execute!(io::stdout(), LeaveAlternateScreen);
-		let _ = self.terminal.show_cursor();
 	}
 }
 
@@ -92,15 +121,19 @@ pub async fn run_tui(
 	let mut interrupted = false;
 
 	let mut guard = TerminalGuard::new().into_diagnostic()?;
-	guard.terminal.hide_cursor().into_diagnostic()?;
 
 	loop {
 		drain_progress(&mut progress_rx, &mut rows);
 
-		guard
-			.terminal
-			.draw(|f| draw(f, &rows, total, &source, only_failing, spinner))
-			.into_diagnostic()?;
+		draw(
+			&mut guard.stdout,
+			&rows,
+			total,
+			&source,
+			only_failing,
+			spinner,
+		)
+		.into_diagnostic()?;
 
 		if all_completed(&rows) {
 			break;
@@ -176,56 +209,61 @@ fn poll_for_quit(timeout: Duration) -> io::Result<bool> {
 }
 
 fn draw(
-	f: &mut ratatui::Frame<'_>,
+	out: &mut Stdout,
 	rows: &[TuiRow],
 	total: usize,
 	source: &SweepSource,
 	only_failing: bool,
 	spinner: usize,
-) {
-	let area = f.area();
-	let layout = Layout::default()
-		.direction(Direction::Vertical)
-		.constraints([
-			Constraint::Length(source_lines(source)),
-			Constraint::Min(0),
-			Constraint::Length(1),
-		])
-		.split(area);
+) -> io::Result<()> {
+	queue!(out, MoveTo(0, 0), Clear(ClearType::All))?;
 
-	let source_para = Paragraph::new(source_line(source)).style(dim_style());
-	f.render_widget(source_para, layout[0]);
-
-	let lines = build_rows(rows, only_failing, spinner);
-	let list_para = Paragraph::new(lines);
-	f.render_widget(list_para, layout[1]);
-
-	let footer = footer_line(rows, total, spinner);
-	let footer_para = Paragraph::new(footer).style(dim_style());
-	f.render_widget(footer_para, layout[2]);
-}
-
-fn source_lines(source: &SweepSource) -> u16 {
-	match source {
-		SweepSource::Local => 0,
-		_ => 1,
+	let mut lines: Vec<StyledLine> = Vec::new();
+	if let Some(line) = source_line(source) {
+		lines.push(line);
 	}
+	lines.extend(build_rows(rows, only_failing, spinner));
+	lines.push(footer_line(rows, total, spinner));
+
+	for line in lines {
+		write_line(out, &line)?;
+		out.write_all(b"\r\n")?;
+	}
+	out.flush()
 }
 
-fn source_line(source: &SweepSource) -> Line<'_> {
-	match source {
-		SweepSource::Local => Line::raw(""),
-		SweepSource::DaemonStreamed => Line::raw("Source: alertd daemon (just now, on demand)"),
-		SweepSource::DaemonCached { computed_at } => {
-			let age = super::render::humanise_age_since(*computed_at);
-			Line::raw(format!(
-				"Source: alertd daemon (computed {age} ago, at {computed_at})"
-			))
+fn write_line(out: &mut Stdout, line: &StyledLine) -> io::Result<()> {
+	for seg in line {
+		match seg.style {
+			SegStyle::Plain => out.write_all(seg.text.as_bytes())?,
+			SegStyle::Dim => {
+				queue!(out, SetAttribute(Attribute::Dim))?;
+				out.write_all(seg.text.as_bytes())?;
+				queue!(out, SetAttribute(Attribute::Reset))?;
+			}
+			SegStyle::BoldFg(c) => {
+				queue!(out, SetForegroundColor(c), SetAttribute(Attribute::Bold))?;
+				out.write_all(seg.text.as_bytes())?;
+				queue!(out, SetAttribute(Attribute::Reset), ResetColor)?;
+			}
 		}
 	}
+	Ok(())
 }
 
-fn build_rows(rows: &[TuiRow], only_failing: bool, spinner: usize) -> Vec<Line<'static>> {
+fn source_line(source: &SweepSource) -> Option<StyledLine> {
+	let text = match source {
+		SweepSource::Local => return None,
+		SweepSource::DaemonStreamed => "Source: alertd daemon (just now, on demand)".to_string(),
+		SweepSource::DaemonCached { computed_at } => {
+			let age = super::render::humanise_age_since(*computed_at);
+			format!("Source: alertd daemon (computed {age} ago, at {computed_at})")
+		}
+	};
+	Some(vec![dim(text)])
+}
+
+fn build_rows(rows: &[TuiRow], only_failing: bool, spinner: usize) -> Vec<StyledLine> {
 	let name_width = rows.iter().map(|r| r.name.len()).max().unwrap_or(0);
 
 	let mut ordered: Vec<&TuiRow> = rows
@@ -259,40 +297,37 @@ fn sort_key(row: &TuiRow) -> u8 {
 	}
 }
 
-fn row_line_running(name: &str, name_width: usize, spinner: usize) -> Line<'static> {
+fn row_line_running(name: &str, name_width: usize, spinner: usize) -> StyledLine {
 	let frame = SPINNER_FRAMES[spinner % SPINNER_FRAMES.len()];
 	let pad = " ".repeat(name_width.saturating_sub(name.len()));
-	Line::from(vec![
-		Span::raw("  "),
-		Span::styled(format!("{frame:<4}"), dim_style()),
-		Span::raw("    "),
-		Span::raw(name.to_string()),
-		Span::raw(pad),
-		Span::raw("   "),
-		Span::styled("…".to_string(), dim_style()),
-	])
+	vec![
+		plain("  "),
+		dim(format!("{frame:<4}")),
+		plain("    "),
+		plain(name.to_string()),
+		plain(pad),
+		plain("   "),
+		dim("…"),
+	]
 }
 
-fn row_line_completed(check: &Check, name_width: usize) -> Line<'static> {
-	let (tag, style) = tag_for(check);
+fn row_line_completed(check: &Check, name_width: usize) -> StyledLine {
+	let (tag, color) = tag_for(check);
 	let pad = " ".repeat(name_width.saturating_sub(check.name.len()));
-	Line::from(vec![
-		Span::raw("  "),
-		Span::styled(format!("{tag:<4}"), style),
-		Span::raw("    "),
-		Span::raw(check.name.to_string()),
-		Span::raw(pad),
-		Span::raw("   "),
-		Span::raw(check.summary.clone()),
-	])
+	vec![
+		plain("  "),
+		bold_fg(format!("{tag:<4}"), color),
+		plain("    "),
+		plain(check.name.to_string()),
+		plain(pad),
+		plain("   "),
+		plain(check.summary.clone()),
+	]
 }
 
-fn reason_line(reason: &str, name_width: usize) -> Line<'static> {
+fn reason_line(reason: &str, name_width: usize) -> StyledLine {
 	let lead = " ".repeat(10 + name_width + 5);
-	Line::from(vec![
-		Span::raw(lead),
-		Span::styled(reason.to_string(), dim_style()),
-	])
+	vec![plain(lead), dim(reason.to_string())]
 }
 
 fn reason_for(check: &Check) -> Option<&str> {
@@ -305,48 +340,31 @@ fn reason_for(check: &Check) -> Option<&str> {
 	}
 }
 
-fn tag_for(check: &Check) -> (&'static str, Style) {
+fn tag_for(check: &Check) -> (&'static str, Color) {
 	match &check.status {
-		CheckStatus::Pass => ("PASS", Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
-		CheckStatus::Skip(_) => (
-			"SKIP",
-			Style::new()
-				.fg(Color::DarkGray)
-				.add_modifier(Modifier::BOLD),
-		),
-		CheckStatus::Warning(_) => (
-			"WARN",
-			Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
-		),
-		CheckStatus::Broken(_) => (
-			"BRKN",
-			Style::new()
-				.fg(Color::Magenta)
-				.add_modifier(Modifier::BOLD),
-		),
-		CheckStatus::Fail(_) => ("FAIL", Style::new().fg(Color::Red).add_modifier(Modifier::BOLD)),
+		CheckStatus::Pass => ("PASS", Color::Green),
+		CheckStatus::Skip(_) => ("SKIP", Color::DarkGrey),
+		CheckStatus::Warning(_) => ("WARN", Color::Yellow),
+		CheckStatus::Broken(_) => ("BRKN", Color::Magenta),
+		CheckStatus::Fail(_) => ("FAIL", Color::Red),
 	}
 }
 
-fn footer_line(rows: &[TuiRow], total: usize, spinner: usize) -> Line<'static> {
+fn footer_line(rows: &[TuiRow], total: usize, spinner: usize) -> StyledLine {
 	let completed = rows
 		.iter()
 		.filter(|r| matches!(r.state, RowState::Completed(_)))
 		.count();
 	let frame = SPINNER_FRAMES[spinner % SPINNER_FRAMES.len()];
-	Line::raw(format!("{frame} {completed} / {total} complete"))
-}
-
-fn dim_style() -> Style {
-	Style::new().add_modifier(Modifier::DIM)
+	vec![dim(format!("{frame} {completed} / {total} complete"))]
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 
-	fn line_text(line: &Line<'_>) -> String {
-		line.spans.iter().map(|s| s.content.as_ref()).collect()
+	fn line_text(line: &StyledLine) -> String {
+		line.iter().map(|s| s.text.as_str()).collect()
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/tamanu/doctor/tui.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/tui.rs
@@ -1,0 +1,442 @@
+use std::{
+	io::{self, Stdout},
+	time::Duration,
+};
+
+use miette::{IntoDiagnostic, Result};
+use ratatui::{
+	Terminal,
+	backend::CrosstermBackend,
+	crossterm::{
+		event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+		execute,
+		terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+	},
+	layout::{Constraint, Direction, Layout},
+	style::{Color, Modifier, Style},
+	text::{Line, Span},
+	widgets::Paragraph,
+};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use bestool_alertd::doctor::{
+	check::{Check, CheckStatus},
+	progress::DoctorEvent,
+};
+
+use super::{SweepSource, order};
+
+const SPINNER_FRAMES: &[&str] = &[
+	"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+];
+const TICK: Duration = Duration::from_millis(80);
+
+/// State of a single row in the TUI.
+#[derive(Clone)]
+enum RowState {
+	Running,
+	Completed(Check),
+}
+
+struct TuiRow {
+	name: &'static str,
+	state: RowState,
+}
+
+pub struct TuiOutcome {
+	pub results: Vec<(Check, bool)>,
+	pub interrupted: bool,
+}
+
+/// RAII guard that restores the terminal on drop (including on panic).
+struct TerminalGuard {
+	terminal: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl TerminalGuard {
+	fn new() -> io::Result<Self> {
+		let mut stdout = io::stdout();
+		enable_raw_mode()?;
+		execute!(stdout, EnterAlternateScreen)?;
+		let backend = CrosstermBackend::new(stdout);
+		let terminal = Terminal::new(backend)?;
+		Ok(Self { terminal })
+	}
+}
+
+impl Drop for TerminalGuard {
+	fn drop(&mut self) {
+		let _ = disable_raw_mode();
+		let _ = execute!(io::stdout(), LeaveAlternateScreen);
+		let _ = self.terminal.show_cursor();
+	}
+}
+
+/// Run the live TUI until either the sweep finishes (progress channel closes
+/// and every selected check has been seen) or the user interrupts (Ctrl+C / q).
+pub async fn run_tui(
+	selected_names: Vec<&'static str>,
+	only_failing: bool,
+	source: SweepSource,
+	mut progress_rx: UnboundedReceiver<DoctorEvent>,
+) -> Result<TuiOutcome> {
+	let total = selected_names.len();
+	let mut rows: Vec<TuiRow> = selected_names
+		.into_iter()
+		.map(|name| TuiRow {
+			name,
+			state: RowState::Running,
+		})
+		.collect();
+	let mut spinner = 0usize;
+	let mut interrupted = false;
+
+	let mut guard = TerminalGuard::new().into_diagnostic()?;
+	guard.terminal.hide_cursor().into_diagnostic()?;
+
+	loop {
+		drain_progress(&mut progress_rx, &mut rows);
+
+		guard
+			.terminal
+			.draw(|f| draw(f, &rows, total, &source, only_failing, spinner))
+			.into_diagnostic()?;
+
+		if all_completed(&rows) {
+			break;
+		}
+
+		if poll_for_quit(TICK).into_diagnostic()? {
+			interrupted = true;
+			break;
+		}
+
+		spinner = (spinner + 1) % SPINNER_FRAMES.len();
+
+		if progress_rx.is_closed() && progress_rx.is_empty() && !all_completed(&rows) {
+			// Sweep ended early (error or aborted) without producing all results.
+			// Treat as interrupted so the caller exits non-zero.
+			interrupted = true;
+			break;
+		}
+	}
+
+	drop(guard);
+
+	let results: Vec<(Check, bool)> = rows
+		.into_iter()
+		.filter_map(|row| match row.state {
+			RowState::Completed(check) => Some((check, true)),
+			RowState::Running => None,
+		})
+		.collect();
+
+	Ok(TuiOutcome {
+		results,
+		interrupted,
+	})
+}
+
+fn drain_progress(rx: &mut UnboundedReceiver<DoctorEvent>, rows: &mut [TuiRow]) {
+	while let Ok(evt) = rx.try_recv() {
+		match evt {
+			DoctorEvent::Completed(check) => {
+				if let Some(row) = rows.iter_mut().find(|r| r.name == check.name) {
+					row.state = RowState::Completed(check);
+				}
+			}
+		}
+	}
+}
+
+fn all_completed(rows: &[TuiRow]) -> bool {
+	rows.iter().all(|r| matches!(r.state, RowState::Completed(_)))
+}
+
+/// Poll keyboard events for up to `timeout`. Returns true if the user pressed a
+/// quit chord (Ctrl+C or q).
+fn poll_for_quit(timeout: Duration) -> io::Result<bool> {
+	if !event::poll(timeout)? {
+		return Ok(false);
+	}
+	while event::poll(Duration::ZERO)? {
+		if let Event::Key(KeyEvent {
+			code, modifiers, ..
+		}) = event::read()?
+		{
+			let ctrl_c =
+				matches!(code, KeyCode::Char('c')) && modifiers.contains(KeyModifiers::CONTROL);
+			let q = matches!(code, KeyCode::Char('q'));
+			if ctrl_c || q {
+				return Ok(true);
+			}
+		}
+	}
+	Ok(false)
+}
+
+fn draw(
+	f: &mut ratatui::Frame<'_>,
+	rows: &[TuiRow],
+	total: usize,
+	source: &SweepSource,
+	only_failing: bool,
+	spinner: usize,
+) {
+	let area = f.area();
+	let layout = Layout::default()
+		.direction(Direction::Vertical)
+		.constraints([
+			Constraint::Length(source_lines(source)),
+			Constraint::Min(0),
+			Constraint::Length(1),
+		])
+		.split(area);
+
+	let source_para = Paragraph::new(source_line(source)).style(dim_style());
+	f.render_widget(source_para, layout[0]);
+
+	let lines = build_rows(rows, only_failing, spinner);
+	let list_para = Paragraph::new(lines);
+	f.render_widget(list_para, layout[1]);
+
+	let footer = footer_line(rows, total, spinner);
+	let footer_para = Paragraph::new(footer).style(dim_style());
+	f.render_widget(footer_para, layout[2]);
+}
+
+fn source_lines(source: &SweepSource) -> u16 {
+	match source {
+		SweepSource::Local => 0,
+		_ => 1,
+	}
+}
+
+fn source_line(source: &SweepSource) -> Line<'_> {
+	match source {
+		SweepSource::Local => Line::raw(""),
+		SweepSource::DaemonStreamed => Line::raw("Source: alertd daemon (just now, on demand)"),
+		SweepSource::DaemonCached { computed_at } => {
+			let age = super::render::humanise_age_since(*computed_at);
+			Line::raw(format!(
+				"Source: alertd daemon (computed {age} ago, at {computed_at})"
+			))
+		}
+	}
+}
+
+fn build_rows(rows: &[TuiRow], only_failing: bool, spinner: usize) -> Vec<Line<'static>> {
+	let name_width = rows.iter().map(|r| r.name.len()).max().unwrap_or(0);
+
+	let mut ordered: Vec<&TuiRow> = rows
+		.iter()
+		.filter(|row| match &row.state {
+			RowState::Running => true,
+			RowState::Completed(check) => order::keep_under_filter(&check.status, only_failing),
+		})
+		.collect();
+	ordered.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)).then_with(|| a.name.cmp(b.name)));
+
+	let mut lines = Vec::with_capacity(ordered.len());
+	for row in ordered {
+		match &row.state {
+			RowState::Running => lines.push(row_line_running(row.name, name_width, spinner)),
+			RowState::Completed(check) => {
+				lines.push(row_line_completed(check, name_width));
+				if let Some(reason) = reason_for(check) {
+					lines.push(reason_line(reason, name_width));
+				}
+			}
+		}
+	}
+	lines
+}
+
+fn sort_key(row: &TuiRow) -> u8 {
+	match &row.state {
+		RowState::Running => 0,
+		RowState::Completed(check) => 1 + order::severity_key(&check.status),
+	}
+}
+
+fn row_line_running(name: &str, name_width: usize, spinner: usize) -> Line<'static> {
+	let frame = SPINNER_FRAMES[spinner % SPINNER_FRAMES.len()];
+	let pad = " ".repeat(name_width.saturating_sub(name.len()));
+	Line::from(vec![
+		Span::raw("  "),
+		Span::styled(format!("{frame:<4}"), dim_style()),
+		Span::raw("    "),
+		Span::raw(name.to_string()),
+		Span::raw(pad),
+		Span::raw("   "),
+		Span::styled("…".to_string(), dim_style()),
+	])
+}
+
+fn row_line_completed(check: &Check, name_width: usize) -> Line<'static> {
+	let (tag, style) = tag_for(check);
+	let pad = " ".repeat(name_width.saturating_sub(check.name.len()));
+	Line::from(vec![
+		Span::raw("  "),
+		Span::styled(format!("{tag:<4}"), style),
+		Span::raw("    "),
+		Span::raw(check.name.to_string()),
+		Span::raw(pad),
+		Span::raw("   "),
+		Span::raw(check.summary.clone()),
+	])
+}
+
+fn reason_line(reason: &str, name_width: usize) -> Line<'static> {
+	let lead = " ".repeat(10 + name_width + 5);
+	Line::from(vec![
+		Span::raw(lead),
+		Span::styled(reason.to_string(), dim_style()),
+	])
+}
+
+fn reason_for(check: &Check) -> Option<&str> {
+	match &check.status {
+		CheckStatus::Pass => None,
+		CheckStatus::Skip(r)
+		| CheckStatus::Warning(r)
+		| CheckStatus::Fail(r)
+		| CheckStatus::Broken(r) => Some(r.as_str()),
+	}
+}
+
+fn tag_for(check: &Check) -> (&'static str, Style) {
+	match &check.status {
+		CheckStatus::Pass => ("PASS", Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+		CheckStatus::Skip(_) => (
+			"SKIP",
+			Style::new()
+				.fg(Color::DarkGray)
+				.add_modifier(Modifier::BOLD),
+		),
+		CheckStatus::Warning(_) => (
+			"WARN",
+			Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+		),
+		CheckStatus::Broken(_) => (
+			"BRKN",
+			Style::new()
+				.fg(Color::Magenta)
+				.add_modifier(Modifier::BOLD),
+		),
+		CheckStatus::Fail(_) => ("FAIL", Style::new().fg(Color::Red).add_modifier(Modifier::BOLD)),
+	}
+}
+
+fn footer_line(rows: &[TuiRow], total: usize, spinner: usize) -> Line<'static> {
+	let completed = rows
+		.iter()
+		.filter(|r| matches!(r.state, RowState::Completed(_)))
+		.count();
+	let frame = SPINNER_FRAMES[spinner % SPINNER_FRAMES.len()];
+	Line::raw(format!("{frame} {completed} / {total} complete"))
+}
+
+fn dim_style() -> Style {
+	Style::new().add_modifier(Modifier::DIM)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn line_text(line: &Line<'_>) -> String {
+		line.spans.iter().map(|s| s.content.as_ref()).collect()
+	}
+
+	#[test]
+	fn build_rows_orders_running_then_pass_skip_warn_broken_fail() {
+		let rows = vec![
+			TuiRow {
+				name: "z-fail",
+				state: RowState::Completed(Check::fail("z-fail", "bad", "r")),
+			},
+			TuiRow {
+				name: "a-pass",
+				state: RowState::Completed(Check::pass("a-pass", "ok")),
+			},
+			TuiRow {
+				name: "m-warn",
+				state: RowState::Completed(Check::warning("m-warn", "deg", "r")),
+			},
+			TuiRow {
+				name: "k-run",
+				state: RowState::Running,
+			},
+			TuiRow {
+				name: "b-skip",
+				state: RowState::Completed(Check::skip("b-skip", "n/a", "r")),
+			},
+			TuiRow {
+				name: "c-broken",
+				state: RowState::Completed(Check::broken("c-broken", "broke", "r")),
+			},
+		];
+		let lines = build_rows(&rows, false, 0);
+		let joined: Vec<String> = lines.iter().map(line_text).collect();
+		let positions = |needle: &str| {
+			joined
+				.iter()
+				.position(|s| s.contains(needle))
+				.unwrap_or_else(|| panic!("missing {needle}"))
+		};
+		assert!(positions("k-run") < positions("a-pass"));
+		assert!(positions("a-pass") < positions("b-skip"));
+		assert!(positions("b-skip") < positions("m-warn"));
+		assert!(positions("m-warn") < positions("c-broken"));
+		assert!(positions("c-broken") < positions("z-fail"));
+	}
+
+	#[test]
+	fn build_rows_only_failing_drops_completed_pass_and_skip_but_keeps_running() {
+		let rows = vec![
+			TuiRow {
+				name: "a-pass",
+				state: RowState::Completed(Check::pass("a-pass", "ok")),
+			},
+			TuiRow {
+				name: "b-skip",
+				state: RowState::Completed(Check::skip("b-skip", "n/a", "r")),
+			},
+			TuiRow {
+				name: "c-warn",
+				state: RowState::Completed(Check::warning("c-warn", "deg", "r")),
+			},
+			TuiRow {
+				name: "d-run",
+				state: RowState::Running,
+			},
+		];
+		let lines = build_rows(&rows, true, 0);
+		let joined: Vec<String> = lines.iter().map(line_text).collect();
+		assert!(joined.iter().any(|s| s.contains("d-run")));
+		assert!(joined.iter().any(|s| s.contains("c-warn")));
+		assert!(!joined.iter().any(|s| s.contains("a-pass")));
+		assert!(!joined.iter().any(|s| s.contains("b-skip")));
+	}
+
+	#[test]
+	fn footer_counts_completed_against_total() {
+		let rows = vec![
+			TuiRow {
+				name: "a",
+				state: RowState::Completed(Check::pass("a", "ok")),
+			},
+			TuiRow {
+				name: "b",
+				state: RowState::Completed(Check::warning("b", "deg", "r")),
+			},
+			TuiRow {
+				name: "c",
+				state: RowState::Running,
+			},
+		];
+		let line = footer_line(&rows, 3, 0);
+		assert!(line_text(&line).contains("2 / 3 complete"));
+	}
+}


### PR DESCRIPTION
Adds `--only-failing` / `-F` to `bestool tamanu doctor`, hiding passing and skipped checks so only warning, broken, and failing outcomes appear in the output. Grouping and ordering (severity ascending, alphabetical within groups) apply whether the filter is active or not.

Replaces the previous line-rewriting live renderer with a ratatui alternate-screen TUI: every selected check starts as a pending row, transitions to a spinner while running, then moves to its sorted position on completion. Under `-F`, rows that resolve to pass/skip are removed; pending and running rows remain visible throughout. On exit or Ctrl+C, the TUI tears down cleanly and replays the final grouped output to scrollback; interrupted runs exit with code 130.

The implementation splits `doctor.rs` into four modules (`doctor.rs`, `order.rs`, `render.rs`, `tui.rs`), replaces `terminal_size` with `ratatui` in the feature dependencies, and leaves JSON output unaffected by the filter.

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->