### PR TITLE
feat(alertd): bestool alertd reload/restart control commands

### DIFF
--- a/crates/alertd/src/commands.rs
+++ b/crates/alertd/src/commands.rs
@@ -2,8 +2,10 @@
 
 use tracing::info;
 
+pub use control::{reload, restart};
 pub use status::get_status;
 
+mod control;
 mod status;
 
 /// Default server addresses to try when connecting to the daemon

--- a/crates/alertd/src/commands/control.rs
+++ b/crates/alertd/src/commands/control.rs
@@ -1,9 +1,31 @@
 //! Clients for the daemon's `/reload` and `/restart` control endpoints.
 
+use std::time::Duration;
+
 use miette::miette;
 use tracing::info;
 
 use super::try_connect_daemon;
+
+/// After a reload/restart, pause then print the daemon status, so the operator
+/// sees the resulting state. Retries while the daemon is unreachable (e.g. a
+/// restart waits out the unit's `RestartSec` before the daemon is back), up to
+/// `attempts` one-second tries; a daemon that never reappears is reported, not
+/// treated as a failure of the command (the action itself succeeded).
+async fn reprint_status(addrs: &[std::net::SocketAddr], attempts: u32) {
+	println!();
+	for attempt in 1..=attempts {
+		tokio::time::sleep(Duration::from_secs(1)).await;
+		match super::get_status(addrs).await {
+			Ok(()) => return,
+			Err(err) if attempt == attempts => {
+				println!("(daemon status not available yet: {err})");
+			}
+			// Not back yet — keep waiting.
+			Err(_) => {}
+		}
+	}
+}
 
 /// Ask a running daemon to reload (re-register backup capabilities, pick up
 /// `/etc/bestool/backups` changes) without restarting.
@@ -19,6 +41,8 @@ pub async fn reload(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
 	}
 	info!("connected to daemon at {url}");
 	println!("Reload requested.");
+	// The daemon stays up across a reload, so one check is enough.
+	reprint_status(addrs, 1).await;
 	Ok(())
 }
 
@@ -36,5 +60,8 @@ pub async fn restart(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
 	}
 	info!("connected to daemon at {url}");
 	println!("Restart requested; the service manager will bring the daemon back.");
+	// The daemon is down until the service manager restarts it (the unit's
+	// RestartSec is 10s) and it rebinds, so wait well past that before giving up.
+	reprint_status(addrs, 20).await;
 	Ok(())
 }

--- a/crates/alertd/src/commands/control.rs
+++ b/crates/alertd/src/commands/control.rs
@@ -1,0 +1,40 @@
+//! Clients for the daemon's `/reload` and `/restart` control endpoints.
+
+use miette::miette;
+use tracing::info;
+
+use super::try_connect_daemon;
+
+/// Ask a running daemon to reload (re-register backup capabilities, pick up
+/// `/etc/bestool/backups` changes) without restarting.
+pub async fn reload(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
+	let (client, url) = try_connect_daemon(addrs).await?;
+	let response = client
+		.post(format!("{url}/reload"))
+		.send()
+		.await
+		.map_err(|e| miette!("failed to request reload: {e}"))?;
+	if !response.status().is_success() {
+		return Err(miette!("reload endpoint returned {}", response.status()));
+	}
+	info!("connected to daemon at {url}");
+	println!("Reload requested.");
+	Ok(())
+}
+
+/// Ask a running daemon to exit so the service manager restarts it (e.g. to pick
+/// up a freshly-installed binary).
+pub async fn restart(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
+	let (client, url) = try_connect_daemon(addrs).await?;
+	let response = client
+		.post(format!("{url}/restart"))
+		.send()
+		.await
+		.map_err(|e| miette!("failed to request restart: {e}"))?;
+	if !response.status().is_success() {
+		return Err(miette!("restart endpoint returned {}", response.status()));
+	}
+	info!("connected to daemon at {url}");
+	println!("Restart requested; the service manager will bring the daemon back.");
+	Ok(())
+}

--- a/crates/alertd/src/commands/status.rs
+++ b/crates/alertd/src/commands/status.rs
@@ -50,7 +50,7 @@ pub async fn get_status(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
 			"           WARNING: running daemon is {}, but this CLI is {local_version}",
 			status.version
 		);
-		println!("           Consider restarting the service to pick up the new version.");
+		println!("           Run `bestool alertd restart` to pick up the new version.");
 	}
 	println!("PID:       {}", status.pid);
 	println!("Started:   {}", status.started_at);

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -10,8 +10,46 @@ use crate::{
 };
 
 enum DaemonEvent {
+	/// Clean stop (SIGINT/SIGTERM, or the service manager): exit 0, no restart.
 	Shutdown,
+	/// Exit non-zero so the service manager (systemd `Restart=`, Windows SCM
+	/// recovery) brings the daemon back — how `bestool alertd restart` works.
+	Restart,
 	WatchdogTimeout,
+}
+
+/// Handle the HTTP control endpoints use to drive the daemon.
+///
+/// `pub` only so it can appear in the (also-internal) `ServerState` /
+/// `start_server` signatures without tripping `private_interfaces`; the
+/// enclosing `daemon` module is private, so it isn't part of the public API.
+#[derive(Clone)]
+pub struct DaemonControl {
+	reload: Arc<tokio::sync::watch::Sender<u64>>,
+	events: mpsc::Sender<DaemonEvent>,
+}
+
+impl DaemonControl {
+	/// Bump the reload channel so tasks refresh (HTTP `/reload`).
+	pub(crate) fn reload(&self) {
+		self.reload.send_modify(|n| *n = n.wrapping_add(1));
+	}
+
+	/// Ask the daemon to exit so the service manager restarts it (HTTP `/restart`).
+	pub(crate) async fn request_restart(&self) {
+		let _ = self.events.send(DaemonEvent::Restart).await;
+	}
+
+	/// A detached control whose channels go nowhere, for tests.
+	#[cfg(test)]
+	pub(crate) fn detached() -> Self {
+		let (reload, _) = tokio::sync::watch::channel(0);
+		let (events, _) = mpsc::channel(1);
+		Self {
+			reload: Arc::new(reload),
+			events,
+		}
+	}
 }
 
 pub async fn run(daemon_config: DaemonConfig) -> Result<()> {
@@ -72,9 +110,10 @@ pub async fn run_with_shutdown(
 		}
 	};
 
-	// Reload channel: the SIGHUP/SIGUSR1 handler bumps it; tasks watch it to
-	// refresh without a restart.
+	// Reload channel: the SIGHUP/SIGUSR1 handler (and the `/reload` HTTP control)
+	// bump it; tasks watch it to refresh without a restart.
 	let (reload_tx, reload_rx) = tokio::sync::watch::channel(0u64);
+	let reload_tx = Arc::new(reload_tx);
 
 	let ctx = Arc::new(InternalContext {
 		pg_pool: pool,
@@ -84,6 +123,12 @@ pub async fn run_with_shutdown(
 	});
 
 	let (event_tx, mut event_rx) = mpsc::channel(100);
+
+	// Control handle for the HTTP server's `/reload` and `/restart` endpoints.
+	let control = DaemonControl {
+		reload: reload_tx.clone(),
+		events: event_tx.clone(),
+	};
 
 	// Start HTTP server
 	if !daemon_config.no_server {
@@ -97,6 +142,7 @@ pub async fn run_with_shutdown(
 				server_addrs,
 				watchdog_timeout,
 				&background_tasks_for_server,
+				control,
 			)
 			.await;
 		});
@@ -233,6 +279,12 @@ pub async fn run_with_shutdown(
 		Some(DaemonEvent::Shutdown) | None => {
 			info!("daemon stopped");
 			Ok(())
+		}
+		Some(DaemonEvent::Restart) => {
+			// Exit non-zero so the service manager restarts us (systemd
+			// `Restart=`, Windows SCM recovery).
+			info!("restart requested; exiting for the service manager to restart");
+			Err(miette!("restart requested"))
 		}
 		Some(DaemonEvent::WatchdogTimeout) => {
 			error!("daemon exiting due to watchdog timeout");

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -2,13 +2,17 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use axum::{Router, routing::get};
+use axum::{
+	Router,
+	routing::{get, post},
+};
 use jiff::Timestamp;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::{Level, error, info, warn};
 
 use crate::{
 	context::InternalContext,
+	daemon::DaemonControl,
 	tasks::{BackgroundTask, TaskEndpointHandler},
 };
 
@@ -27,6 +31,7 @@ pub async fn start_server(
 	addrs: Vec<std::net::SocketAddr>,
 	watchdog_timeout: Option<Duration>,
 	background_tasks: &[Arc<dyn BackgroundTask>],
+	control: DaemonControl,
 ) {
 	let started_at = Timestamp::now();
 	let pid = std::process::id();
@@ -39,6 +44,7 @@ pub async fn start_server(
 		internal_context,
 		watchdog_timeout,
 		task_endpoints: Arc::new(task_endpoints),
+		control,
 	};
 
 	let app = Router::new()
@@ -46,6 +52,8 @@ pub async fn start_server(
 		.route("/metrics", get(handle_metrics))
 		.route("/status", get(handle_status))
 		.route("/health", get(handle_health))
+		.route("/reload", post(handle_reload))
+		.route("/restart", post(handle_restart))
 		.route("/tasks/{task}/{endpoint}", get(handle_task_endpoint))
 		.layer(
 			TraceLayer::new_for_http()

--- a/crates/alertd/src/http_server/endpoints.rs
+++ b/crates/alertd/src/http_server/endpoints.rs
@@ -1,9 +1,11 @@
+mod control;
 mod health;
 mod index;
 mod metrics;
 mod status;
 mod tasks;
 
+pub use control::{handle_reload, handle_restart};
 pub use health::handle_health;
 pub use index::handle_index;
 pub use metrics::handle_metrics;

--- a/crates/alertd/src/http_server/endpoints/control.rs
+++ b/crates/alertd/src/http_server/endpoints/control.rs
@@ -1,0 +1,30 @@
+//! Control endpoints: `/reload` and `/restart`.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, response::IntoResponse};
+use serde_json::json;
+use tracing::info;
+
+use crate::http_server::state::ServerState;
+
+/// `POST /reload` — refresh runtime state (re-register backup capabilities, pick
+/// up `/etc/bestool/backups` changes) without restarting.
+pub async fn handle_reload(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
+	info!("reload requested via HTTP");
+	state.control.reload();
+	Json(json!({ "reloading": true }))
+}
+
+/// `POST /restart` — ask the daemon to exit so the service manager restarts it
+/// (e.g. to pick up a new binary). Triggered after a short delay so this
+/// response reaches the client before the daemon exits.
+pub async fn handle_restart(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
+	info!("restart requested via HTTP");
+	let control = state.control.clone();
+	tokio::spawn(async move {
+		tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+		control.request_restart().await;
+	});
+	Json(json!({ "restarting": true }))
+}

--- a/crates/alertd/src/http_server/state.rs
+++ b/crates/alertd/src/http_server/state.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use jiff::Timestamp;
 
-use crate::{context::InternalContext, tasks::TaskEndpointHandler};
+use crate::{context::InternalContext, daemon::DaemonControl, tasks::TaskEndpointHandler};
 
 #[derive(Clone)]
 pub struct ServerState {
@@ -14,4 +14,6 @@ pub struct ServerState {
 	/// `(task_name, endpoint_name)` so the `/tasks/:task/:endpoint` route can
 	/// dispatch in O(1) without walking the task registry per request.
 	pub task_endpoints: Arc<HashMap<(String, String), TaskEndpointHandler>>,
+	/// Drives the daemon's `/reload` and `/restart` control endpoints.
+	pub control: DaemonControl,
 }

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -24,5 +24,6 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		internal_context: ctx,
 		watchdog_timeout: Some(std::time::Duration::from_secs(600)),
 		task_endpoints: Arc::new(HashMap::new()),
+		control: crate::daemon::DaemonControl::detached(),
 	})
 }

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -8,6 +8,8 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool alertd`↴](#bestool-alertd)
 * [`bestool alertd run`↴](#bestool-alertd-run)
 * [`bestool alertd status`↴](#bestool-alertd-status)
+* [`bestool alertd reload`↴](#bestool-alertd-reload)
+* [`bestool alertd restart`↴](#bestool-alertd-restart)
 * [`bestool audit-psql`↴](#bestool-audit-psql)
 * [`bestool caddy`↴](#bestool-caddy)
 * [`bestool caddy configure-tamanu`↴](#bestool-caddy-configure-tamanu)
@@ -60,6 +62,8 @@ This document contains the help content for the `bestool` command-line program.
 * [`bestool tamanu alertd`↴](#bestool-tamanu-alertd)
 * [`bestool tamanu alertd run`↴](#bestool-tamanu-alertd-run)
 * [`bestool tamanu alertd status`↴](#bestool-tamanu-alertd-status)
+* [`bestool tamanu alertd reload`↴](#bestool-tamanu-alertd-reload)
+* [`bestool tamanu alertd restart`↴](#bestool-tamanu-alertd-restart)
 * [`bestool tamanu artifacts`↴](#bestool-tamanu-artifacts)
 * [`bestool tamanu backup`↴](#bestool-tamanu-backup)
 * [`bestool tamanu backup-configs`↴](#bestool-tamanu-backup-configs)
@@ -158,6 +162,8 @@ sweeps, with every Tamanu-dependent check skipped.
 
 * `run` — Run the healthcheck daemon
 * `status` — Show status and health of a running daemon
+* `reload` — Reload a running daemon
+* `restart` — Restart a running daemon
 
 
 
@@ -202,6 +208,34 @@ Connects to the running daemon's HTTP API and displays version, uptime, health, 
 * `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try
 
    Can be provided multiple times. Will attempt to connect to each address in order until one succeeds. Defaults to [::1]:8271 and 127.0.0.1:8271
+
+
+
+## `bestool alertd reload`
+
+Reload a running daemon
+
+Asks the daemon to re-register backup capabilities and pick up changes under /etc/bestool/backups, without restarting.
+
+**Usage:** `bestool alertd reload [OPTIONS]`
+
+###### **Options:**
+
+* `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try (defaults to [::1]:8271 and 127.0.0.1:8271)
+
+
+
+## `bestool alertd restart`
+
+Restart a running daemon
+
+Asks the daemon to exit so the service manager restarts it — e.g. to pick up a freshly-installed bestool binary.
+
+**Usage:** `bestool alertd restart [OPTIONS]`
+
+###### **Options:**
+
+* `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try (defaults to [::1]:8271 and 127.0.0.1:8271)
 
 
 
@@ -1430,6 +1464,8 @@ sweeps, with every Tamanu-dependent check skipped.
 
 * `run` — Run the healthcheck daemon
 * `status` — Show status and health of a running daemon
+* `reload` — Reload a running daemon
+* `restart` — Restart a running daemon
 
 
 
@@ -1474,6 +1510,34 @@ Connects to the running daemon's HTTP API and displays version, uptime, health, 
 * `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try
 
    Can be provided multiple times. Will attempt to connect to each address in order until one succeeds. Defaults to [::1]:8271 and 127.0.0.1:8271
+
+
+
+## `bestool tamanu alertd reload`
+
+Reload a running daemon
+
+Asks the daemon to re-register backup capabilities and pick up changes under /etc/bestool/backups, without restarting.
+
+**Usage:** `bestool tamanu alertd reload [OPTIONS]`
+
+###### **Options:**
+
+* `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try (defaults to [::1]:8271 and 127.0.0.1:8271)
+
+
+
+## `bestool tamanu alertd restart`
+
+Restart a running daemon
+
+Asks the daemon to exit so the service manager restarts it — e.g. to pick up a freshly-installed bestool binary.
+
+**Usage:** `bestool tamanu alertd restart [OPTIONS]`
+
+###### **Options:**
+
+* `--server-addr <SERVER_ADDR>` — HTTP server address(es) to try (defaults to [::1]:8271 and 127.0.0.1:8271)
 
 
 

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -82,6 +82,26 @@ enum Command {
 		server_addr: Vec<SocketAddr>,
 	},
 
+	/// Reload a running daemon
+	///
+	/// Asks the daemon to re-register backup capabilities and pick up changes
+	/// under /etc/bestool/backups, without restarting.
+	Reload {
+		/// HTTP server address(es) to try (defaults to [::1]:8271 and 127.0.0.1:8271)
+		#[arg(long)]
+		server_addr: Vec<SocketAddr>,
+	},
+
+	/// Restart a running daemon
+	///
+	/// Asks the daemon to exit so the service manager restarts it — e.g. to pick
+	/// up a freshly-installed bestool binary.
+	Restart {
+		/// HTTP server address(es) to try (defaults to [::1]:8271 and 127.0.0.1:8271)
+		#[arg(long)]
+		server_addr: Vec<SocketAddr>,
+	},
+
 	/// Install the daemon as a Windows service
 	///
 	/// Creates a Windows service named 'bestool-alertd' that will start automatically
@@ -120,6 +140,22 @@ pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 				server_addr
 			};
 			bestool_alertd::commands::get_status(&addrs).await
+		}
+		Command::Reload { server_addr } => {
+			let addrs = if server_addr.is_empty() {
+				bestool_alertd::commands::default_server_addrs()
+			} else {
+				server_addr
+			};
+			bestool_alertd::commands::reload(&addrs).await
+		}
+		Command::Restart { server_addr } => {
+			let addrs = if server_addr.is_empty() {
+				bestool_alertd::commands::default_server_addrs()
+			} else {
+				server_addr
+			};
+			bestool_alertd::commands::restart(&addrs).await
 		}
 		Command::Run { daemon } => {
 			let daemon_config = build_config(&ctx, daemon).await?;


### PR DESCRIPTION
🤖 Stacked on #523. Adds `bestool alertd reload` and `bestool alertd restart`, mirroring `bestool alertd status` — they talk to the daemon's loopback HTTP server.

- **`reload`** → `POST /reload`: bumps the reload channel so the daemon re-registers backup capabilities and picks up `/etc/bestool/backups` changes, without a restart. (Same effect as SIGHUP, over HTTP.)
- **`restart`** → `POST /restart`: asks the daemon to exit **non-zero** so the service manager brings it back — systemd `Restart=` on Linux, Windows SCM failure-recovery (which is why the exit is non-zero, matching the existing Win32(1)→recovery mapping). For picking up a freshly-installed binary. The HTTP response is flushed before the daemon exits.

Wired via a small `DaemonControl` handle (reload sender + event sender) threaded into the HTTP server's `ServerState`; the daemon gains a `DaemonEvent::Restart` that returns `Err` so both service managers restart it.

`bestool alertd status` already warns when the running daemon's version differs from the CLI's; it now points at `bestool alertd restart` to pick up the new version.

Both commands also exist under the `bestool tamanu alertd` alias. clippy/fmt clean, Windows GNU compile-checked, 175 alertd tests pass, USAGE.md regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
