### PR TITLE
fix(kopia): use the aws-lc-rs rustls provider in the proxy

### DIFF
--- a/crates/kopia/Cargo.toml
+++ b/crates/kopia/Cargo.toml
@@ -35,11 +35,11 @@ hex = { version = "0.4.3", optional = true }
 hmac = { version = "0.12.1", optional = true }
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.9.0", features = ["server", "client", "http1"], optional = true }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "ring", "webpki-tokio"], optional = true }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "aws-lc-rs", "webpki-tokio"], optional = true }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "server", "tokio"], optional = true }
 jiff = { version = "0.2.28", features = ["serde"] }
 miette = { workspace = true }
-rustls = { version = "0.23.40", default-features = false, features = ["ring"], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 sha2 = { version = "0.10.9", optional = true }

--- a/crates/kopia/src/proxy.rs
+++ b/crates/kopia/src/proxy.rs
@@ -102,9 +102,10 @@ pub async fn spawn(
 	config: S3ProxyConfig,
 	provider: Arc<dyn CredentialProvider>,
 ) -> std::io::Result<RunningProxy> {
-	// The TLS upstream leg needs a rustls crypto provider; install ring's if no
-	// process default is set yet (idempotent, ignores "already installed").
-	let _ = rustls::crypto::ring::default_provider().install_default();
+	// The TLS upstream leg needs a rustls crypto provider; install aws-lc-rs's
+	// (the workspace standard) if no process default is set yet (idempotent,
+	// ignores "already installed").
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
 	let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
 	let addr = listener.local_addr()?;


### PR DESCRIPTION
🤖 The S3 re-signing proxy (#529) configured `hyper-rustls`/`rustls` with the `ring` crypto provider, pulling a second rustls backend into the build. The rest of the workspace standardises on **aws-lc-rs** (`crates/postgres` TLS pool, alertd `caddy_certs`). This switches the proxy to aws-lc-rs so the build carries a single provider.

- `hyper-rustls` and `rustls` features: `ring` → `aws-lc-rs`.
- `proxy::spawn` installs `rustls::crypto::aws_lc_rs::default_provider()`.

`cargo tree -i ring` for `bestool-kopia --features proxy` is now empty; the MinIO+kopia e2e (which builds the HTTPS connector and installs the provider) still passes.
