### PR TITLE
feat(canopy): thin-LVM snapshot backend

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -36,6 +36,8 @@ pub(super) enum Teardown {
 	Nothing,
 	/// A btrfs snapshot + its mounts.
 	Btrfs(super::postgresql::btrfs::Mounts),
+	/// A thin-LVM snapshot + its mount.
+	Lvm(super::postgresql::lvm::Snapshot),
 	/// A streamed base backup directory to remove.
 	BaseBackup(PathBuf),
 }
@@ -106,6 +108,7 @@ impl Method {
 		match prepared.teardown {
 			Teardown::Nothing => Ok(()),
 			Teardown::Btrfs(mounts) => super::postgresql::btrfs::teardown(mounts).await,
+			Teardown::Lvm(snapshot) => super::postgresql::lvm::teardown(snapshot).await,
 			Teardown::BaseBackup(root) => super::postgresql::basebackup::teardown(root).await,
 		}
 	}

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -3,13 +3,15 @@
 //! Generic postgres (no Tamanu coupling): driven by the `[postgresql]` config
 //! table. Resolves the cluster's data directory, issues a best-effort
 //! `CHECKPOINT` to bound WAL replay on restore, detects the storage backend, and
-//! captures it. btrfs is implemented; thin-LVM / Windows VSS / `pg_basebackup`
-//! land in follow-ups.
+//! captures it: a crash-consistent btrfs or thin-LVM snapshot where available,
+//! else a `pg_basebackup` base backup. (Windows VSS is the remaining backend.)
 
 pub mod basebackup;
 pub mod btrfs;
+pub mod lvm;
 pub mod resolve;
 pub mod strategy;
+mod sys;
 
 use std::{
 	collections::BTreeMap,
@@ -76,6 +78,15 @@ pub async fn prepare(config: &PostgresqlConfig, backup_type: &str) -> Result<Pre
 				teardown: Teardown::Btrfs(mounts),
 			})
 		}
+		Strategy::ThinLvm => {
+			let (source, snapshot) = lvm::prepare(&resolved, backup_type).await?;
+			Ok(Prepared {
+				path: source,
+				extra_tags: metadata_tags(&resolved, strategy),
+				ignore: ignore_globs(),
+				teardown: Teardown::Lvm(snapshot),
+			})
+		}
 		Strategy::BaseBackup => {
 			let (source, root) = basebackup::prepare(
 				&resolved,
@@ -91,9 +102,8 @@ pub async fn prepare(config: &PostgresqlConfig, backup_type: &str) -> Result<Pre
 				teardown: Teardown::BaseBackup(root),
 			})
 		}
-		other => bail!(
-			"postgresql backup strategy {other:?} is not implemented yet \
-			 (btrfs and pg_basebackup are; thin-LVM and VSS are coming)"
+		Strategy::Vss => bail!(
+			"the Windows VSS backup backend is not implemented yet"
 		),
 	}
 }

--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -7,19 +7,16 @@
 //! directory within. No `pg_backup_start`/`backup_label` — the snapshot restores
 //! by plain crash recovery.
 //!
-//! The privileged steps (mount, `btrfs subvolume snapshot`, id lookups) can't run
-//! in unit tests; the pure helpers (names, idmap, paths) are tested and the whole
-//! flow is verified on a real btrfs host per the plan.
+//! The privileged steps (mount, `btrfs subvolume snapshot`) can't run in unit
+//! tests; the pure helpers (names, paths) are tested and the whole flow is
+//! verified on a real btrfs host per the plan.
 
-use std::{
-	path::{Path, PathBuf},
-	process::Stdio,
-};
+use std::path::{Path, PathBuf};
 
-use miette::{Context as _, IntoDiagnostic as _, Result, bail};
+use miette::{Result, miette};
 use tracing::{info, warn};
 
-use super::resolve::ResolvedCluster;
+use super::{resolve::ResolvedCluster, sys};
 
 /// Where the reaper looks for / makes per-run top-level mounts.
 const TOPLEVEL_MOUNT_PREFIX: &str = "/mnt/bestool-btrfs-toplevel";
@@ -39,8 +36,7 @@ pub struct Mounts {
 	kopia_mount: PathBuf,
 }
 
-/// The stable mount path for a backup type (see
-/// [`super::stable_source_dir`]).
+/// The stable mount path for a backup type (see [`super::stable_source_dir`]).
 fn stable_kopia_mount(backup_type: &str) -> PathBuf {
 	super::stable_source_dir(backup_type)
 }
@@ -55,43 +51,17 @@ fn toplevel_mount(pid: u32) -> PathBuf {
 	PathBuf::from(format!("{TOPLEVEL_MOUNT_PREFIX}.{pid}"))
 }
 
-/// The btrfs `X-mount.idmap` mapping postgres's uid/gid to kopia's, so the kopia
-/// user can read the postgres-owned files in the read-only snapshot.
-fn idmap(postgres_uid: u32, kopia_uid: u32, postgres_gid: u32, kopia_gid: u32) -> String {
-	format!("u:{postgres_uid}:{kopia_uid}:1 g:{postgres_gid}:{kopia_gid}:1")
-}
-
-/// The cluster directory's path relative to the filesystem mountpoint.
-fn relative_data_path(data_dir: &Path, base_mount: &Path) -> Result<PathBuf> {
-	data_dir
-		.strip_prefix(base_mount)
-		.map(Path::to_path_buf)
-		.map_err(|_| {
-			miette::miette!(
-				"data dir {} is not under its mountpoint {}",
-				data_dir.display(),
-				base_mount.display()
-			)
-		})
-}
-
 /// Take the snapshot and mount it; returns the kopia source path and the
 /// teardown state. Caller must always pass the result to [`teardown`].
 pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(PathBuf, Mounts)> {
 	let pid = std::process::id();
-	let base_mount = findmnt_target(&resolved.data_dir).await?;
-	let rel = relative_data_path(&resolved.data_dir, &base_mount)?;
+	let base_mount = sys::findmnt_target(&resolved.data_dir).await?;
+	let rel = sys::relative_data_path(&resolved.data_dir, &base_mount)?;
 	let fsdev = format!(
 		"/dev/disk/by-uuid/{}",
-		findmnt_field("UUID", &resolved.data_dir).await?
+		sys::findmnt_field("UUID", &resolved.data_dir).await?
 	);
-
-	let map = idmap(
-		uid_of("postgres").await?,
-		uid_of("kopia").await?,
-		gid_of("postgres").await?,
-		gid_of("kopia").await?,
-	);
+	let map = sys::postgres_to_kopia_idmap().await?;
 
 	let kopia_mount = stable_kopia_mount(backup_type);
 	reap_stale(&fsdev, &kopia_mount).await;
@@ -107,29 +77,33 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 		kopia_mount: PathBuf::new(),
 	};
 
-	mkdir(&toplevel_mount).await?;
-	run_ok("mount", &["-o", "subvolid=5", &fsdev, path(&toplevel_mount)]).await?;
+	sys::mkdir(&toplevel_mount).await?;
+	sys::run_ok(
+		"mount",
+		&["-o", "subvolid=5", &fsdev, sys::path(&toplevel_mount)],
+	)
+	.await?;
 
 	info!(snapshot = %snapshot_path.display(), "creating read-only btrfs snapshot");
-	run_ok(
+	sys::run_ok(
 		"btrfs",
 		&[
 			"subvolume",
 			"snapshot",
 			"-r",
-			path(&base_mount),
-			path(&snapshot_path),
+			sys::path(&base_mount),
+			sys::path(&snapshot_path),
 		],
 	)
 	.await?;
 	mounts.snapshot_path = snapshot_path.clone();
 
-	mkdir(&kopia_mount).await?;
-	run_ok(
+	sys::mkdir(&kopia_mount).await?;
+	sys::run_ok(
 		"mount",
 		&[
 			&fsdev,
-			path(&kopia_mount),
+			sys::path(&kopia_mount),
 			"-o",
 			&format!("subvol={snapshot_name},X-mount.idmap={map}"),
 		],
@@ -137,28 +111,28 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 	.await?;
 	mounts.kopia_mount = kopia_mount.clone();
 
-	let source = kopia_mount.join(rel);
-	Ok((source, mounts))
+	Ok((kopia_mount.join(rel), mounts))
 }
 
 /// Release a prepared snapshot: unmount the kopia mount, delete the snapshot
 /// subvolume, unmount and remove the top-level mount. Best-effort throughout.
 pub async fn teardown(mounts: Mounts) -> Result<()> {
 	if !mounts.kopia_mount.as_os_str().is_empty() {
-		umount(&mounts.kopia_mount).await;
-		rmdir(&mounts.kopia_mount).await;
+		sys::umount(&mounts.kopia_mount).await;
+		sys::rmdir(&mounts.kopia_mount).await;
 	}
 	if !mounts.snapshot_path.as_os_str().is_empty() {
-		let _ = run_ok(
+		let _ = sys::run_ok(
 			"btrfs",
-			&["subvolume", "delete", path(&mounts.snapshot_path)],
+			&["subvolume", "delete", sys::path(&mounts.snapshot_path)],
 		)
 		.await
-		.inspect_err(|err| warn!("deleting snapshot subvolume failed: {err}"));
+		.map_err(|err| miette!("deleting snapshot subvolume: {err}"))
+		.inspect_err(|err| warn!("{err}"));
 	}
 	if !mounts.toplevel_mount.as_os_str().is_empty() {
-		umount(&mounts.toplevel_mount).await;
-		rmdir(&mounts.toplevel_mount).await;
+		sys::umount(&mounts.toplevel_mount).await;
+		sys::rmdir(&mounts.toplevel_mount).await;
 	}
 	Ok(())
 }
@@ -167,138 +141,29 @@ pub async fn teardown(mounts: Mounts) -> Result<()> {
 /// the stable kopia mount, stray top-level mounts, and orphaned `bestool-kopia-*`
 /// snapshot subvolumes. All best-effort.
 async fn reap_stale(fsdev: &str, kopia_mount: &Path) {
-	umount(kopia_mount).await;
+	sys::umount(kopia_mount).await;
 
-	if let Ok(entries) = glob_prefix("/mnt", "bestool-btrfs-toplevel.") {
+	if let Ok(entries) = sys::glob_prefix("/mnt", "bestool-btrfs-toplevel.") {
 		for stale in entries {
-			umount(&stale).await;
-			rmdir(&stale).await;
+			sys::umount(&stale).await;
+			sys::rmdir(&stale).await;
 		}
 	}
 
 	let reap_mount = PathBuf::from(format!("{TOPLEVEL_MOUNT_PREFIX}-reap.{}", std::process::id()));
-	if mkdir(&reap_mount).await.is_ok()
-		&& run_ok("mount", &["-o", "subvolid=5", fsdev, path(&reap_mount)])
+	if sys::mkdir(&reap_mount).await.is_ok()
+		&& sys::run_ok("mount", &["-o", "subvolid=5", fsdev, sys::path(&reap_mount)])
 			.await
 			.is_ok()
 	{
-		if let Ok(subs) = glob_prefix(path(&reap_mount), SNAPSHOT_INFIX) {
+		if let Ok(subs) = sys::glob_prefix(sys::path(&reap_mount), SNAPSHOT_INFIX) {
 			for sub in subs {
-				let _ = run_ok("btrfs", &["subvolume", "delete", path(&sub)]).await;
+				let _ = sys::run_ok("btrfs", &["subvolume", "delete", sys::path(&sub)]).await;
 			}
 		}
-		umount(&reap_mount).await;
+		sys::umount(&reap_mount).await;
 	}
-	rmdir(&reap_mount).await;
-}
-
-// --- thin command wrappers -------------------------------------------------
-
-fn path(p: &Path) -> &str {
-	p.to_str().unwrap_or_default()
-}
-
-async fn run_ok(program: &str, args: &[&str]) -> Result<()> {
-	let output = tokio::process::Command::new(program)
-		.args(args)
-		.stdin(Stdio::null())
-		.output()
-		.await
-		.into_diagnostic()
-		.wrap_err_with(|| format!("spawning {program}"))?;
-	if !output.status.success() {
-		bail!(
-			"{program} {} failed: {}",
-			args.join(" "),
-			String::from_utf8_lossy(&output.stderr).trim()
-		);
-	}
-	Ok(())
-}
-
-async fn capture(program: &str, args: &[&str]) -> Result<String> {
-	let output = tokio::process::Command::new(program)
-		.args(args)
-		.stdin(Stdio::null())
-		.output()
-		.await
-		.into_diagnostic()
-		.wrap_err_with(|| format!("spawning {program}"))?;
-	if !output.status.success() {
-		bail!(
-			"{program} {} failed: {}",
-			args.join(" "),
-			String::from_utf8_lossy(&output.stderr).trim()
-		);
-	}
-	Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
-}
-
-async fn findmnt_target(data_dir: &Path) -> Result<PathBuf> {
-	Ok(PathBuf::from(findmnt_field("TARGET", data_dir).await?))
-}
-
-async fn findmnt_field(field: &str, data_dir: &Path) -> Result<String> {
-	capture("findmnt", &["-no", field, "--target", path(data_dir)]).await
-}
-
-async fn uid_of(user: &str) -> Result<u32> {
-	parse_id(&capture("id", &["-u", user]).await?, user)
-}
-
-async fn gid_of(user: &str) -> Result<u32> {
-	parse_id(&capture("id", &["-g", user]).await?, user)
-}
-
-fn parse_id(out: &str, user: &str) -> Result<u32> {
-	out.trim()
-		.parse()
-		.into_diagnostic()
-		.wrap_err_with(|| format!("parsing id for {user}: {out:?}"))
-}
-
-async fn mkdir(dir: &Path) -> Result<()> {
-	tokio::fs::create_dir_all(dir)
-		.await
-		.into_diagnostic()
-		.wrap_err_with(|| format!("creating {}", dir.display()))
-}
-
-async fn umount(dir: &Path) {
-	if is_mountpoint(dir).await {
-		let _ = run_ok("umount", &[path(dir)]).await;
-	}
-}
-
-async fn rmdir(dir: &Path) {
-	let _ = tokio::fs::remove_dir(dir).await;
-}
-
-async fn is_mountpoint(dir: &Path) -> bool {
-	tokio::process::Command::new("mountpoint")
-		.arg("-q")
-		.arg(dir)
-		.stdin(Stdio::null())
-		.status()
-		.await
-		.map(|s| s.success())
-		.unwrap_or(false)
-}
-
-/// Directory entries whose file name starts with `prefix`.
-fn glob_prefix(dir: impl AsRef<Path>, prefix: &str) -> Result<Vec<PathBuf>> {
-	let mut out = Vec::new();
-	for entry in std::fs::read_dir(dir.as_ref()).into_diagnostic()? {
-		let entry = entry.into_diagnostic()?;
-		if entry
-			.file_name()
-			.to_string_lossy()
-			.starts_with(prefix)
-		{
-			out.push(entry.path());
-		}
-	}
-	Ok(out)
+	sys::rmdir(&reap_mount).await;
 }
 
 #[cfg(test)]
@@ -310,26 +175,6 @@ mod tests {
 		let name = snapshot_name(4242);
 		assert_eq!(name, "bestool-kopia-4242");
 		assert!(name.starts_with(SNAPSHOT_INFIX));
-	}
-
-	#[test]
-	fn idmap_format() {
-		assert_eq!(idmap(114, 997, 120, 995), "u:114:997:1 g:120:995:1");
-	}
-
-	#[test]
-	fn relative_data_path_strips_mountpoint() {
-		let rel = relative_data_path(
-			Path::new("/var/lib/postgresql/16/main"),
-			Path::new("/var/lib/postgresql"),
-		)
-		.unwrap();
-		assert_eq!(rel, PathBuf::from("16/main"));
-	}
-
-	#[test]
-	fn relative_data_path_rejects_outside() {
-		assert!(relative_data_path(Path::new("/srv/pg"), Path::new("/var/lib/postgresql")).is_err());
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/canopy/backup/postgresql/lvm.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/lvm.rs
@@ -1,0 +1,170 @@
+//! Crash-consistent thin-LVM snapshot of a postgres cluster.
+//!
+//! The thin-pool analogue of the btrfs path: take a thin snapshot of the LV the
+//! data directory lives on (CoW within the pool, no read-copy), mount it
+//! read-only at a stable path, and hand kopia the cluster directory within. No
+//! `pg_backup_start`/`backup_label` — it restores by plain crash recovery.
+//!
+//! Only reached for **thin** LVs (a thick LV's snapshot is costly, so those go
+//! to `pg_basebackup`). The privileged `lvcreate`/`mount` steps are verified
+//! on-host; the pure helpers (parsing, mount options) are unit-tested.
+
+use std::path::PathBuf;
+
+use miette::{Result, bail, miette};
+use tracing::{info, warn};
+
+use super::{resolve::ResolvedCluster, sys};
+
+/// Infix marking our ephemeral snapshot LVs, so the reaper never matches a live LV.
+const SNAPSHOT_INFIX: &str = "bestool-kopia-";
+
+/// Teardown state for a prepared thin-LVM snapshot, released by [`teardown`].
+#[derive(Debug)]
+pub struct Snapshot {
+	/// The volume group the snapshot LV lives in.
+	vg: String,
+	/// The ephemeral snapshot LV's name.
+	lv: String,
+	/// The stable read-only mount kopia reads from.
+	kopia_mount: PathBuf,
+}
+
+fn snapshot_name(pid: u32) -> String {
+	format!("{SNAPSHOT_INFIX}{pid}")
+}
+
+/// Parse `lvs --noheadings -o vg_name,lv_name <dev>` output into `(vg, lv)`.
+fn parse_vg_lv(output: &str) -> Result<(String, String)> {
+	let mut fields = output.split_whitespace();
+	match (fields.next(), fields.next()) {
+		(Some(vg), Some(lv)) => Ok((vg.to_owned(), lv.to_owned())),
+		_ => bail!("could not parse vg/lv from lvs output: {output:?}"),
+	}
+}
+
+/// Mount options for a read-only snapshot mount, idmapped for the kopia user.
+/// XFS refuses a second mount with a duplicate fs UUID without `nouuid`.
+fn mount_options(fstype: &str, idmap: &str) -> String {
+	let mut opts = vec!["ro".to_owned()];
+	if fstype == "xfs" {
+		opts.push("nouuid".to_owned());
+	}
+	opts.push(format!("X-mount.idmap={idmap}"));
+	opts.join(",")
+}
+
+/// Take a thin snapshot and mount it; returns the kopia source path and the
+/// teardown state. Caller must always pass the result to [`teardown`].
+pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(PathBuf, Snapshot)> {
+	let pid = std::process::id();
+	let base_mount = sys::findmnt_target(&resolved.data_dir).await?;
+	let rel = sys::relative_data_path(&resolved.data_dir, &base_mount)?;
+	let source = sys::findmnt_field("SOURCE", &resolved.data_dir).await?;
+	let fstype = sys::findmnt_field("FSTYPE", &resolved.data_dir).await?;
+	let (vg, lv) = parse_vg_lv(
+		&sys::capture("lvs", &["--noheadings", "-o", "vg_name,lv_name", &source]).await?,
+	)?;
+	let map = sys::postgres_to_kopia_idmap().await?;
+
+	let kopia_mount = super::stable_source_dir(backup_type);
+	reap_stale(&vg, &kopia_mount).await;
+
+	let snapshot_lv = snapshot_name(pid);
+	let mut snapshot = Snapshot {
+		vg: vg.clone(),
+		lv: String::new(),
+		kopia_mount: PathBuf::new(),
+	};
+
+	info!(vg = %vg, lv = %snapshot_lv, "creating thin-LVM snapshot");
+	sys::run_ok(
+		"lvcreate",
+		&["--snapshot", "--name", &snapshot_lv, &format!("{vg}/{lv}")],
+	)
+	.await?;
+	snapshot.lv = snapshot_lv.clone();
+
+	// Thin snapshots carry the activation-skip flag; -K overrides it.
+	sys::run_ok(
+		"lvchange",
+		&["-ay", "-K", &format!("{vg}/{snapshot_lv}")],
+	)
+	.await?;
+
+	sys::mkdir(&kopia_mount).await?;
+	sys::run_ok(
+		"mount",
+		&[
+			&format!("/dev/{vg}/{snapshot_lv}"),
+			sys::path(&kopia_mount),
+			"-o",
+			&mount_options(&fstype, &map),
+		],
+	)
+	.await?;
+	snapshot.kopia_mount = kopia_mount.clone();
+
+	Ok((kopia_mount.join(rel), snapshot))
+}
+
+/// Release a prepared snapshot: unmount, deactivate, and remove the snapshot LV.
+pub async fn teardown(snapshot: Snapshot) -> Result<()> {
+	if !snapshot.kopia_mount.as_os_str().is_empty() {
+		sys::umount(&snapshot.kopia_mount).await;
+		sys::rmdir(&snapshot.kopia_mount).await;
+	}
+	if !snapshot.lv.is_empty() {
+		let target = format!("{}/{}", snapshot.vg, snapshot.lv);
+		let _ = sys::run_ok("lvchange", &["-an", &target]).await;
+		let _ = sys::run_ok("lvremove", &["-f", &target])
+			.await
+			.map_err(|err| miette!("removing snapshot LV {target}: {err}"))
+			.inspect_err(|err| warn!("{err}"));
+	}
+	Ok(())
+}
+
+/// Sweep leftover `bestool-kopia-*` snapshot LVs from a crashed run.
+async fn reap_stale(vg: &str, kopia_mount: &std::path::Path) {
+	sys::umount(kopia_mount).await;
+	let Ok(list) = sys::capture("lvs", &["--noheadings", "-o", "lv_name", vg]).await else {
+		return;
+	};
+	for name in list.lines().map(str::trim).filter(|n| n.starts_with(SNAPSHOT_INFIX)) {
+		let target = format!("{vg}/{name}");
+		let _ = sys::run_ok("lvchange", &["-an", &target]).await;
+		let _ = sys::run_ok("lvremove", &["-f", &target]).await;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_vg_lv_from_padded_output() {
+		assert_eq!(
+			parse_vg_lv("  ubuntu-vg ubuntu-lv ").unwrap(),
+			("ubuntu-vg".to_owned(), "ubuntu-lv".to_owned())
+		);
+		assert!(parse_vg_lv("").is_err());
+	}
+
+	#[test]
+	fn mount_options_add_nouuid_only_for_xfs() {
+		assert_eq!(
+			mount_options("ext4", "u:1:2:1 g:3:4:1"),
+			"ro,X-mount.idmap=u:1:2:1 g:3:4:1"
+		);
+		assert_eq!(
+			mount_options("xfs", "u:1:2:1 g:3:4:1"),
+			"ro,nouuid,X-mount.idmap=u:1:2:1 g:3:4:1"
+		);
+	}
+
+	#[test]
+	fn snapshot_name_carries_reaper_infix() {
+		assert!(snapshot_name(99).starts_with(SNAPSHOT_INFIX));
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/strategy.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/strategy.rs
@@ -34,20 +34,17 @@ impl Strategy {
 	}
 }
 
-/// Map a filesystem type to its strategy.
-///
-/// btrfs takes the cheap snapshot path; everything else (thick LV, ext4/xfs,
-/// …) falls back to `pg_basebackup`, which is always correct. (Thin-LVM
-/// detection — distinguishing it from thick — is a separate step added with the
-/// thin-LVM strategy.)
-fn fstype_to_strategy(fstype: &str) -> Strategy {
-	match fstype {
-		"btrfs" => Strategy::Btrfs,
-		_ => Strategy::BaseBackup,
-	}
+/// Whether an `lvs -o segtype` value is a thin LV (the only LVM kind that gets
+/// a cheap snapshot; thick LVs fall back to `pg_basebackup`).
+fn segtype_is_thin(segtype: &str) -> bool {
+	segtype.trim() == "thin"
 }
 
 /// Detect the strategy for `data_dir`, honouring a config override.
+///
+/// btrfs and thin-LVM get cheap crash-consistent snapshots; everything else
+/// (thick LV, plain ext4/xfs partition) falls back to `pg_basebackup`, which is
+/// always correct.
 pub fn detect(strategy_override: Option<&str>, data_dir: &Path) -> Result<Strategy> {
 	if let Some(name) = strategy_override {
 		return Strategy::parse(name);
@@ -55,20 +52,40 @@ pub fn detect(strategy_override: Option<&str>, data_dir: &Path) -> Result<Strate
 	if cfg!(windows) {
 		return Ok(Strategy::Vss);
 	}
-	let fstype = findmnt_fstype(data_dir)?;
-	Ok(fstype_to_strategy(&fstype))
+	if findmnt_field("FSTYPE", data_dir)? == "btrfs" {
+		return Ok(Strategy::Btrfs);
+	}
+	if is_thin_lvm(data_dir) {
+		return Ok(Strategy::ThinLvm);
+	}
+	Ok(Strategy::BaseBackup)
 }
 
-/// `findmnt -no FSTYPE --target <path>` — the filesystem type backing `path`.
-fn findmnt_fstype(path: &Path) -> Result<String> {
+/// Whether `data_dir`'s backing device is a thin LV. Any failure (not LVM, no
+/// `lvs`) is treated as "not thin" — the `pg_basebackup` fallback is correct.
+fn is_thin_lvm(data_dir: &Path) -> bool {
+	let Ok(source) = findmnt_field("SOURCE", data_dir) else {
+		return false;
+	};
+	let Ok(output) = Command::new("lvs")
+		.args(["--noheadings", "-o", "segtype", &source])
+		.output()
+	else {
+		return false;
+	};
+	output.status.success() && segtype_is_thin(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// A single `findmnt -no <field> --target <path>` value.
+fn findmnt_field(field: &str, path: &Path) -> Result<String> {
 	let output = Command::new("findmnt")
-		.args(["-no", "FSTYPE", "--target"])
+		.args(["-no", field, "--target"])
 		.arg(path)
 		.output()
 		.map_err(|e| miette::miette!("running findmnt for {}: {e}", path.display()))?;
 	if !output.status.success() {
 		bail!(
-			"findmnt failed for {}: {}",
+			"findmnt {field} failed for {}: {}",
 			path.display(),
 			String::from_utf8_lossy(&output.stderr).trim()
 		);
@@ -81,10 +98,11 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn fstype_mapping() {
-		assert_eq!(fstype_to_strategy("btrfs"), Strategy::Btrfs);
-		assert_eq!(fstype_to_strategy("ext4"), Strategy::BaseBackup);
-		assert_eq!(fstype_to_strategy("xfs"), Strategy::BaseBackup);
+	fn thin_segtype_detection() {
+		assert!(segtype_is_thin("thin"));
+		assert!(segtype_is_thin("  thin  "));
+		assert!(!segtype_is_thin("linear"));
+		assert!(!segtype_is_thin("striped"));
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/canopy/backup/postgresql/sys.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/sys.rs
@@ -1,0 +1,175 @@
+//! Shared system-command and mount helpers for the snapshot strategies
+//! (btrfs, thin-LVM). Thin wrappers around `findmnt`, `mount`, `id`, etc.; the
+//! privileged calls are verified on-host, the pure bits (idmap, path math) are
+//! unit-tested.
+
+use std::{
+	path::{Path, PathBuf},
+	process::Stdio,
+};
+
+use miette::{Context as _, IntoDiagnostic as _, Result, bail, miette};
+
+/// A `Path` as a `&str` (lossy-empty if non-UTF-8 — our paths are ASCII).
+pub(super) fn path(p: &Path) -> &str {
+	p.to_str().unwrap_or_default()
+}
+
+/// Run a command, erroring (with stderr) on non-zero exit.
+pub(super) async fn run_ok(program: &str, args: &[&str]) -> Result<()> {
+	let output = tokio::process::Command::new(program)
+		.args(args)
+		.stdin(Stdio::null())
+		.output()
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("spawning {program}"))?;
+	if !output.status.success() {
+		bail!(
+			"{program} {} failed: {}",
+			args.join(" "),
+			String::from_utf8_lossy(&output.stderr).trim()
+		);
+	}
+	Ok(())
+}
+
+/// Run a command and return its trimmed stdout, erroring on non-zero exit.
+pub(super) async fn capture(program: &str, args: &[&str]) -> Result<String> {
+	let output = tokio::process::Command::new(program)
+		.args(args)
+		.stdin(Stdio::null())
+		.output()
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("spawning {program}"))?;
+	if !output.status.success() {
+		bail!(
+			"{program} {} failed: {}",
+			args.join(" "),
+			String::from_utf8_lossy(&output.stderr).trim()
+		);
+	}
+	Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+/// The mountpoint of the filesystem backing `data_dir`.
+pub(super) async fn findmnt_target(data_dir: &Path) -> Result<PathBuf> {
+	Ok(PathBuf::from(findmnt_field("TARGET", data_dir).await?))
+}
+
+/// A single `findmnt` field (`UUID`, `SOURCE`, `FSTYPE`, …) for `data_dir`.
+pub(super) async fn findmnt_field(field: &str, data_dir: &Path) -> Result<String> {
+	capture("findmnt", &["-no", field, "--target", path(data_dir)]).await
+}
+
+/// A user's numeric uid / gid (via `id`).
+pub(super) async fn uid_of(user: &str) -> Result<u32> {
+	parse_id(&capture("id", &["-u", user]).await?, user)
+}
+
+pub(super) async fn gid_of(user: &str) -> Result<u32> {
+	parse_id(&capture("id", &["-g", user]).await?, user)
+}
+
+fn parse_id(out: &str, user: &str) -> Result<u32> {
+	out.trim()
+		.parse()
+		.into_diagnostic()
+		.wrap_err_with(|| format!("parsing id for {user}: {out:?}"))
+}
+
+pub(super) async fn mkdir(dir: &Path) -> Result<()> {
+	tokio::fs::create_dir_all(dir)
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("creating {}", dir.display()))
+}
+
+pub(super) async fn umount(dir: &Path) {
+	if is_mountpoint(dir).await {
+		let _ = run_ok("umount", &[path(dir)]).await;
+	}
+}
+
+pub(super) async fn rmdir(dir: &Path) {
+	let _ = tokio::fs::remove_dir(dir).await;
+}
+
+pub(super) async fn is_mountpoint(dir: &Path) -> bool {
+	tokio::process::Command::new("mountpoint")
+		.arg("-q")
+		.arg(dir)
+		.stdin(Stdio::null())
+		.status()
+		.await
+		.map(|s| s.success())
+		.unwrap_or(false)
+}
+
+/// Directory entries whose file name starts with `prefix`.
+pub(super) fn glob_prefix(dir: impl AsRef<Path>, prefix: &str) -> Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	for entry in std::fs::read_dir(dir.as_ref()).into_diagnostic()? {
+		let entry = entry.into_diagnostic()?;
+		if entry.file_name().to_string_lossy().starts_with(prefix) {
+			out.push(entry.path());
+		}
+	}
+	Ok(out)
+}
+
+/// The `X-mount.idmap` mapping postgres's uid/gid to kopia's, so the kopia user
+/// can read the postgres-owned files in a read-only snapshot mount.
+pub(super) fn idmap(postgres_uid: u32, kopia_uid: u32, postgres_gid: u32, kopia_gid: u32) -> String {
+	format!("u:{postgres_uid}:{kopia_uid}:1 g:{postgres_gid}:{kopia_gid}:1")
+}
+
+/// Build the postgres→kopia idmap by resolving both users' ids.
+pub(super) async fn postgres_to_kopia_idmap() -> Result<String> {
+	Ok(idmap(
+		uid_of("postgres").await?,
+		uid_of("kopia").await?,
+		gid_of("postgres").await?,
+		gid_of("kopia").await?,
+	))
+}
+
+/// The cluster directory's path relative to its filesystem mountpoint.
+pub(super) fn relative_data_path(data_dir: &Path, base_mount: &Path) -> Result<PathBuf> {
+	data_dir
+		.strip_prefix(base_mount)
+		.map(Path::to_path_buf)
+		.map_err(|_| {
+			miette!(
+				"data dir {} is not under its mountpoint {}",
+				data_dir.display(),
+				base_mount.display()
+			)
+		})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn idmap_format() {
+		assert_eq!(idmap(114, 997, 120, 995), "u:114:997:1 g:120:995:1");
+	}
+
+	#[test]
+	fn relative_data_path_strips_mountpoint() {
+		let rel = relative_data_path(
+			Path::new("/var/lib/postgresql/16/main"),
+			Path::new("/var/lib/postgresql"),
+		)
+		.unwrap();
+		assert_eq!(rel, PathBuf::from("16/main"));
+	}
+
+	#[test]
+	fn relative_data_path_rejects_outside() {
+		assert!(relative_data_path(Path::new("/srv/pg"), Path::new("/var/lib/postgresql")).is_err());
+	}
+}


### PR DESCRIPTION
🤖 Stacked on #520. Adds the thin-LVM snapshot backend — the thin-pool analogue of the btrfs path.

Take a thin snapshot of the LV the data directory lives on (CoW within the pool, no read-copy), mount it read-only — idmapped so the kopia user can read it, with `nouuid` on xfs — at the stable per-type source path, and snapshot it. Restores by plain crash recovery, no `backup_label`. On cleanup the snapshot LV is deactivated and removed; a reaper sweeps `bestool-kopia-*` LVs left by a crashed run.

Strategy detection now distinguishes **thin** LVs (via `lvs -o segtype`) from thick ones: only thin gets the cheap snapshot; thick LVs (and plain ext4/xfs partitions) still fall back to `pg_basebackup`, which is always correct.

Also extracts the system-command/mount glue (findmnt, mount, idmap, id lookups, reaping) shared by the btrfs and thin-LVM backends into a `sys` module. Pure helpers (vg/lv parsing, mount-option building, segtype matching) are unit-tested; the privileged `lvcreate`/`mount` steps are verified on-host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
