### PR TITLE
docs: add spec-writing rules

### DIFF
--- a/.workhorse/rules.md
+++ b/.workhorse/rules.md
@@ -1,0 +1,45 @@
+# Spec rules
+
+Specs live in `.workhorse/specs/<area>/<name>.md`. Each carries an `id` in its
+frontmatter (e.g. `BAK`, `S3P`) and is cross-referenced by linking the file
+under that id, e.g. `[BAK](backup.md)`.
+
+A spec is the durable description of **what** the system requires. It is read by
+someone deciding whether the implementation is correct, or re-implementing the
+feature from scratch — not as a narrative of how the code works or how it came
+to be.
+
+## What, not how
+
+- Describe **what** the system requires, not **how** the code achieves it. Keep
+  out of spec text: tool and command names (`sfdisk`, `kopia snapshot create`),
+  crate and library names, syscall names (`splice(2)`), internal API details,
+  data-structure choices, and environment variable names used only by the
+  implementation.
+- Acceptable, because external actors or other components depend on them:
+  interface contracts — config file paths and formats, on-disk and on-the-wire
+  shapes, endpoint shapes, partition UUIDs, credential scopes.
+- The test: would someone re-implementing the feature from scratch be
+  constrained to the same choice? If not, it's an implementation detail and
+  doesn't belong in the spec.
+
+## Present, not past
+
+- State what the system does, not how it got there. No "this supersedes X",
+  "formerly Y", "a spike settled Z", changelog entries, or migration narration.
+- When something is removed or replaced, edit the spec to describe the new
+  reality and delete the old text, rather than describing the transition. The
+  git history is the record of change; the spec is the record of the present.
+
+## Own behaviour, not a dependency's internals
+
+- Describe the system's own behaviour and contracts: the request shape it
+  handles, the guarantee it makes. Don't narrate a dependency's decision logic
+  or version-specific quirks beyond the minimum needed to justify a requirement.
+- Don't scaffold or label: no "Strategy A/B", "Phase N", or plan tags in spec
+  prose. Describe the mechanism directly.
+
+## Workflow
+
+- When adding or changing a feature, or fixing a bug: update the spec in
+  `.workhorse/specs` first, then implement, then add tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,5 @@
 - When changing Windows-specific code, run `cargo check` with a Windows GNU target (unless currently running on Windows).
 - Releases are automated via release-plz: pushing to `main` opens a `repo: release` PR which auto-merges and publishes to crates.io. No manual release step is needed.
 - It's very important for alertd that postgres (or anything else we're checking) IS NOT REQUIRED for the alertd daemon to start, because otherwise we CANNOT ALERT ON THE DATABASE BEING DOWN.
+- When writing or changing specs in `.workhorse/specs/`, follow the spec rules in [.workhorse/rules.md](.workhorse/rules.md).
 <!-- end rules -->


### PR DESCRIPTION
🤖 Adds `.workhorse/rules.md` with the rules for writing specs in `.workhorse/specs/`, adapted from the seedling repo's conventions, and references it from `AGENTS.md`.

Covers:
- **What, not how** — specs describe what the system requires, not implementation choices (tool/crate names, syscalls, internal APIs, impl-only env vars stay out); interface contracts external actors depend on stay in. The re-implementation test for deciding.
- **Present, not past** — no "supersedes X", "formerly Y", "a spike settled Z", or migration narration; edit to the new reality and delete the old text.
- **Own behaviour, not a dependency's internals** — and no plan-scaffolding labels in spec prose.
- **Workflow** — spec first, then implement, then tests.

seedling's tracey-annotation rules are omitted — this repo doesn't use tracey.
