### PR TITLE
feat(alertd): systemd sd_notify readiness/status/reload (notify-reload)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "rustls",
+ "sd-notify",
  "serde",
  "serde_json",
  "sysinfo",
@@ -6335,6 +6336,15 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sd-notify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -40,5 +40,9 @@ tracing = { workspace = true }
 url = { version = "2.5.8", features = ["serde"] }
 x509-parser = "0.18.1"
 
+[target.'cfg(unix)'.dependencies]
+# systemd readiness/reload/status notifications (no-op when not under systemd).
+sd-notify = "0.5.0"
+
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8.0"

--- a/crates/alertd/src/context.rs
+++ b/crates/alertd/src/context.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use tokio::sync::watch;
+
 use crate::canopy::CanopyClient;
 
 /// Shared resources the daemon holds for the lifetime of the process and hands
@@ -10,4 +12,7 @@ pub struct InternalContext {
 	pub pg_pool: Option<bestool_postgres::pool::PgPool>,
 	pub http_client: reqwest::Client,
 	pub canopy_client: Option<Arc<CanopyClient>>,
+	/// Bumped on each reload request (SIGHUP/SIGUSR1); tasks watch it to refresh
+	/// their state without a restart.
+	pub reload: watch::Receiver<u64>,
 }

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -72,10 +72,15 @@ pub async fn run_with_shutdown(
 		}
 	};
 
+	// Reload channel: the SIGHUP/SIGUSR1 handler bumps it; tasks watch it to
+	// refresh without a restart.
+	let (reload_tx, reload_rx) = tokio::sync::watch::channel(0u64);
+
 	let ctx = Arc::new(InternalContext {
 		pg_pool: pool,
 		http_client: crate::http_client(),
 		canopy_client,
+		reload: reload_rx,
 	});
 
 	let (event_tx, mut event_rx) = mpsc::channel(100);
@@ -130,7 +135,33 @@ pub async fn run_with_shutdown(
 			info!("received SIGTERM, shutting down");
 			let _ = signal_tx_term.send(DaemonEvent::Shutdown).await;
 		});
+
+		// Reload on SIGHUP (systemd's notify-reload `ReloadSignal`) or SIGUSR1:
+		// notify systemd we're reloading, bump the reload channel so tasks
+		// refresh, then notify ready again. The reload work itself is async and
+		// best-effort, so READY is sent once the refresh is dispatched.
+		tokio::spawn(async move {
+			let mut sighup = signal(SignalKind::hangup()).expect("failed to setup SIGHUP handler");
+			let mut sigusr1 =
+				signal(SignalKind::user_defined1()).expect("failed to setup SIGUSR1 handler");
+			loop {
+				tokio::select! {
+					_ = sighup.recv() => {}
+					_ = sigusr1.recv() => {}
+				}
+				info!("received reload signal; refreshing");
+				let mut reloading = vec![sd_notify::NotifyState::Reloading];
+				if let Ok(stamp) = sd_notify::NotifyState::monotonic_usec_now() {
+					reloading.push(stamp);
+				}
+				let _ = sd_notify::notify(&reloading);
+				reload_tx.send_modify(|n| *n = n.wrapping_add(1));
+				let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
+			}
+		});
 	}
+	#[cfg(not(unix))]
+	let _ = reload_tx; // no reload signals off Unix; tasks keep their other triggers
 
 	// Registered background tasks (e.g. the doctor sweep). Each ticks at its
 	// own interval; errors are logged but don't tear down the daemon.
@@ -185,11 +216,20 @@ pub async fn run_with_shutdown(
 	}
 
 	info!("daemon started successfully");
+	// Tell systemd (Type=notify[-reload]) we're up; no-op when not under systemd.
+	#[cfg(unix)]
+	let _ = sd_notify::notify(&[
+		sd_notify::NotifyState::Ready,
+		sd_notify::NotifyState::Status("monitoring"),
+	]);
 
 	// Block until the first lifecycle event arrives: a shutdown signal, or the
 	// watchdog firing. `None` means every sender was dropped, which we treat as
 	// a shutdown too.
-	match event_rx.recv().await {
+	let event = event_rx.recv().await;
+	#[cfg(unix)]
+	let _ = sd_notify::notify(&[sd_notify::NotifyState::Stopping]);
+	match event {
 		Some(DaemonEvent::Shutdown) | None => {
 			info!("daemon stopped");
 			Ok(())

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -15,6 +15,7 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		pg_pool: Some(pool),
 		http_client: reqwest::Client::new(),
 		canopy_client: None,
+		reload: tokio::sync::watch::channel(0).1,
 	});
 
 	Arc::new(ServerState {

--- a/crates/alertd/src/tasks.rs
+++ b/crates/alertd/src/tasks.rs
@@ -16,6 +16,9 @@ pub struct TaskContext {
 	pub pg_pool: Option<bestool_postgres::pool::PgPool>,
 	pub http_client: reqwest::Client,
 	pub canopy_client: Option<Arc<CanopyClient>>,
+	/// Bumped on each reload request (SIGHUP/SIGUSR1); a task can
+	/// `reload.changed().await` to refresh its state without a restart.
+	pub reload: tokio::sync::watch::Receiver<u64>,
 }
 
 impl TaskContext {
@@ -24,6 +27,7 @@ impl TaskContext {
 			pg_pool: ctx.pg_pool.clone(),
 			http_client: ctx.http_client.clone(),
 			canopy_client: ctx.canopy_client.clone(),
+			reload: ctx.reload.clone(),
 		}
 	}
 }

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -307,30 +307,22 @@ mod backup {
 				// Held for the task's lifetime so events keep arriving.
 				let _watcher = watch_backups_dir(tx);
 
+				// The daemon turns SIGHUP/SIGUSR1 (and systemd's reload) into a
+				// bump on this channel; we also re-register on a backups-dir
+				// change and a periodic safety-net tick.
+				let mut reload = ctx.reload.clone();
 				let mut periodic = tokio::time::interval(REREGISTER_INTERVAL);
 				periodic.tick().await; // consume the immediate first tick
 
-				#[cfg(unix)]
-				{
-					use tokio::signal::unix::{SignalKind, signal};
-					let mut sighup = signal(SignalKind::hangup()).into_diagnostic()?;
-					let mut sigusr1 = signal(SignalKind::user_defined1()).into_diagnostic()?;
-					loop {
-						tokio::select! {
-							_ = periodic.tick() => reregister("periodic", ctx).await,
-							_ = rx.recv() => { drain(&mut rx); reregister("backups dir changed", ctx).await }
-							_ = sighup.recv() => reregister("SIGHUP", ctx).await,
-							_ = sigusr1.recv() => reregister("SIGUSR1", ctx).await,
-						}
-					}
-				}
-				#[cfg(not(unix))]
-				{
-					loop {
-						tokio::select! {
-							_ = periodic.tick() => reregister("periodic", ctx).await,
-							_ = rx.recv() => { drain(&mut rx); reregister("backups dir changed", ctx).await }
-						}
+				loop {
+					tokio::select! {
+						_ = periodic.tick() => reregister("periodic", ctx).await,
+						_ = rx.recv() => { drain(&mut rx); reregister("backups dir changed", ctx).await }
+						changed = reload.changed() => match changed {
+							Ok(()) => reregister("reload signal", ctx).await,
+							// Sender dropped → daemon is shutting down.
+							Err(_) => break Ok(()),
+						},
 					}
 				}
 			})

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -3,15 +3,17 @@ Description=Tamanu alert daemon
 After=network.target
 
 [Service]
-Type=simple
+# notify-reload: the daemon signals readiness (READY=1), status, and shutdown
+# (STOPPING=1) over $NOTIFY_SOCKET, and `systemctl reload` sends SIGHUP (the
+# default ReloadSignal) which the daemon answers with RELOADING=1 / READY=1 —
+# re-registering backup capabilities (picking up /etc/bestool/backups changes)
+# without a restart. Needs systemd >= 253; on older systemd use Type=notify plus
+# `ExecReload=/bin/kill -HUP $MAINPID`.
+Type=notify-reload
 # Distinct journal identifier so rsyslog can filter alertd apart from other
 # bestool invocations (which all otherwise log as "bestool").
 SyslogIdentifier=bestool-alertd
 ExecStart=/usr/bin/bestool alertd run
-# `systemctl reload bestool-alertd` re-registers backup capabilities with canopy,
-# picking up changes under /etc/bestool/backups without a restart (handled by the
-# daemon's SIGHUP/SIGUSR1 reload).
-ExecReload=/bin/kill -HUP $MAINPID
 MemoryMax=500M
 Restart=always
 RestartSec=10


### PR DESCRIPTION
🤖 Stacked on #522. Teaches the alertd daemon the systemd `sd_notify` protocol so systemd gets real lifecycle info instead of just "the process forked".

- **READY=1 + STATUS=** once the daemon is actually up (so `systemctl start` waits for genuine readiness).
- **STOPPING=1** on shutdown.
- **notify-reload**: the daemon now owns the reload signals (SIGHUP — systemd's default `ReloadSignal` — and SIGUSR1) and answers them with `RELOADING=1` + `MONOTONIC_USEC` then `READY=1`. The signal is turned into a watch-channel bump that background tasks subscribe to; the backup-capabilities task re-registers off that (and the dir-watch / periodic tick) rather than handling signals itself. This supersedes the task-level SIGHUP/SIGUSR1 handling from #519 with daemon-coordinated reload.

`sd-notify` is unix-only (gated to `cfg(unix)` deps) and a no-op when `$NOTIFY_SOCKET` is unset, so non-systemd and Windows builds are unaffected (Windows keeps its SCM status path). Verified on the `x86_64-pc-windows-gnu` target.

The unit becomes `Type=notify-reload` and drops the manual `ExecReload`. That needs **systemd ≥ 253**; the unit comments the `Type=notify` + `ExecReload=/bin/kill -HUP $MAINPID` fallback for older systemd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
