### PR TITLE
feat(canopy): pg_basebackup backup method for non-snapshot backends

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -36,6 +36,8 @@ pub(super) enum Teardown {
 	Nothing,
 	/// A btrfs snapshot + its mounts.
 	Btrfs(super::postgresql::btrfs::Mounts),
+	/// A streamed base backup directory to remove.
+	BaseBackup(PathBuf),
 }
 
 /// `[simple]` method: snapshot a path verbatim.
@@ -104,6 +106,7 @@ impl Method {
 		match prepared.teardown {
 			Teardown::Nothing => Ok(()),
 			Teardown::Btrfs(mounts) => super::postgresql::btrfs::teardown(mounts).await,
+			Teardown::BaseBackup(root) => super::postgresql::basebackup::teardown(root).await,
 		}
 	}
 

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -6,17 +6,29 @@
 //! captures it. btrfs is implemented; thin-LVM / Windows VSS / `pg_basebackup`
 //! land in follow-ups.
 
+pub mod basebackup;
 pub mod btrfs;
 pub mod resolve;
 pub mod strategy;
 
-use std::{collections::BTreeMap, path::Path};
+use std::{
+	collections::BTreeMap,
+	path::{Path, PathBuf},
+};
 
 use miette::{Context as _, IntoDiagnostic as _, Result, bail};
 use tracing::{info, warn};
 
 use self::strategy::Strategy;
 use super::method::{PostgresqlConfig, Prepared, Teardown};
+
+/// The stable path the snapshot/basebackup is exposed at for kopia — fixed per
+/// backup type so kopia's history/dedup attribute to one source, regardless of
+/// which strategy produced it (a host migrating btrfs↔basebackup keeps its
+/// history). The version/cluster suffix the caller adds is the only moving part.
+pub(super) fn stable_source_dir(backup_type: &str) -> PathBuf {
+	PathBuf::from("/var/lib/kopia/bestool-backup").join(backup_type)
+}
 
 /// Transient files safe to exclude from the snapshot. Never `pg_wal`, `pg_xact`,
 /// `pg_control`, `global`, or tablespaces — those are required for recovery.
@@ -64,8 +76,24 @@ pub async fn prepare(config: &PostgresqlConfig, backup_type: &str) -> Result<Pre
 				teardown: Teardown::Btrfs(mounts),
 			})
 		}
+		Strategy::BaseBackup => {
+			let (source, root) = basebackup::prepare(
+				&resolved,
+				backup_type,
+				config.socket.as_deref(),
+				config.port,
+			)
+			.await?;
+			Ok(Prepared {
+				path: source,
+				extra_tags: metadata_tags(&resolved, strategy),
+				ignore: ignore_globs(),
+				teardown: Teardown::BaseBackup(root),
+			})
+		}
 		other => bail!(
-			"postgresql backup strategy {other:?} is not implemented yet (btrfs only for now)"
+			"postgresql backup strategy {other:?} is not implemented yet \
+			 (btrfs and pg_basebackup are; thin-LVM and VSS are coming)"
 		),
 	}
 }

--- a/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
@@ -1,0 +1,176 @@
+//! `pg_basebackup` base backup.
+//!
+//! For backends with no cheap atomic snapshot (ext4/xfs, thick LVM):
+//! `pg_basebackup --wal-method=stream` streams a complete base backup with the
+//! WAL **and the backup-end record** bundled in, so it restores by clean crash
+//! recovery — no `pg_resetwal`, no forced REINDEX. Always correct, just heavier
+//! than a CoW snapshot (a full copy each run).
+//!
+//! The streaming + chown steps are privileged and verified on-host; the pure
+//! helpers (paths, argv) are unit-tested.
+
+use std::{
+	path::{Path, PathBuf},
+	process::Stdio,
+};
+
+use miette::{Context as _, IntoDiagnostic as _, Result, bail};
+use tracing::{info, warn};
+
+use super::resolve::ResolvedCluster;
+
+/// Where this run's base backup is streamed to (and what kopia snapshots). Nests
+/// `<version>/<cluster>` under the stable source dir so the kopia source path
+/// matches the btrfs strategy's — a host can migrate between them and keep one
+/// continuous history.
+fn destination(backup_type: &str, resolved: &ResolvedCluster) -> PathBuf {
+	super::stable_source_dir(backup_type)
+		.join(&resolved.version)
+		.join(&resolved.cluster)
+}
+
+/// `pg_basebackup` args for a plain (uncompressed) base backup with streamed WAL.
+fn basebackup_args(dest: &Path, socket: Option<&Path>, port: Option<u16>) -> Vec<String> {
+	let mut args = vec![
+		"-D".to_owned(),
+		dest.to_string_lossy().into_owned(),
+		"--wal-method=stream".to_owned(),
+		"--checkpoint=fast".to_owned(),
+		"--no-password".to_owned(),
+	];
+	if let Some(socket) = socket {
+		args.push("-h".to_owned());
+		args.push(socket.to_string_lossy().into_owned());
+	}
+	if let Some(port) = port {
+		args.push("-p".to_owned());
+		args.push(port.to_string());
+	}
+	args
+}
+
+/// Stream a base backup and return (kopia source path, the dir to clean up).
+pub async fn prepare(
+	resolved: &ResolvedCluster,
+	backup_type: &str,
+	socket: Option<&Path>,
+	port: Option<u16>,
+) -> Result<(PathBuf, PathBuf)> {
+	let root = super::stable_source_dir(backup_type);
+	let dest = destination(backup_type, resolved);
+
+	// pg_basebackup requires an empty target; clear leftovers from a crashed run.
+	if root.exists() {
+		tokio::fs::remove_dir_all(&root)
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("clearing stale base backup at {}", root.display()))?;
+	}
+	if let Some(parent) = dest.parent() {
+		tokio::fs::create_dir_all(parent)
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("creating {}", parent.display()))?;
+	}
+
+	let bin = crate::find_postgres::find_postgres_bin("pg_basebackup")
+		.map(|p| p.to_string_lossy().into_owned())
+		.unwrap_or_else(|_| "pg_basebackup".to_owned());
+
+	info!(dest = %dest.display(), "streaming pg_basebackup");
+	// Run as the postgres OS user (peer auth + replication privilege).
+	let mut cmd = tokio::process::Command::new("sudo");
+	cmd.args(["-u", "postgres", &bin]);
+	cmd.args(basebackup_args(&dest, socket, port));
+	cmd.stdin(Stdio::null());
+	let status = cmd
+		.status()
+		.await
+		.into_diagnostic()
+		.wrap_err("spawning pg_basebackup")?;
+	if !status.success() {
+		bail!("pg_basebackup failed ({status})");
+	}
+
+	make_readable_by_kopia(&root).await;
+	Ok((dest, root))
+}
+
+/// Remove the streamed base backup (a full copy; reclaim the space).
+pub async fn teardown(root: PathBuf) -> Result<()> {
+	tokio::fs::remove_dir_all(&root)
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("removing base backup at {}", root.display()))
+}
+
+/// pg_basebackup writes files owned by postgres and mode 0600; hand them to the
+/// kopia user so the (elevated-to-kopia) kopia run can read them. Best-effort —
+/// when there's no kopia user the run is direct (current user already reads it).
+async fn make_readable_by_kopia(root: &Path) {
+	let kopia_exists = tokio::process::Command::new("id")
+		.args(["-u", "kopia"])
+		.stdin(Stdio::null())
+		.stdout(Stdio::null())
+		.stderr(Stdio::null())
+		.status()
+		.await
+		.map(|s| s.success())
+		.unwrap_or(false);
+	if !kopia_exists {
+		return;
+	}
+	let status = tokio::process::Command::new("chown")
+		.args(["-R", "kopia:kopia"])
+		.arg(root)
+		.stdin(Stdio::null())
+		.status()
+		.await;
+	if !matches!(status, Ok(s) if s.success()) {
+		warn!("could not chown base backup to the kopia user; kopia may fail to read it");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn destination_nests_version_and_cluster_under_stable_dir() {
+		let resolved = ResolvedCluster {
+			data_dir: "/var/lib/postgresql/16/main".into(),
+			version: "16".into(),
+			cluster: "main".into(),
+		};
+		assert_eq!(
+			destination("tamanu-postgres", &resolved),
+			PathBuf::from("/var/lib/kopia/bestool-backup/tamanu-postgres/16/main")
+		);
+	}
+
+	#[test]
+	fn basebackup_args_stream_wal_and_fast_checkpoint() {
+		let args = basebackup_args(Path::new("/staging/16/main"), None, None);
+		assert_eq!(
+			args,
+			vec![
+				"-D",
+				"/staging/16/main",
+				"--wal-method=stream",
+				"--checkpoint=fast",
+				"--no-password",
+			]
+		);
+	}
+
+	#[test]
+	fn basebackup_args_include_socket_and_port() {
+		let args = basebackup_args(
+			Path::new("/staging/16/main"),
+			Some(Path::new("/var/run/postgresql")),
+			Some(5433),
+		);
+		assert!(args.windows(2).any(|w| w == ["-h", "/var/run/postgresql"]));
+		assert!(args.windows(2).any(|w| w == ["-p", "5433"]));
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -39,11 +39,10 @@ pub struct Mounts {
 	kopia_mount: PathBuf,
 }
 
-/// The stable mount path for a backup type — fixed across runs so kopia sees one
-/// source. The version/cluster suffix in the source path (added by the caller)
-/// is the only part that moves, and only across a major-version upgrade.
+/// The stable mount path for a backup type (see
+/// [`super::stable_source_dir`]).
 fn stable_kopia_mount(backup_type: &str) -> PathBuf {
-	PathBuf::from("/var/lib/kopia/bestool-backup").join(backup_type)
+	super::stable_source_dir(backup_type)
 }
 
 /// Name for this run's ephemeral snapshot subvolume.


### PR DESCRIPTION
🤖 Stacked on #516. Adds the `pg_basebackup` strategy (Strategy B), so the `postgresql` method now works on any Linux filesystem — btrfs takes the cheap CoW snapshot, everything else (ext4/xfs, thick LVM) takes a base backup.

`pg_basebackup --wal-method=stream --checkpoint=fast` streams a complete base backup with the WAL **and the backup-end record** bundled in, so it restores by clean crash recovery — no `pg_resetwal`, no forced REINDEX. Always correct, just heavier than a snapshot (a full copy each run, which kopia then dedupes).

Details:
- Streams into the **same stable per-`(type)` source path** the btrfs strategy uses (nested `<version>/<cluster>`), so a host migrating between strategies keeps one continuous kopia history.
- Hands the streamed files to the kopia user (chown) so the elevated kopia run can read them, and removes the full copy on cleanup.
- Strategy detection now routes non-btrfs filesystems here; thin-LVM and Windows VSS are still to come (both fall back to this correct-but-heavier path until then).

This is the proper `pg_basebackup` path — **not** the old `pg_backup_start` + overlay scheme that wrote a partial `backup_label` and produced the dirty restores this whole effort exists to fix.

Pure helpers (paths, argv) are unit-tested; the streaming + chown are verified on-host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
