### PR TITLE
feat(alertd): reload backup capabilities on change/signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "node-semver",
+ "notify",
  "owo-colors 4.3.0",
  "p256",
  "percent-encoding",
@@ -2601,6 +2602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,6 +3493,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,7 +3600,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3794,6 +3824,26 @@ checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
 dependencies = [
  "crossbeam",
  "rayon",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -4387,6 +4437,33 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "ntapi"

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -55,6 +55,7 @@ merkle_hash = { version = "3.8.0", optional = true }
 miette = { workspace = true, features = ["fancy"] }
 mimalloc = "0.1.50"
 node-semver = { version = "2.2.0", optional = true }
+notify = { version = "8.2.0", optional = true }
 owo-colors = { version = "4.2.3", optional = true }
 p256 = { version = "0.13.2", features = ["pkcs8", "pem"], optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
@@ -186,7 +187,7 @@ canopy-tags = ["__canopy", "tamanu-config", "bestool-tamanu/canopy-registration"
 # Config-driven backups: registers capabilities with canopy, runs pre/method/post
 # per a backups/*.toml def, drives kopia, reports the outcome. The `postgresql`
 # method needs bestool-postgres (CHECKPOINT/verify) but not Tamanu config.
-canopy-backup = ["__canopy", "bestool-tamanu/canopy-registration", "dep:bestool-kopia", "dep:bestool-postgres", "dep:axum", "dep:toml"]
+canopy-backup = ["__canopy", "bestool-tamanu/canopy-registration", "dep:bestool-kopia", "dep:bestool-postgres", "dep:axum", "dep:toml", "dep:notify"]
 canopy-restore = ["canopy-backup"]
 __canopy = ["dep:bestool-canopy"] # internal feature to enable the canopy subcommand common code
 
@@ -206,6 +207,7 @@ __iti = ["dep:zmq"] # internal feature to enable the iti subcommand common code
 ## Legacy noop features to avoid breaking builds
 tamanu-upgrade = []
 walg = []
+notify = ["dep:notify"]
 
 [dev-dependencies]
 age = { version = "0.11.3", features = ["async"] }

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -214,17 +214,80 @@ fn backup_dispatch() -> bestool_alertd::doctor::BackupDispatch {
 
 /// A background task that registers this server's backup capabilities with
 /// canopy (the types of every def in the backups directory).
+///
+/// It's a resident task: after the initial registration it stays running and
+/// re-registers when the backups directory changes, when a reload signal
+/// (SIGHUP/SIGUSR1) arrives, or on a periodic safety-net tick — so dropping a
+/// new def in `/etc/bestool/backups` is picked up without restarting the daemon.
 #[cfg(feature = "canopy-backup")]
 mod backup {
 	use std::time::Duration;
 
 	use futures::future::BoxFuture;
 	use miette::{IntoDiagnostic as _, Result};
-	use tracing::info;
+	use tokio::sync::mpsc;
+	use tracing::{info, warn};
 
 	use crate::actions::canopy::backup::config;
 
+	/// Re-register at least this often even without an external trigger, so a
+	/// missed event still converges.
+	const REREGISTER_INTERVAL: Duration = Duration::from_secs(3600);
+
 	pub(super) struct BackupCapabilitiesTask;
+
+	/// Load the configured backup types and register them with canopy.
+	async fn register(ctx: &bestool_alertd::TaskContext) -> Result<()> {
+		let Some(client) = ctx.canopy_client.as_ref() else {
+			return Ok(());
+		};
+		let defs = config::load_dir(&config::backups_dir()).await?;
+		let types: Vec<String> = defs.into_iter().map(|d| d.r#type).collect();
+		if types.is_empty() {
+			return Ok(());
+		}
+		let base_url = bestool_canopy::DEFAULT_CANOPY_URL.parse().into_diagnostic()?;
+		client.backup_capabilities(&base_url, &types).await?;
+		info!(?types, "registered backup capabilities with canopy");
+		Ok(())
+	}
+
+	/// Re-register, logging the trigger; failures are warned, never fatal.
+	async fn reregister(reason: &str, ctx: &bestool_alertd::TaskContext) {
+		info!(reason, "registering backup capabilities");
+		if let Err(err) = register(ctx).await {
+			warn!("registering backup capabilities failed (will retry): {err}");
+		}
+	}
+
+	/// Watch the backups directory, sending `()` on any change. Returns the
+	/// watcher (kept alive by the caller) or `None` if it couldn't be set up
+	/// (e.g. the directory doesn't exist yet) — the periodic tick still covers it.
+	fn watch_backups_dir(tx: mpsc::UnboundedSender<()>) -> Option<notify::RecommendedWatcher> {
+		use notify::{RecursiveMode, Watcher as _};
+
+		let dir = config::backups_dir();
+		let mut watcher =
+			notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+				if res.is_ok() {
+					let _ = tx.send(());
+				}
+			})
+			.inspect_err(|err| warn!("could not create backups-dir watcher: {err}"))
+			.ok()?;
+		match watcher.watch(&dir, RecursiveMode::NonRecursive) {
+			Ok(()) => Some(watcher),
+			Err(err) => {
+				warn!(dir = %dir.display(), "could not watch backups dir (using timer/signals): {err}");
+				None
+			}
+		}
+	}
+
+	/// Coalesce a burst of fs events into one re-registration.
+	fn drain(rx: &mut mpsc::UnboundedReceiver<()>) {
+		while rx.try_recv().is_ok() {}
+	}
 
 	impl bestool_alertd::BackgroundTask for BackupCapabilitiesTask {
 		fn name(&self) -> &'static str {
@@ -232,25 +295,44 @@ mod backup {
 		}
 
 		fn interval(&self) -> Duration {
-			// Re-register hourly so newly-dropped defs get picked up; the first
-			// tick fires at startup.
-			Duration::from_secs(3600)
+			// run() is resident, so this only gates the (single) first tick.
+			REREGISTER_INTERVAL
 		}
 
 		fn run<'a>(&'a self, ctx: &'a bestool_alertd::TaskContext) -> BoxFuture<'a, Result<()>> {
 			Box::pin(async move {
-				let Some(client) = ctx.canopy_client.as_ref() else {
-					return Ok(());
-				};
-				let defs = config::load_dir(&config::backups_dir()).await?;
-				let types: Vec<String> = defs.into_iter().map(|d| d.r#type).collect();
-				if types.is_empty() {
-					return Ok(());
+				reregister("startup", ctx).await;
+
+				let (tx, mut rx) = mpsc::unbounded_channel();
+				// Held for the task's lifetime so events keep arriving.
+				let _watcher = watch_backups_dir(tx);
+
+				let mut periodic = tokio::time::interval(REREGISTER_INTERVAL);
+				periodic.tick().await; // consume the immediate first tick
+
+				#[cfg(unix)]
+				{
+					use tokio::signal::unix::{SignalKind, signal};
+					let mut sighup = signal(SignalKind::hangup()).into_diagnostic()?;
+					let mut sigusr1 = signal(SignalKind::user_defined1()).into_diagnostic()?;
+					loop {
+						tokio::select! {
+							_ = periodic.tick() => reregister("periodic", ctx).await,
+							_ = rx.recv() => { drain(&mut rx); reregister("backups dir changed", ctx).await }
+							_ = sighup.recv() => reregister("SIGHUP", ctx).await,
+							_ = sigusr1.recv() => reregister("SIGUSR1", ctx).await,
+						}
+					}
 				}
-				let base_url = bestool_canopy::DEFAULT_CANOPY_URL.parse().into_diagnostic()?;
-				client.backup_capabilities(&base_url, &types).await?;
-				info!(?types, "registered backup capabilities with canopy");
-				Ok(())
+				#[cfg(not(unix))]
+				{
+					loop {
+						tokio::select! {
+							_ = periodic.tick() => reregister("periodic", ctx).await,
+							_ = rx.recv() => { drain(&mut rx); reregister("backups dir changed", ctx).await }
+						}
+					}
+				}
 			})
 		}
 	}

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -8,6 +8,10 @@ Type=simple
 # bestool invocations (which all otherwise log as "bestool").
 SyslogIdentifier=bestool-alertd
 ExecStart=/usr/bin/bestool alertd run
+# `systemctl reload bestool-alertd` re-registers backup capabilities with canopy,
+# picking up changes under /etc/bestool/backups without a restart (handled by the
+# daemon's SIGHUP/SIGUSR1 reload).
+ExecReload=/bin/kill -HUP $MAINPID
 MemoryMax=500M
 Restart=always
 RestartSec=10


### PR DESCRIPTION
🤖 Stacked on #517.

**Made the capability task reactive.** It's now resident: after the initial registration it watches `/etc/bestool/backups` (via `notify`) and re-registers when a def is added/changed/removed, and on **SIGHUP/SIGUSR1** — so an operator (or ansible) can drop in a new backup def and have canopy pick it up without restarting the daemon. A periodic tick remains as a safety net, and fs-event bursts are coalesced into a single re-registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
