### PR TITLE
feat(canopy): run backups via the alertd daemon, with attach and live status

### DIFF
--- a/.workhorse/specs/canopy/backup.md
+++ b/.workhorse/specs/canopy/backup.md
@@ -33,7 +33,7 @@ When the device is not yet authorised for backups — not bound to a live server
 
 ## Taking a backup
 
-`bestool canopy backup --type <type>` drives one run, and is also what the daemon invokes in-process when Canopy asks for a backup. A run:
+A backup run goes through one driver, whether Canopy triggers it through the daemon or an operator runs `bestool canopy backup --type <type>`. A run:
 
 1. mints a run id (which becomes the report's run id and the `canopy-run` snapshot tag) and resolves the definition for the type, failing fast without touching the network if no definition exists;
 2. takes an exclusive per-type lock for the whole run, so a second run for the same type — a re-emitted request, or a manual run racing the daemon — no-ops rather than starting a concurrent kopia. The lock lives in a runtime directory and is released by the OS if the process dies;
@@ -61,7 +61,7 @@ When run under the bestool-alertd daemon, the device registers its capabilities 
 
 Canopy decides when a server backs up. On each device-to-Canopy healthcheck tick, Canopy's response names the backup types the server should run right now (the union of operator one-offs and schedule-due types; empty means nothing to do). The daemon runs each named type's driver in-process, skipping any type whose previous run is still going. Reporting a run clears the corresponding one-off, so the heartbeat stops re-emitting it.
 
-A standalone `bestool canopy backup` run works without the daemon, for manual use or an external scheduler; it spawns its own ephemeral re-signing proxy for the run.
+`bestool canopy backup` prefers the running daemon: it asks the daemon to run the named type and streams the run's progress and outcome back, so a manual backup takes the same in-process path, environment, and per-type lock as a Canopy-triggered one, and a manual run cannot run concurrently with a scheduled one. When no daemon is reachable, or `--no-daemon` is given, the command runs the backup itself. The run is identical either way; only the process hosting it differs.
 
 ## The postgresql method
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7424,6 +7424,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -34,7 +34,7 @@ sysinfo.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-serde_json-1"] }
 tokio-rustls = "0.26.4"
-tokio-stream = "0.1.17"
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = { workspace = true }
 url = { version = "2.5.8", features = ["serde"] }

--- a/crates/alertd/src/backup.rs
+++ b/crates/alertd/src/backup.rs
@@ -44,7 +44,7 @@ struct RunHandle {
 }
 
 /// One in-flight backup, for the daemon's status.
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct RunningBackup {
 	pub r#type: String,
 	pub run_id: Option<String>,

--- a/crates/alertd/src/backup.rs
+++ b/crates/alertd/src/backup.rs
@@ -1,0 +1,284 @@
+//! Backup run registry and the on-demand `run` endpoint.
+//!
+//! A backup of a given type runs at most once at a time inside the daemon.
+//! [`BackupRegistry::ensure_run`] is start-or-attach: it starts a run via the
+//! injected [`BackupRunner`] when the type is idle, or hands back a subscription
+//! to the in-flight run otherwise. A subscriber sees a replay of the latest
+//! status, then live status events and a periodic heartbeat, then the run's
+//! terminal event. [`BackupRegistry::running`] lists in-flight runs for the
+//! daemon's status.
+//!
+//! The actual backup driver lives in the bestool binary; it's injected here as a
+//! [`BackupRunner`] so this crate carries no backup logic of its own.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
+use jiff::Timestamp;
+use miette::Result;
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::{
+	BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse, tasks::TaskEndpointHandler,
+};
+
+/// Runs one backup of `backup_type`, emitting JSON status events into the sink
+/// and resolving when the run finishes. Injected by the binary that owns the
+/// backup driver. The runner must emit a terminal `done`/`error` event before it
+/// returns, so attached clients always see an end.
+pub type BackupRunner = Arc<
+	dyn Fn(String, mpsc::UnboundedSender<Value>) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+>;
+
+const HEARTBEAT: Duration = Duration::from_secs(5);
+const BROADCAST_CAPACITY: usize = 256;
+
+struct RunHandle {
+	started_at: Timestamp,
+	run_id: Mutex<Option<String>>,
+	/// Most recent status event, replayed to a late attacher so it isn't blank.
+	latest: Mutex<Value>,
+	events: broadcast::Sender<Value>,
+}
+
+/// One in-flight backup, for the daemon's status.
+#[derive(Clone, serde::Serialize)]
+pub struct RunningBackup {
+	pub r#type: String,
+	pub run_id: Option<String>,
+	pub started_at: String,
+	pub latest: Value,
+}
+
+/// Tracks in-flight backup runs and fans their status out to subscribers.
+pub struct BackupRegistry {
+	runner: BackupRunner,
+	running: Mutex<HashMap<String, Arc<RunHandle>>>,
+}
+
+impl BackupRegistry {
+	pub fn new(runner: BackupRunner) -> Arc<Self> {
+		Arc::new(Self {
+			runner,
+			running: Mutex::new(HashMap::new()),
+		})
+	}
+
+	/// Start a run for `backup_type`, or attach to the one already in flight.
+	/// Returns a stream of JSON status events ending with the terminal event.
+	pub async fn ensure_run(self: &Arc<Self>, backup_type: String) -> BoxStream<'static, Value> {
+		let mut running = self.running.lock().await;
+
+		if let Some(handle) = running.get(&backup_type) {
+			let attached = json!({
+				"event": "attached",
+				"runId": *handle.run_id.lock().await,
+				"startedAt": handle.started_at.to_string(),
+				"latest": *handle.latest.lock().await,
+			});
+			return subscription(Some(attached), handle.events.subscribe());
+		}
+
+		let (events, receiver) = broadcast::channel(BROADCAST_CAPACITY);
+		let handle = Arc::new(RunHandle {
+			started_at: Timestamp::now(),
+			run_id: Mutex::new(None),
+			latest: Mutex::new(json!({ "event": "starting" })),
+			events: events.clone(),
+		});
+		running.insert(backup_type.clone(), handle.clone());
+		drop(running);
+
+		let (sink, run_rx) = mpsc::unbounded_channel::<Value>();
+		let runner = (self.runner)(backup_type.clone(), sink);
+		let registry = self.clone();
+		tokio::spawn(async move {
+			tokio::spawn(runner);
+			registry.pump(backup_type, handle, run_rx, events).await;
+		});
+
+		subscription(None, receiver)
+	}
+
+	/// Drain the runner's events into the broadcast (updating the handle's
+	/// latest/run id), emitting a heartbeat between events, until the runner
+	/// finishes; then deregister the type.
+	async fn pump(
+		self: Arc<Self>,
+		backup_type: String,
+		handle: Arc<RunHandle>,
+		mut run_rx: mpsc::UnboundedReceiver<Value>,
+		events: broadcast::Sender<Value>,
+	) {
+		let mut heartbeat = tokio::time::interval(HEARTBEAT);
+		heartbeat.tick().await; // the first tick is immediate; skip it
+		loop {
+			tokio::select! {
+				message = run_rx.recv() => match message {
+					Some(event) => {
+						if let Some(id) = event.get("runId").and_then(Value::as_str) {
+							*handle.run_id.lock().await = Some(id.to_owned());
+						}
+						*handle.latest.lock().await = event.clone();
+						let _ = events.send(event);
+					}
+					None => break, // runner finished
+				},
+				_ = heartbeat.tick() => {
+					let _ = events.send(json!({ "event": "heartbeat" }));
+				}
+			}
+		}
+		self.running.lock().await.remove(&backup_type);
+		// `events` drops here, closing subscribers after the terminal event.
+	}
+
+	/// In-flight runs, for the status endpoint.
+	pub async fn running(&self) -> Vec<RunningBackup> {
+		let map = self.running.lock().await;
+		let mut out = Vec::with_capacity(map.len());
+		for (backup_type, handle) in map.iter() {
+			out.push(RunningBackup {
+				r#type: backup_type.clone(),
+				run_id: handle.run_id.lock().await.clone(),
+				started_at: handle.started_at.to_string(),
+				latest: handle.latest.lock().await.clone(),
+			});
+		}
+		out
+	}
+}
+
+fn subscription(
+	replay: Option<Value>,
+	receiver: broadcast::Receiver<Value>,
+) -> BoxStream<'static, Value> {
+	// Drop lagged markers; end the stream when the broadcast closes.
+	let live = BroadcastStream::new(receiver).filter_map(|item| async move { item.ok() });
+	match replay {
+		Some(value) => futures::stream::once(async move { value })
+			.chain(live)
+			.boxed(),
+		None => live.boxed(),
+	}
+}
+
+/// Exposes `GET /tasks/backup/run?type=X` (start-or-attach, streaming status)
+/// and `GET /tasks/backup/running` (in-flight runs). Holds no periodic work; the
+/// registry drives runs on demand.
+pub struct BackupTask {
+	registry: Arc<BackupRegistry>,
+}
+
+impl BackupTask {
+	pub fn new(registry: Arc<BackupRegistry>) -> Self {
+		Self { registry }
+	}
+}
+
+impl BackgroundTask for BackupTask {
+	fn name(&self) -> &'static str {
+		"backup"
+	}
+
+	fn interval(&self) -> Duration {
+		// On-demand only; no periodic work. A long interval keeps the watchdog
+		// from treating idleness as a hang.
+		Duration::from_secs(3600)
+	}
+
+	fn run<'a>(&'a self, _ctx: &'a TaskContext) -> BoxFuture<'a, Result<()>> {
+		Box::pin(async { Ok(()) })
+	}
+
+	fn http_endpoints(&self) -> Vec<TaskEndpoint> {
+		let run_handler: TaskEndpointHandler = {
+			let registry = self.registry.clone();
+			Arc::new(move |ctx| {
+				let registry = registry.clone();
+				Box::pin(async move {
+					let Some(backup_type) = ctx.query.get("type").cloned() else {
+						return TaskEndpointResponse::Error {
+							status: 400,
+							message: "missing ?type= query parameter".into(),
+						};
+					};
+					TaskEndpointResponse::JsonLines(registry.ensure_run(backup_type).await)
+				})
+			})
+		};
+
+		let running_handler: TaskEndpointHandler = {
+			let registry = self.registry.clone();
+			Arc::new(move |_ctx| {
+				let registry = registry.clone();
+				Box::pin(async move {
+					TaskEndpointResponse::Json(json!({ "running": registry.running().await }))
+				})
+			})
+		};
+
+		vec![
+			TaskEndpoint {
+				name: "run",
+				handler: run_handler,
+			},
+			TaskEndpoint {
+				name: "running",
+				handler: running_handler,
+			},
+		]
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use tokio::sync::Notify;
+
+	use super::*;
+
+	fn event(value: &Value) -> String {
+		value
+			.get("event")
+			.and_then(Value::as_str)
+			.unwrap_or_default()
+			.to_owned()
+	}
+
+	#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+	async fn start_then_attach_then_finish() {
+		// A runner that announces, waits for the gate, then finishes — so a
+		// second request can attach while it's in flight.
+		let gate = Arc::new(Notify::new());
+		let runner: BackupRunner = {
+			let gate = gate.clone();
+			Arc::new(move |_type, sink: mpsc::UnboundedSender<Value>| {
+				let gate = gate.clone();
+				Box::pin(async move {
+					let _ = sink.send(json!({ "event": "started", "runId": "r1" }));
+					gate.notified().await;
+					let _ = sink.send(json!({ "event": "done", "success": true }));
+				})
+			})
+		};
+		let registry = BackupRegistry::new(runner);
+
+		let mut starter = registry.ensure_run("pg".into()).await;
+		assert_eq!(event(&starter.next().await.unwrap()), "started");
+
+		// A second request for the same type attaches rather than starting a
+		// second run.
+		let mut attacher = registry.ensure_run("pg".into()).await;
+		assert_eq!(event(&attacher.next().await.unwrap()), "attached");
+		assert_eq!(registry.running().await.len(), 1);
+
+		// Release the run; both subscribers see the terminal event and end.
+		gate.notify_one();
+		let starter_events: Vec<String> = starter.map(|v| event(&v)).collect().await;
+		assert!(starter_events.contains(&"done".to_owned()));
+		let attacher_events: Vec<String> = attacher.map(|v| event(&v)).collect().await;
+		assert!(attacher_events.contains(&"done".to_owned()));
+	}
+}

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -136,6 +136,7 @@ pub async fn run_with_shutdown(
 		let background_tasks_for_server = daemon_config.background_tasks.clone();
 		let server_addrs = daemon_config.server_addrs.clone();
 		let watchdog_timeout = daemon_config.watchdog_timeout;
+		let backups = daemon_config.backups.clone();
 		tokio::spawn(async move {
 			http_server::start_server(
 				ctx_for_server,
@@ -143,6 +144,7 @@ pub async fn run_with_shutdown(
 				watchdog_timeout,
 				&background_tasks_for_server,
 				control,
+				backups,
 			)
 			.await;
 		});

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -32,6 +32,7 @@ pub async fn start_server(
 	watchdog_timeout: Option<Duration>,
 	background_tasks: &[Arc<dyn BackgroundTask>],
 	control: DaemonControl,
+	backups: Option<Arc<crate::BackupRegistry>>,
 ) {
 	let started_at = Timestamp::now();
 	let pid = std::process::id();
@@ -45,6 +46,7 @@ pub async fn start_server(
 		watchdog_timeout,
 		task_endpoints: Arc::new(task_endpoints),
 		control,
+		backups,
 	};
 
 	let app = Router::new()

--- a/crates/alertd/src/http_server/endpoints/status.rs
+++ b/crates/alertd/src/http_server/endpoints/status.rs
@@ -5,11 +5,16 @@ use axum::{Json, extract::State, response::IntoResponse};
 use crate::http_server::{state::ServerState, types::StatusResponse};
 
 pub async fn handle_status(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
+	let backups_running = match &state.backups {
+		Some(registry) => registry.running().await,
+		None => Vec::new(),
+	};
 	let status = StatusResponse {
 		name: "bestool-alertd".to_string(),
 		version: env!("CARGO_PKG_VERSION").to_string(),
 		started_at: state.started_at.to_string(),
 		pid: state.pid,
+		backups_running,
 	};
 	Json(status)
 }

--- a/crates/alertd/src/http_server/endpoints/tasks.rs
+++ b/crates/alertd/src/http_server/endpoints/tasks.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use axum::{
 	Json,
 	body::Body,
-	extract::{Path, State},
+	extract::{Path, Query, State},
 	http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
 	response::{IntoResponse, Response},
 };
@@ -25,6 +25,7 @@ use crate::{
 pub async fn handle_task_endpoint(
 	State(state): State<Arc<ServerState>>,
 	Path((task, endpoint)): Path<(String, String)>,
+	Query(query): Query<BTreeMap<String, String>>,
 ) -> Response {
 	let Some(handler) = state.task_endpoints.get(&(task.clone(), endpoint.clone())) else {
 		return (
@@ -34,7 +35,8 @@ pub async fn handle_task_endpoint(
 			.into_response();
 	};
 
-	let ctx = TaskContext::from_internal(&state.internal_context);
+	let mut ctx = TaskContext::from_internal(&state.internal_context);
+	ctx.query = query;
 	let response = handler(ctx).await;
 
 	match response {

--- a/crates/alertd/src/http_server/state.rs
+++ b/crates/alertd/src/http_server/state.rs
@@ -16,4 +16,7 @@ pub struct ServerState {
 	pub task_endpoints: Arc<HashMap<(String, String), TaskEndpointHandler>>,
 	/// Drives the daemon's `/reload` and `/restart` control endpoints.
 	pub control: DaemonControl,
+	/// Backup run registry, when backups are compiled in; lets `/status` list
+	/// in-flight runs.
+	pub backups: Option<Arc<crate::BackupRegistry>>,
 }

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -25,5 +25,6 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		watchdog_timeout: Some(std::time::Duration::from_secs(600)),
 		task_endpoints: Arc::new(HashMap::new()),
 		control: crate::daemon::DaemonControl::detached(),
+		backups: None,
 	})
 }

--- a/crates/alertd/src/http_server/types.rs
+++ b/crates/alertd/src/http_server/types.rs
@@ -6,4 +6,8 @@ pub struct StatusResponse {
 	pub version: String,
 	pub started_at: String,
 	pub pid: u32,
+	/// Backups running on this daemon right now (empty when none, or when
+	/// backups aren't compiled in).
+	#[serde(default)]
+	pub backups_running: Vec<crate::RunningBackup>,
 }

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -3,6 +3,7 @@ use std::{fmt, sync::Arc, time::Duration};
 pub use bestool_canopy as canopy;
 pub use bestool_canopy::Redacted;
 
+pub mod backup;
 pub mod commands;
 mod context;
 mod daemon;
@@ -14,6 +15,7 @@ pub mod tasks;
 #[cfg(windows)]
 pub mod windows_service;
 
+pub use backup::{BackupRegistry, BackupRunner, BackupTask, RunningBackup};
 pub use context::InternalContext;
 pub use daemon::{run, run_with_shutdown};
 pub use tasks::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -82,6 +82,10 @@ pub struct DaemonConfig {
 	/// Each task ticks at its own `interval()`. Errors are logged but do not
 	/// kill the daemon. Activity from each tick counts towards the watchdog.
 	pub background_tasks: Vec<Arc<dyn BackgroundTask>>,
+
+	/// Backup run registry, set when backups are compiled in. Surfaced via the
+	/// daemon's status so an operator can see what's backing up right now.
+	pub backups: Option<Arc<BackupRegistry>>,
 }
 
 impl fmt::Debug for DaemonConfig {
@@ -120,11 +124,18 @@ impl DaemonConfig {
 			server_addrs: Vec::new(),
 			watchdog_timeout: Some(Duration::from_secs(10 * 60)),
 			background_tasks: Vec::new(),
+			backups: None,
 		}
 	}
 
 	pub fn with_task(mut self, task: Arc<dyn BackgroundTask>) -> Self {
 		self.background_tasks.push(task);
+		self
+	}
+
+	/// Attach the backup registry, so the daemon's status can list in-flight runs.
+	pub fn with_backups(mut self, registry: Arc<BackupRegistry>) -> Self {
+		self.backups = Some(registry);
 		self
 	}
 

--- a/crates/alertd/src/tasks.rs
+++ b/crates/alertd/src/tasks.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use futures::{future::BoxFuture, stream::BoxStream};
 use miette::Result;
@@ -19,6 +19,9 @@ pub struct TaskContext {
 	/// Bumped on each reload request (SIGHUP/SIGUSR1); a task can
 	/// `reload.changed().await` to refresh its state without a restart.
 	pub reload: tokio::sync::watch::Receiver<u64>,
+	/// Query parameters of the request, for HTTP endpoint handlers. Empty on the
+	/// periodic `run` tick.
+	pub query: BTreeMap<String, String>,
 }
 
 impl TaskContext {
@@ -28,6 +31,7 @@ impl TaskContext {
 			http_client: ctx.http_client.clone(),
 			canopy_client: ctx.canopy_client.clone(),
 			reload: ctx.reload.clone(),
+			query: BTreeMap::new(),
 		}
 	}
 }

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -442,6 +442,9 @@ Run a configured backup, driving kopia and reporting to Canopy
    Must have a definition in the backups directory (a `*.toml` whose `type` matches).
 * `--config <DIR>` — Override the registration directory (matching `register`/`export`)
 * `--backups-dir <DIR>` — Override the backups definition directory
+* `--no-daemon` — Run the backup in this process instead of delegating to the alertd daemon.
+
+   By default, when the daemon is running, the backup is run by it and its progress is streamed here; this forces a local run.
 
 
 

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -201,51 +201,113 @@ fn doctor_task(
 	version: String,
 	tamanu: Option<bestool_alertd::doctor::SweepTamanu>,
 ) -> DoctorTask {
-	let task = DoctorTask::new(version, tamanu);
-	#[cfg(feature = "canopy-backup")]
-	let task = task.with_backup_dispatch(backup_dispatch());
-	task
+	DoctorTask::new(version, tamanu)
 }
 
-/// Register the daemon's tasks, adding the backup-capabilities task when backups
-/// are compiled in.
+/// Register the daemon's tasks. When backups are compiled in, this creates the
+/// backup registry once and shares it: the doctor task's canopy-trigger dispatch
+/// and the `backup` task (its `run`/`running` endpoints) drive the same runs.
 fn with_daemon_tasks(
 	config: bestool_alertd::DaemonConfig,
 	doctor: DoctorTask,
 ) -> bestool_alertd::DaemonConfig {
+	#[cfg(feature = "canopy-backup")]
+	let (config, doctor) = {
+		let registry = bestool_alertd::BackupRegistry::new(backup_runner());
+		let doctor = doctor.with_backup_dispatch(backup_dispatch(registry.clone()));
+		let config = config.with_task(Arc::new(bestool_alertd::BackupTask::new(registry)));
+		(config, doctor)
+	};
+
 	let config = config.with_task(Arc::new(doctor));
 	#[cfg(feature = "canopy-backup")]
 	let config = config.with_task(Arc::new(backup::BackupCapabilitiesTask));
 	config
 }
 
-/// The in-process backup trigger: runs the driver for each type canopy requests
-/// via `backup_now`, skipping any type already in flight.
+/// The in-process backup trigger: routes each type canopy requests via
+/// `backup_now` through the registry (which starts a run, or no-ops onto the one
+/// already in flight), draining the status stream — the run reports to canopy
+/// itself.
 #[cfg(feature = "canopy-backup")]
-fn backup_dispatch() -> bestool_alertd::doctor::BackupDispatch {
-	use std::collections::HashSet;
+fn backup_dispatch(
+	registry: Arc<bestool_alertd::BackupRegistry>,
+) -> bestool_alertd::doctor::BackupDispatch {
+	use futures::StreamExt as _;
 
-	use tokio::sync::Mutex;
-
-	let in_flight = Arc::new(Mutex::new(HashSet::<String>::new()));
 	Arc::new(move |types: Vec<String>| {
 		for backup_type in types {
-			let in_flight = in_flight.clone();
+			let registry = registry.clone();
 			tokio::spawn(async move {
-				// Overlap guard: skip a type whose previous run is still going
-				// (canopy re-emits idempotently until the report clears it).
-				if !in_flight.lock().await.insert(backup_type.clone()) {
-					return;
-				}
-				if let Err(err) =
-					crate::actions::canopy::backup::run_backup(&backup_type, None, None, None).await
-				{
-					tracing::error!("backup '{backup_type}' failed: {err}");
-				}
-				in_flight.lock().await.remove(&backup_type);
+				let mut stream = registry.ensure_run(backup_type).await;
+				while stream.next().await.is_some() {}
 			});
 		}
 	})
+}
+
+/// Builds the registry's runner: drives [`run_backup`] with a sink, mapping its
+/// [`BackupEvent`]s to JSON status lines and guaranteeing a terminal event.
+///
+/// [`run_backup`]: crate::actions::canopy::backup::run_backup
+/// [`BackupEvent`]: crate::actions::canopy::backup::BackupEvent
+#[cfg(feature = "canopy-backup")]
+fn backup_runner() -> bestool_alertd::BackupRunner {
+	use serde_json::{Value, json};
+	use tokio::sync::mpsc;
+
+	use crate::actions::canopy::backup::{BackupEvent, run_backup};
+
+	fn to_json(event: BackupEvent) -> Value {
+		match event {
+			BackupEvent::Started { run_id } => json!({"event": "started", "runId": run_id}),
+			BackupEvent::Phase(phase) => json!({"event": "phase", "phase": phase}),
+			BackupEvent::Done {
+				snapshot_id,
+				bytes_uploaded,
+			} => json!({
+				"event": "done", "success": true,
+				"snapshotId": snapshot_id, "uploadedBytes": bytes_uploaded,
+			}),
+			BackupEvent::Failed { error } => {
+				json!({"event": "error", "success": false, "message": error})
+			}
+		}
+	}
+
+	Arc::new(
+		move |backup_type: String,
+		      out: mpsc::UnboundedSender<Value>|
+		      -> futures::future::BoxFuture<'static, ()> {
+			Box::pin(async move {
+				let (tx, mut rx) = mpsc::unbounded_channel::<BackupEvent>();
+				let run =
+					tokio::spawn(async move { run_backup(&backup_type, None, None, Some(tx)).await });
+
+				let mut terminal = false;
+				while let Some(event) = rx.recv().await {
+					terminal |= matches!(event, BackupEvent::Done { .. } | BackupEvent::Failed { .. });
+					let _ = out.send(to_json(event));
+				}
+
+				// run_backup has returned (its sink dropped). Guarantee a
+				// terminal event for any early-exit path that emitted none.
+				if !terminal {
+					let event = match run.await {
+						Ok(Ok(())) => json!({"event": "done", "success": true}),
+						Ok(Err(err)) => {
+							json!({"event": "error", "success": false, "message": format!("{err}")})
+						}
+						Err(join) => json!({
+							"event": "error", "success": false,
+							"message": format!("backup task aborted: {join}"),
+						}),
+					};
+					let _ = out.send(event);
+				}
+			})
+		},
+	)
 }
 
 /// A background task that registers this server's backup capabilities with

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -238,7 +238,7 @@ fn backup_dispatch() -> bestool_alertd::doctor::BackupDispatch {
 					return;
 				}
 				if let Err(err) =
-					crate::actions::canopy::backup::run_backup(&backup_type, None, None).await
+					crate::actions::canopy::backup::run_backup(&backup_type, None, None, None).await
 				{
 					tracing::error!("backup '{backup_type}' failed: {err}");
 				}

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -215,7 +215,9 @@ fn with_daemon_tasks(
 	let (config, doctor) = {
 		let registry = bestool_alertd::BackupRegistry::new(backup_runner());
 		let doctor = doctor.with_backup_dispatch(backup_dispatch(registry.clone()));
-		let config = config.with_task(Arc::new(bestool_alertd::BackupTask::new(registry)));
+		let config = config
+			.with_backups(registry.clone())
+			.with_task(Arc::new(bestool_alertd::BackupTask::new(registry)));
 		(config, doctor)
 	};
 

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -62,6 +62,7 @@ pub async fn run(args: BackupArgs, _ctx: Context) -> Result<()> {
 		&args.backup_type,
 		args.config.as_deref(),
 		args.backups_dir.as_deref(),
+		None,
 	)
 	.await
 }
@@ -71,6 +72,37 @@ pub async fn run(args: BackupArgs, _ctx: Context) -> Result<()> {
 struct SnapshotResult {
 	id: Option<String>,
 	bytes_uploaded: Option<i64>,
+}
+
+/// A status event emitted by [`run_backup`] when it's given a progress sink, so
+/// the daemon's backup task can stream a run's progress to an attached client.
+#[derive(Debug, Clone)]
+#[expect(
+	dead_code,
+	reason = "fields are read by the daemon backup task added later in this stack"
+)]
+pub enum BackupEvent {
+	/// The run acquired its per-type lock and started.
+	Started { run_id: String },
+	/// Entered a named phase: `prepare`, `snapshot`, or `report`.
+	Phase(&'static str),
+	/// The run finished successfully.
+	Done {
+		snapshot_id: Option<String>,
+		bytes_uploaded: Option<i64>,
+	},
+	/// The run failed.
+	Failed { error: String },
+}
+
+/// Sink for [`BackupEvent`]s. Unbounded so emitting never blocks the run on a
+/// slow consumer; events are best-effort and dropped once the receiver is gone.
+pub type BackupProgress = tokio::sync::mpsc::UnboundedSender<BackupEvent>;
+
+fn emit(sink: &Option<BackupProgress>, event: BackupEvent) {
+	if let Some(tx) = sink {
+		let _ = tx.send(event);
+	}
 }
 
 /// Connection details for a kopia run: the loopback proxy endpoint and the repo
@@ -139,6 +171,7 @@ pub async fn run_backup(
 	backup_type: &str,
 	registration_dir: Option<&Path>,
 	backups_dir: Option<&Path>,
+	progress: Option<BackupProgress>,
 ) -> Result<()> {
 	let run_id = Uuid::new_v4().to_string();
 
@@ -160,6 +193,7 @@ pub async fn run_backup(
 		return Ok(());
 	};
 	info!(backup_type, method = def.method.name(), %run_id, "starting backup");
+	emit(&progress, BackupEvent::Started { run_id: run_id.clone() });
 
 	let reg = load_registration(registration_dir)
 		.await?
@@ -204,7 +238,9 @@ pub async fn run_backup(
 		endpoint: proxy.endpoint(),
 		password: target.repo_password.0.clone(),
 	};
-	let outcome = run_kopia_backup(&def, &target, &conn, &server_id, &device_id, &run_id).await;
+	let outcome =
+		run_kopia_backup(&def, &target, &conn, &server_id, &device_id, &run_id, &progress).await;
+	emit(&progress, BackupEvent::Phase("report"));
 
 	// Report whatever happened, then surface the original error (if any).
 	let report = match &outcome {
@@ -232,6 +268,17 @@ pub async fn run_backup(
 		.await
 		.wrap_err("reporting backup outcome to canopy")?;
 
+	match &outcome {
+		Ok(snapshot) => emit(
+			&progress,
+			BackupEvent::Done {
+				snapshot_id: snapshot.id.clone(),
+				bytes_uploaded: snapshot.bytes_uploaded,
+			},
+		),
+		Err(err) => emit(&progress, BackupEvent::Failed { error: trim_error(err) }),
+	}
+
 	outcome.map(|_| ())
 }
 
@@ -246,13 +293,16 @@ async fn run_kopia_backup(
 	server_id: &str,
 	device_id: &str,
 	run_id: &str,
+	progress: &Option<BackupProgress>,
 ) -> Result<SnapshotResult> {
 	run_hooks(&def.pre, true).await?;
 
+	emit(progress, BackupEvent::Phase("prepare"));
 	let prepared = def.method.prepare(&def.r#type).await?;
 	let source_path = prepared.path.clone();
 	let tags = assemble_tags(&def.tags, &prepared.extra_tags, device_id, run_id, &def.r#type);
 
+	emit(progress, BackupEvent::Phase("snapshot"));
 	let result = snapshot(target, conn, &source_path, server_id, &tags, &prepared.ignore).await;
 
 	// Cleanup and post-hooks run regardless of the snapshot outcome.

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -55,16 +55,131 @@ pub struct BackupArgs {
 	/// Override the backups definition directory.
 	#[arg(long, value_name = "DIR")]
 	pub backups_dir: Option<std::path::PathBuf>,
+
+	/// Run the backup in this process instead of delegating to the alertd daemon.
+	///
+	/// By default, when the daemon is running, the backup is run by it and its
+	/// progress is streamed here; this forces a local run.
+	#[arg(long)]
+	pub no_daemon: bool,
 }
 
 pub async fn run(args: BackupArgs, _ctx: Context) -> Result<()> {
-	run_backup(
-		&args.backup_type,
-		args.config.as_deref(),
-		args.backups_dir.as_deref(),
-		None,
-	)
-	.await
+	let run_local = || {
+		run_backup(
+			&args.backup_type,
+			args.config.as_deref(),
+			args.backups_dir.as_deref(),
+			None,
+		)
+	};
+
+	if args.no_daemon {
+		return run_local().await;
+	}
+
+	match run_via_daemon(&args.backup_type).await {
+		Ok(()) => Ok(()),
+		Err(DaemonError::Failed(message)) => bail!("backup failed: {message}"),
+		Err(DaemonError::Unreachable(err)) => {
+			info!(%err, "alertd daemon not reachable; running the backup locally");
+			run_local().await
+		}
+	}
+}
+
+/// Why a delegated run didn't yield a clean success.
+enum DaemonError {
+	/// The daemon couldn't be reached (or doesn't expose the endpoint); the
+	/// caller should run locally.
+	Unreachable(String),
+	/// The daemon ran the backup and it failed, or the stream was lost mid-run.
+	Failed(String),
+}
+
+const DAEMON_BASE: &str = "http://127.0.0.1:8271";
+
+/// Ask the running daemon to run the backup (starting a run or attaching to one
+/// already in flight) and render its streamed status. Returns `Unreachable` if
+/// the daemon isn't there, so the caller can fall back to a local run.
+async fn run_via_daemon(backup_type: &str) -> std::result::Result<(), DaemonError> {
+	use futures::StreamExt as _;
+
+	let url = format!("{DAEMON_BASE}/tasks/backup/run?type={backup_type}");
+	let response = crate::http::client()
+		.get(&url)
+		.send()
+		.await
+		.map_err(|err| DaemonError::Unreachable(err.to_string()))?;
+	if !response.status().is_success() {
+		return Err(DaemonError::Unreachable(format!(
+			"alertd returned {}",
+			response.status()
+		)));
+	}
+
+	let mut stream = response.bytes_stream();
+	let mut buffer = Vec::<u8>::new();
+	let mut terminal: Option<std::result::Result<(), String>> = None;
+	while let Some(chunk) = stream.next().await {
+		let chunk = chunk.map_err(|err| DaemonError::Failed(format!("daemon stream: {err}")))?;
+		buffer.extend_from_slice(&chunk);
+		while let Some(nl) = buffer.iter().position(|&b| b == b'\n') {
+			let line: Vec<u8> = buffer.drain(..=nl).collect();
+			let Ok(event) = serde_json::from_slice::<serde_json::Value>(&line) else {
+				continue;
+			};
+			if let Some(outcome) = render_daemon_event(backup_type, &event) {
+				terminal = Some(outcome);
+			}
+		}
+	}
+
+	match terminal {
+		Some(Ok(())) => Ok(()),
+		Some(Err(message)) => Err(DaemonError::Failed(message)),
+		None => Err(DaemonError::Failed(
+			"lost the connection to the daemon; the backup may still be running".into(),
+		)),
+	}
+}
+
+/// Render one streamed status event; returns `Some` for a terminal event.
+fn render_daemon_event(
+	backup_type: &str,
+	event: &serde_json::Value,
+) -> Option<std::result::Result<(), String>> {
+	let field = |key| event.get(key).and_then(serde_json::Value::as_str);
+	match field("event") {
+		Some("started") => {
+			info!(backup_type, run_id = field("runId"), "daemon started the backup");
+			None
+		}
+		Some("attached") => {
+			info!(
+				backup_type,
+				run_id = field("runId"),
+				started_at = field("startedAt"),
+				"attached to a backup already running on the daemon"
+			);
+			None
+		}
+		Some("phase") => {
+			info!(backup_type, phase = field("phase"), "backup phase");
+			None
+		}
+		Some("heartbeat") => None,
+		Some("done") => {
+			info!(
+				backup_type,
+				snapshot_id = field("snapshotId"),
+				"daemon finished the backup"
+			);
+			Some(Ok(()))
+		}
+		Some("error") => Some(Err(field("message").unwrap_or("unknown error").to_owned())),
+		_ => None,
+	}
 }
 
 /// Parsed bits of a finished kopia `snapshot create --json` we report to Canopy.
@@ -77,10 +192,6 @@ struct SnapshotResult {
 /// A status event emitted by [`run_backup`] when it's given a progress sink, so
 /// the daemon's backup task can stream a run's progress to an attached client.
 #[derive(Debug, Clone)]
-#[expect(
-	dead_code,
-	reason = "fields are read by the daemon backup task added later in this stack"
-)]
 pub enum BackupEvent {
 	/// The run acquired its per-type lock and started.
 	Started { run_id: String },

--- a/docs/plans/canopy-backup-daemon.md
+++ b/docs/plans/canopy-backup-daemon.md
@@ -1,0 +1,159 @@
+# canopy backup via the alertd daemon
+
+Implements the delegation behaviour added to [BAK](../../.workhorse/specs/canopy/backup.md):
+`bestool canopy backup` prefers the running daemon, streaming the run's progress
+and outcome back, and falls back to running locally when no daemon is reachable
+or `--no-daemon` is given. Mirrors how `bestool tamanu doctor` integrates with
+the daemon. Restore stays local. Shape: stream live status, attach to an
+in-progress run rather than failing or queueing, and surface running runs in the
+daemon's status.
+
+## Context
+
+- The daemon (`bestool-alertd`) serves loopback HTTP on `:8271`
+  (`crates/alertd/src/http_server.rs`): a generic task dispatch
+  `GET /tasks/{task}/{endpoint}` returning `TaskEndpointResponse::{Json,
+  JsonLines(BoxStream<Value>), Error}`, plus `/status`.
+- `tamanu doctor` already does daemon-or-local with `--no-daemon` and an NDJSON
+  stream, falling back to local on any daemon error
+  (`crates/bestool/src/actions/tamanu/doctor.rs`).
+- The daemon already runs backups in-process: `DoctorTask` calls an injected
+  `BackupDispatch` with Canopy's `backup_now` list;
+  `crates/bestool/src/actions/alertd.rs` wires it to
+  `canopy::backup::run_backup(&type, None, None)` under an overlap-guard HashSet.
+- `run_backup` (`crates/bestool/src/actions/canopy/backup.rs`) holds a
+  cross-process per-type file lock for the whole run.
+
+## Backup registry (daemon, the core new piece)
+
+A registry in the alertd crate, keyed by backup type, is the single way a backup
+runs inside the daemon — used by both the Canopy-triggered path and the CLI
+`run` endpoint. Each in-progress run holds:
+
+- run id, type, started-at, and the latest status event;
+- a `tokio::sync::broadcast` sender so any number of subscribers receive live
+  status.
+
+`ensure_run(type) -> Subscription` is start-or-attach: if the type isn't
+running, it starts a run (via an injected runner, below) and registers the
+handle; if it is, it returns a subscription to the existing run. A subscription
+first yields the latest known status (so a late attacher isn't blank), then live
+events, then the terminal event. The entry is removed when the run ends (keeping
+the terminal outcome briefly so in-flight subscribers see it). This replaces the
+overlap-guard HashSet: attaching, not failing or queueing, is the behaviour for a
+second request.
+
+The runner is injected from bestool (where `run_backup` lives):
+
+```rust
+// alertd-side
+type BackupRunner =
+    Arc<dyn Fn(String, mpsc::Sender<serde_json::Value>) -> BoxFuture<'static, ()> + Send + Sync>;
+```
+
+bestool's runner calls `run_backup(type, None, None, Some(sink))`, adapting
+`BackupEvent`s to JSON. The registry owns the fan-out and lifecycle; the runner
+just produces one run's event stream.
+
+## run_backup progress sink (phase status + heartbeat)
+
+`run_backup` gains `progress: Option<mpsc::Sender<BackupEvent>>` (`None`
+preserves today's behaviour). Events:
+
+```rust
+pub enum BackupEvent {
+    Started { run_id: String },
+    Phase(&'static str),   // connect, pre-hooks, prepare, snapshot, report
+    Done { snapshot_id: Option<String>, uploaded_bytes: Option<i64> },
+    Failed { error: String },
+}
+```
+
+`run_backup` already has the run id, the phase boundaries, the snapshot result
+(bytes/id), and the lock-skip path, so it emits these directly with no change to
+how kopia is invoked. The registry adds a periodic heartbeat into the broadcast
+so the connection stays alive during the long snapshot phase.
+
+Byte-level live progress is **not** in v1: verified that kopia emits no progress
+output when its stderr is not a TTY (the daemon's case) — only the opening
+"Snapshotting…" line. Surfacing live counters would mean running kopia under an
+allocated PTY and parsing its human progress line, which is fragile and platform-
+specific; deferred as a follow-up. Phase status + the final byte count is the
+status v1 streams.
+
+## `run` endpoint
+
+`GET /tasks/backup/run?type=X` → `ensure_run(type)` then stream the subscription
+as NDJSON, mirroring doctor's events:
+
+```json
+{"event":"started","runId":"…","attached":false}
+{"event":"phase","phase":"snapshot"}
+{"event":"heartbeat"}
+{"event":"done","success":true,"snapshotId":"…","uploadedBytes":123}
+{"event":"error","message":"…"}
+```
+
+`attached:true` on the first event tells the client it joined an already-running
+backup. The endpoint needs the `type` query parameter, which the dispatch
+doesn't currently pass to handlers — extend `TaskContext` with the request's
+query parameters (`BTreeMap<String,String>`), populated in
+`handle_task_endpoint`. Missing/unknown `type` → `Error{400}`.
+
+## Running backups in `/status`
+
+`/status` (`crates/alertd/src/http_server/endpoints/`) gains a `backups.running`
+list from the registry: type, run id, started-at, and latest phase/progress. So
+an operator (or a `bestool` status view) can see what's backing up right now.
+
+## CLI delegation
+
+`BackupArgs` gains `--no-daemon`. `run()`:
+
+- `--no-daemon` → `run_backup(type, …, None)` locally (today's path; no attach —
+  attach is a daemon-registry feature and can't cross processes);
+- otherwise `GET …/tasks/backup/run?type=X` (`127.0.0.1` and `[::1]`) with a
+  short connect timeout; on connect, stream NDJSON and render status/progress,
+  noting when it attached to an existing run, exiting by the terminal event;
+- on any connect/transport error, fall back to the local path.
+
+Reuse doctor's client helpers (`DAEMON_BASE`, the NDJSON line drain, the
+fall-back-on-error structure).
+
+## Unifying the Canopy-triggered path
+
+The existing `BackupDispatch` wiring routes through the registry's `ensure_run`
+too, so a Canopy-scheduled run and a CLI-initiated one share one run and one
+broadcast (the CLI attaches to a scheduled run already in flight, and vice
+versa), and both appear in `/status`.
+
+## Security / lifecycle
+
+Loopback-only, no auth — same as doctor and the control endpoints. The
+cross-process file lock still guards the daemon-vs-`--no-daemon` case; within the
+daemon the registry guarantees one run per type with attach.
+
+## Out of scope
+
+`bestool canopy restore` — operator-interactive (clobber confirmation), local.
+
+## Commit sequence
+
+1. `run_backup` progress sink: phase + terminal events, `None` preserves
+   behaviour; unit-test the event sequence.
+2. `TaskContext` query parameters.
+3. Registry (start-or-attach, broadcast, heartbeat, `running()`), `BackupRunner`
+   type, and the `backup` task with the `run` endpoint, in the alertd crate.
+4. `/status` running-backups list.
+5. bestool wiring: inject the `run_backup`-backed runner; route the Canopy
+   dispatch through the registry; register the task.
+6. CLI `--no-daemon` + daemon delegation with local fallback; `./update-usage.sh`.
+
+## Decisions (settled)
+
+- **Stream phase status + heartbeat**, not fire-and-report — a backup runs far
+  longer than a doctor sweep. Byte-level live progress is deferred (kopia emits
+  none without a TTY).
+- **Attach to an in-progress run** of the same type rather than failing or
+  queueing.
+- **Backup only**; restore stays local.


### PR DESCRIPTION
🤖 `bestool canopy backup` now prefers the running alertd daemon — it asks the daemon to run the backup and streams the run's status back — and falls back to running locally when the daemon is unreachable or `--no-daemon` is given. Mirrors how `bestool tamanu doctor` integrates with the daemon. Restore stays local (it's operator-interactive). Implements [BAK](.workhorse/specs/canopy/backup.md); see [the plan](docs/plans/canopy-backup-daemon.md).

## What's here

- **Backup run registry** in the daemon, keyed by type, with a broadcast fan-out. `ensure_run` is **start-or-attach**: a second request for a type already running *attaches* to it (replaying the latest status, then live events + heartbeat, then the terminal event) rather than failing or queueing. This unifies the Canopy-triggered path and the CLI path through one run, replacing the old overlap-guard.
- **Live status, not just a heartbeat**: `run_backup` gained a progress sink emitting phase events (connect → prepare → snapshot → report) and a terminal `done`/`error`; the daemon adds a heartbeat between events.
- **Running backups in `/status`** (and `GET /tasks/backup/running`): type, run id, started-at, and latest status for each in-flight run.
- **`GET /tasks/backup/run?type=X`** streams a run's status as NDJSON; `TaskContext` now carries request query params.
- **CLI**: `--no-daemon` forces a local run; otherwise it streams from the daemon, noting when it attached to a run already in flight, and falls back to local on any daemon error.

## Notes

- **Byte-level live progress is deferred.** Verified that kopia emits no progress output when its stderr isn't a TTY (the daemon's case), so live byte/file counters would need running kopia under an allocated PTY and parsing its human progress line — a follow-up. v1 streams phase status + heartbeat + the final byte count, which is real status beyond a heartbeat. The plan is left in place for that follow-up rather than unplanned.
- The registry's start-or-attach/lifecycle is unit-tested; the end-to-end device path (a live daemon + Canopy) isn't exercised in CI.
