### PR TITLE
docs(specs): document the backup def TOML shape

### DIFF
--- a/.workhorse/rules.md
+++ b/.workhorse/rules.md
@@ -1,45 +1,36 @@
 # Spec rules
 
-Specs live in `.workhorse/specs/<area>/<name>.md`. Each carries an `id` in its
-frontmatter (e.g. `BAK`, `S3P`) and is cross-referenced by linking the file
-under that id, e.g. `[BAK](backup.md)`.
+Specs live in `.workhorse/specs/<area>/<name>.md`.
+Each carries an `id` in its frontmatter (e.g. `BAK`, `S3P`) and is cross-referenced by linking the file under that id, e.g. `[BAK](backup.md)`.
 
-A spec is the durable description of **what** the system requires. It is read by
-someone deciding whether the implementation is correct, or re-implementing the
-feature from scratch — not as a narrative of how the code works or how it came
-to be.
+A spec is the durable description of **what** the system requires.
+It is read by someone deciding whether the implementation is correct, or re-implementing the feature from scratch — not as a narrative of how the code works or how it came to be.
+
+Specs are written in markdown prose with each sentence on its own line and no hard-wrapping.
+This balances ease of writing and diff parseability.
 
 ## What, not how
 
-- Describe **what** the system requires, not **how** the code achieves it. Keep
-  out of spec text: tool and command names (`sfdisk`, `kopia snapshot create`),
-  crate and library names, syscall names (`splice(2)`), internal API details,
-  data-structure choices, and environment variable names used only by the
-  implementation.
-- Acceptable, because external actors or other components depend on them:
-  interface contracts — config file paths and formats, on-disk and on-the-wire
-  shapes, endpoint shapes, partition UUIDs, credential scopes.
-- The test: would someone re-implementing the feature from scratch be
-  constrained to the same choice? If not, it's an implementation detail and
-  doesn't belong in the spec.
+- Describe **what** the system requires, not **how** the code achieves it.
+  Keep out of spec text: tool and command names (`sfdisk`, `kopia snapshot create`), crate and library names, syscall names (`splice(2)`), internal API details, data-structure choices, and environment variable names used only by the implementation.
+- Acceptable, because external actors or other components depend on them: interface contracts — config file paths and formats, on-disk and on-the-wire shapes, endpoint shapes, partition UUIDs, credential scopes.
+- The test: would someone re-implementing the feature from scratch be constrained to the same choice?
+  If not, it's an implementation detail and doesn't belong in the spec.
 
 ## Present, not past
 
-- State what the system does, not how it got there. No "this supersedes X",
-  "formerly Y", "a spike settled Z", changelog entries, or migration narration.
-- When something is removed or replaced, edit the spec to describe the new
-  reality and delete the old text, rather than describing the transition. The
-  git history is the record of change; the spec is the record of the present.
+- State what the system does, not how it got there.
+  No "this supersedes X", "formerly Y", "a spike settled Z", changelog entries, or migration narration.
+- When something is removed or replaced, edit the spec to describe the new reality and delete the old text, rather than describing the transition.
+  The git history is the record of change; the spec is the record of the present.
 
 ## Own behaviour, not a dependency's internals
 
-- Describe the system's own behaviour and contracts: the request shape it
-  handles, the guarantee it makes. Don't narrate a dependency's decision logic
-  or version-specific quirks beyond the minimum needed to justify a requirement.
-- Don't scaffold or label: no "Strategy A/B", "Phase N", or plan tags in spec
-  prose. Describe the mechanism directly.
+- Describe the system's own behaviour and contracts: the request shape it handles, the guarantee it makes.
+  Don't narrate a dependency's decision logic or version-specific quirks beyond the minimum needed to justify a requirement.
+- Don't scaffold or label: no "Strategy A/B", "Phase N", or plan tags in spec prose.
+  Describe the mechanism directly.
 
 ## Workflow
 
-- When adding or changing a feature, or fixing a bug: update the spec in
-  `.workhorse/specs` first, then implement, then add tests.
+- When adding or changing a feature, or fixing a bug: update the spec in `.workhorse/specs` first, then implement, then add tests.

--- a/.workhorse/specs/canopy/backup.md
+++ b/.workhorse/specs/canopy/backup.md
@@ -4,13 +4,19 @@ id: BAK
 
 # Canopy backups
 
-bestool is the device-side producer for Canopy's backup control plane. It advertises which backups a server can take, and when prompted, fetches short-lived per-group object-store credentials and the repository target from Canopy, drives kopia to take a backup, and reports the outcome. Canopy owns scheduling, retention, maintenance, inspection, and alerting; the device holds no long-lived bucket credentials, never deletes from the repository, and never caches the bucket — the target and credentials are re-derived from Canopy on every run, so a server-side configuration change propagates without per-host action.
+bestool is the device-side producer for Canopy's backup control plane.
+It advertises which backups a server can take, and when prompted, fetches short-lived per-group object-store credentials and the repository target from Canopy, drives kopia to take a backup, and reports the outcome.
+Canopy owns scheduling, retention, maintenance, inspection, and alerting; the device holds no long-lived bucket credentials, never deletes from the repository, and never caches the bucket — the target and credentials are re-derived from Canopy on every run, so a server-side configuration change propagates without per-host action.
 
 ## Backup definitions
 
-A backup is configured by a TOML definition file in the backups directory — `/etc/bestool/backups/*.toml` on Unix, a per-platform data directory on Windows — one definition per file (so configuration management can drop in a single file per backup). A definition carries a `type` (the Canopy-facing label), optional `[tags]` (extra kopia tags), optional ordered `[[pre]]` and `[[post]]` command hooks, and exactly one method table — `[simple]` or `[postgresql]` — selecting a built-in method. A definition with no method table, or with more than one, is a load error. The `type` is the only identity that matters to Canopy; the filename is informational.
+A backup is configured by a TOML definition file in the backups directory — `/etc/bestool/backups/*.toml` on Unix, a per-platform data directory on Windows — one definition per file (so configuration management can drop in a single file per backup).
+A definition carries a `type` (the Canopy-facing label), optional `[tags]` (extra kopia tags), optional ordered `[[pre]]` and `[[post]]` command hooks, and exactly one method table — `[simple]` or `[postgresql]` — selecting a built-in method.
+A definition with no method table, or with more than one, is a load error.
+The `type` is the only identity that matters to Canopy; the filename is informational.
 
-Backups are generic: a definition names a method and a target, and `type` is just a label. A `tamanu-postgres` backup is a definition that selects the `postgresql` method; there is nothing Tamanu-specific in the machinery.
+Backups are generic: a definition names a method and a target, and `type` is just a label.
+A `tamanu-postgres` backup is a definition that selects the `postgresql` method; there is nothing Tamanu-specific in the machinery.
 
 ### Common fields
 
@@ -62,10 +68,13 @@ A method exposes a `prepare` step that produces the path kopia snapshots (plus a
 
 ## The control-plane contract
 
-The device authenticates to Canopy with the identity established at enrolment — the tailscale path where available, otherwise the device mTLS certificate. Four endpoints back the system:
+The device authenticates to Canopy with the identity established at enrolment — the tailscale path where available, otherwise the device mTLS certificate.
+Four endpoints back the system:
 
-- **Register capabilities** — the device posts the set of backup types it can run. Canopy records them; a newly-seen type comes up enabled or disabled per Canopy's defaults.
-- **Issue credentials** — given a type and a purpose (`backup` or `restore`), Canopy returns short-lived object-store credentials. `backup` grants write-without-delete; `restore` is downscoped read-only.
+- **Register capabilities** — the device posts the set of backup types it can run.
+  Canopy records them; a newly-seen type comes up enabled or disabled per Canopy's defaults.
+- **Issue credentials** — given a type and a purpose (`backup` or `restore`), Canopy returns short-lived object-store credentials.
+  `backup` grants write-without-delete; `restore` is downscoped read-only.
 - **Fetch target** — returns the repository target: storage kind, bucket, prefix (normally empty), region, and the repository password.
 - **Report a run** — the device posts the run's outcome (success or failure) with the client-minted run id, the type, the purpose, and, on success, the snapshot id and bytes uploaded where known.
 
@@ -73,54 +82,83 @@ When the device is not yet authorised for backups — not bound to a live server
 
 ## Taking a backup
 
-`bestool canopy backup --type <type>` drives one run, and is also what the daemon invokes in-process when Canopy asks for a backup. A run:
+`bestool canopy backup --type <type>` drives one run, and is also what the daemon invokes in-process when Canopy asks for a backup.
+A run:
 
 1. mints a run id (which becomes the report's run id and the `canopy-run` snapshot tag) and resolves the definition for the type, failing fast without touching the network if no definition exists;
-2. takes an exclusive per-type lock for the whole run, so a second run for the same type — a re-emitted request, or a manual run racing the daemon — no-ops rather than starting a concurrent kopia. The lock lives in a runtime directory and is released by the OS if the process dies;
-3. fetches the target. A "not yet authorised" response is treated as idle: the run logs that there's nothing to do and exits successfully without reporting. This lets a server image ship backup wiring unconditionally and simply wait until an operator authorises the group;
+2. takes an exclusive per-type lock for the whole run, so a second run for the same type — a re-emitted request, or a manual run racing the daemon — no-ops rather than starting a concurrent kopia.
+   The lock lives in a runtime directory and is released by the OS if the process dies;
+3. fetches the target.
+   A "not yet authorised" response is treated as idle: the run logs that there's nothing to do and exits successfully without reporting.
+   This lets a server image ship backup wiring unconditionally and simply wait until an operator authorises the group;
 4. starts a loopback re-signing proxy for kopia (below) and connects kopia to the repository through it, reconnecting if the target changed so a server-side bucket change is picked up;
 5. runs the `pre` hooks, prepares the method's source, applies an ignore policy for any method-supplied transient files, and takes the kopia snapshot;
 6. cleans up and runs the `post` hooks;
-7. reports the outcome. Any run that started kopia reports (success or failure); a run that exited idle at step 3 reports nothing. A failed report is logged and surfaced as a non-zero exit, but is not retried — Canopy's repository inspection is the backstop for a lost report.
+7. reports the outcome.
+   Any run that started kopia reports (success or failure); a run that exited idle at step 3 reports nothing.
+   A failed report is logged and surfaced as a non-zero exit, but is not retried — Canopy's repository inspection is the backstop for a lost report.
 
-The repository password is a real secret and is kept reasonably protected from leakage — out of the process argument list and out of any persisted configuration, so it can't be read from a process listing or left on the device. The S3 credentials kopia is given need no such protection: they are dummy values, the real credentials living only in the re-signing proxy ([S3P](s3-sigv4-proxy.md)). kopia runs against a transient per-run config, so the device never holds the bucket either.
+The repository password is a real secret and is kept reasonably protected from leakage — out of the process argument list and out of any persisted configuration, so it can't be read from a process listing or left on the device.
+The S3 credentials kopia is given need no such protection: they are dummy values, the real credentials living only in the re-signing proxy ([S3P](s3-sigv4-proxy.md)).
+kopia runs against a transient per-run config, so the device never holds the bucket either.
 
 ## Credentials
 
-kopia binds its S3 credentials once at start-up and has no mid-run refresh, while Canopy's assumed-role credentials are short-lived — so a long operation would otherwise outlive them. The driver bridges this with a loopback re-signing proxy ([S3P](s3-sigv4-proxy.md)): kopia is pointed at the proxy with meaningless dummy keys, and the proxy re-signs each request with live credentials fetched from Canopy, refreshed as they near expiry. A long run is bounded by how long Canopy stays reachable to reissue credentials, not by a single issuance. Environment variables that would otherwise let the host's ambient credentials shadow the dummy keys are scrubbed from kopia's environment.
+kopia binds its S3 credentials once at start-up and has no mid-run refresh, while Canopy's assumed-role credentials are short-lived — so a long operation would otherwise outlive them.
+The driver bridges this with a loopback re-signing proxy ([S3P](s3-sigv4-proxy.md)): kopia is pointed at the proxy with meaningless dummy keys, and the proxy re-signs each request with live credentials fetched from Canopy, refreshed as they near expiry.
+A long run is bounded by how long Canopy stays reachable to reissue credentials, not by a single issuance.
+Environment variables that would otherwise let the host's ambient credentials shadow the dummy keys are scrubbed from kopia's environment.
 
 ## Repository identity and tags
 
-kopia's snapshot source host is set to the server id, so a backup's source is attributed to the backup subject and survives device replacement with continuous history; the username is fixed. The source path is stable across runs for a given backup type, so kopia's snapshot history, deduplication, and retention attribute to one source.
+kopia's snapshot source host is set to the server id, so a backup's source is attributed to the backup subject and survives device replacement with continuous history; the username is fixed.
+The source path is stable across runs for a given backup type, so kopia's snapshot history, deduplication, and retention attribute to one source.
 
 Every snapshot is tagged with the device id, the run id, and the backup type, plus any tags the definition or the method contribute; the canopy-owned tags take precedence so a definition cannot override them.
 
 ## Registration and triggering by the daemon
 
-When run under the bestool-alertd daemon, the device registers its capabilities — the types of every definition in the backups directory — with Canopy at startup, again on reload, and periodically as a safety net. A reload is triggered by the daemon's reload signal or its control endpoint, and a change to the backups directory is picked up by watching it, so dropping in a new definition is registered without a restart.
+When run under the bestool-alertd daemon, the device registers its capabilities — the types of every definition in the backups directory — with Canopy at startup, again on reload, and periodically as a safety net.
+A reload is triggered by the daemon's reload signal or its control endpoint, and a change to the backups directory is picked up by watching it, so dropping in a new definition is registered without a restart.
 
-Canopy decides when a server backs up. On each device-to-Canopy healthcheck tick, Canopy's response names the backup types the server should run right now (the union of operator one-offs and schedule-due types; empty means nothing to do). The daemon runs each named type's driver in-process, skipping any type whose previous run is still going. Reporting a run clears the corresponding one-off, so the heartbeat stops re-emitting it.
+Canopy decides when a server backs up.
+On each device-to-Canopy healthcheck tick, Canopy's response names the backup types the server should run right now (the union of operator one-offs and schedule-due types; empty means nothing to do).
+The daemon runs each named type's driver in-process, skipping any type whose previous run is still going.
+Reporting a run clears the corresponding one-off, so the heartbeat stops re-emitting it.
 
 A standalone `bestool canopy backup` run works without the daemon, for manual use or an external scheduler; it spawns its own ephemeral re-signing proxy for the run.
 
 ## The postgresql method
 
-The method produces an atomic, crash-consistent copy of the cluster and never writes a `backup_label`, so a restore is plain crash recovery — the cluster replays its WAL to a consistent state. This is what keeps restores clean: it avoids the forced WAL reset and full reindex that a partial backup label or a non-atomic copy provoke downstream. An explicit CHECKPOINT is issued just before the capture to bound how much WAL the restore replays; it is an optimisation, not a correctness requirement.
+The method produces an atomic, crash-consistent copy of the cluster and never writes a `backup_label`, so a restore is plain crash recovery — the cluster replays its WAL to a consistent state.
+This is what keeps restores clean: it avoids the forced WAL reset and full reindex that a partial backup label or a non-atomic copy provoke downstream.
+An explicit CHECKPOINT is issued just before the capture to bound how much WAL the restore replays; it is an optimisation, not a correctness requirement.
 
-The method is generic postgres, driven by its configuration (a cluster name, with optional data-directory, version, port, and socket overrides) rather than by any application's configuration. It resolves the cluster's data directory and the volumes the cluster occupies, then captures by the cheapest consistent means the storage offers: where the underlying volume can take a cheap, point-in-time read-only snapshot, it snapshots the volume; otherwise it streams a `pg_basebackup` base backup, which bundles the WAL and the backup-end record so it too restores by clean crash recovery.
+The method is generic postgres, driven by its configuration (a cluster name, with optional data-directory, version, port, and socket overrides) rather than by any application's configuration.
+It resolves the cluster's data directory and the volumes the cluster occupies, then captures by the cheapest consistent means the storage offers: where the underlying volume can take a cheap, point-in-time read-only snapshot, it snapshots the volume; otherwise it streams a `pg_basebackup` base backup, which bundles the WAL and the backup-end record so it too restores by clean crash recovery.
 
-A volume snapshot necessarily freezes the whole volume the data directory lives on — it is taken at the volume or block level, not of a bare subdirectory — but kopia only backs up the cluster's subdirectory within the frozen, read-only mount, exposed at the stable source path. Transient files (the postmaster lock, logs, the stats temp directory) are ignored; the WAL, transaction-status, control, global, and tablespace data never are.
+A volume snapshot necessarily freezes the whole volume the data directory lives on — it is taken at the volume or block level, not of a bare subdirectory — but kopia only backs up the cluster's subdirectory within the frozen, read-only mount, exposed at the stable source path.
+Transient files (the postmaster lock, logs, the stats temp directory) are ignored; the WAL, transaction-status, control, global, and tablespace data never are.
 
-If a snapshot cannot be taken — the volume's snapshot mechanism is unavailable, insufficient privilege, or a multi-volume layout that cannot be frozen atomically — the method falls back to `pg_basebackup` rather than fail. This is a safe degradation to a correct, if heavier, base backup; it never falls back to reading the live data directory. A capture never silently degrades to an unsafe copy.
+If a snapshot cannot be taken — the volume's snapshot mechanism is unavailable, insufficient privilege, or a multi-volume layout that cannot be frozen atomically — the method falls back to `pg_basebackup` rather than fail.
+This is a safe degradation to a correct, if heavier, base backup; it never falls back to reading the live data directory.
+A capture never silently degrades to an unsafe copy.
 
-Before creating a capture the method sweeps leftovers from a previously crashed run (a hard reboot skips cleanup), so orphaned snapshots and mounts do not accumulate. Backups run with the privilege the capture needs.
+Before creating a capture the method sweeps leftovers from a previously crashed run (a hard reboot skips cleanup), so orphaned snapshots and mounts do not accumulate.
+Backups run with the privilege the capture needs.
 
 ## Restore
 
-`bestool canopy restore --type <type>` is the operator-facing restore. It resolves the definition, fetches restore-purpose (read-only) credentials, connects to the repository, and selects a snapshot — the latest, or one named by id — filtered to this server and this backup type. It restores the snapshot into a staging area on the same filesystem as the target so the final move is atomic, then hands off to the method.
+`bestool canopy restore --type <type>` is the operator-facing restore.
+It resolves the definition, fetches restore-purpose (read-only) credentials, connects to the repository, and selects a snapshot — the latest, or one named by id — filtered to this server and this backup type.
+It restores the snapshot into a staging area on the same filesystem as the target so the final move is atomic, then hands off to the method.
 
-The `postgresql` method's restore is a full automated swap: it stops the cluster, moves the existing data directory aside (kept, not deleted), moves the restored tree into place with the right ownership and permissions, starts the cluster via plain crash recovery, and verifies it accepts connections. A WAL reset is only attempted as a logged last resort if the cluster will not start. The `simple` method's restore lays the files back at its path or a given target.
+The `postgresql` method's restore is a full automated swap: it stops the cluster, moves the existing data directory aside (kept, not deleted), moves the restored tree into place with the right ownership and permissions, starts the cluster via plain crash recovery, and verifies it accepts connections.
+A WAL reset is only attempted as a logged last resort if the cluster will not start.
+The `simple` method's restore lays the files back at its path or a given target.
 
-Restore refuses to overwrite existing data by default. To proceed an operator passes an explicit confirmation flag (for non-interactive use) or answers an interactive double confirmation; with neither, over occupied data, it refuses. Migrations, configuration sync, and version upgrades are left to the operator.
+Restore refuses to overwrite existing data by default.
+To proceed an operator passes an explicit confirmation flag (for non-interactive use) or answers an interactive double confirmation; with neither, over occupied data, it refuses.
+Migrations, configuration sync, and version upgrades are left to the operator.
 
 Off-host restore verification is Canopy's concern, not this command's; this command's job is to produce clean backups and to restore them on demand.

--- a/.workhorse/specs/canopy/backup.md
+++ b/.workhorse/specs/canopy/backup.md
@@ -8,9 +8,49 @@ bestool is the device-side producer for Canopy's backup control plane. It advert
 
 ## Backup definitions
 
-A backup is configured by a definition file in the backups directory — `/etc/bestool/backups/*.toml` on Unix, a per-platform data directory on Windows — one definition per file (so configuration management can drop in a single file per backup). A definition carries a `type` (the Canopy-facing label), optional `[tags]` (extra kopia tags), optional ordered `[[pre]]` and `[[post]]` command hooks, and exactly one method table — `[simple]` or `[postgresql]` — selecting a built-in method. A definition with no method table, or with more than one, is a load error. The `type` is the only identity that matters to Canopy; the filename is informational.
+A backup is configured by a TOML definition file in the backups directory — `/etc/bestool/backups/*.toml` on Unix, a per-platform data directory on Windows — one definition per file (so configuration management can drop in a single file per backup). A definition carries a `type` (the Canopy-facing label), optional `[tags]` (extra kopia tags), optional ordered `[[pre]]` and `[[post]]` command hooks, and exactly one method table — `[simple]` or `[postgresql]` — selecting a built-in method. A definition with no method table, or with more than one, is a load error. The `type` is the only identity that matters to Canopy; the filename is informational.
 
 Backups are generic: a definition names a method and a target, and `type` is just a label. A `tamanu-postgres` backup is a definition that selects the `postgresql` method; there is nothing Tamanu-specific in the machinery.
+
+### Common fields
+
+```toml
+type = "tamanu-postgres"          # required — the Canopy backup-type label
+
+[tags]                            # optional — extra kopia tags (string to string)
+component = "database"
+
+[[pre]]                           # optional, ordered — run before the snapshot
+command = ["/usr/bin/systemctl", "stop", "example"]
+
+[[post]]                          # optional, ordered — run after cleanup
+command = ["/usr/bin/systemctl", "start", "example"]
+```
+
+A hook is a table with a `command` array, run argv-style (no shell).
+
+### Method tables
+
+There must be exactly one method table.
+
+#### Simple
+
+```toml
+[simple]                          # snapshot a path as-is
+path = "/var/lib/example"         # required
+```
+
+#### PostgreSQL
+
+```toml
+[postgresql]                      # crash-consistent postgres cluster snapshot
+cluster = "main"                  # required — the cluster to resolve
+
+data_dir = "/var/lib/postgresql/16/main"  # optional — override the resolved data directory
+version = "16"                    # optional — override the resolved major version
+port = 5432                       # optional — override the port used to issue CHECKPOINT
+socket = "/var/run/postgresql"    # optional — override the unix socket directory
+```
 
 ## Methods
 

--- a/.workhorse/specs/canopy/s3-sigv4-proxy.md
+++ b/.workhorse/specs/canopy/s3-sigv4-proxy.md
@@ -4,23 +4,33 @@ id: S3P
 
 # S3 SigV4 re-signing proxy
 
-A small loopback HTTP proxy that fronts a real S3 endpoint and re-signs every request with live, auto-refreshing credentials, so a long-running S3 client that binds its credentials once at start-up can keep talking to S3 past the lifetime of any single set of credentials. Both Canopy (server-side maintenance, inspection, init) and bestool (device backups and restores) drive kopia through it.
+A small loopback HTTP proxy that fronts a real S3 endpoint and re-signs every request with live, auto-refreshing credentials, so a long-running S3 client that binds its credentials once at start-up can keep talking to S3 past the lifetime of any single set of credentials.
+Both Canopy (server-side maintenance, inspection, init) and bestool (device backups and restores) drive kopia through it.
 
 ## Why it exists
 
-kopia's S3 connector resolves credentials once, at process start, and signs every request for the life of the process with that fixed key material. It has no mid-run refresh: it binds real credentials at start-up and has no way to pick up fresh ones for the S3 backend while running. Assumed-role / STS credentials are short-lived (about an hour), so any kopia operation that outlives the credentials fails partway through. That window is routinely exceeded: maintenance on a mid-size repository has run 40 minutes and climbing, and device backups and restores of large clusters run much longer.
+kopia's S3 connector resolves credentials once, at process start, and signs every request for the life of the process with that fixed key material.
+It has no mid-run refresh: it binds real credentials at start-up and has no way to pick up fresh ones for the S3 backend while running.
+Assumed-role / STS credentials are short-lived (about an hour), so any kopia operation that outlives the credentials fails partway through.
+That window is routinely exceeded: maintenance on a mid-size repository has run 40 minutes and climbing, and device backups and restores of large clusters run much longer.
 
-Static credentials passed by environment are an adequate stopgap for genuinely short operations (init, stats, listing snapshots, rotation, inspection), but not for these. The proxy removes the time bound: kopia holds only meaningless static dummy keys and points at the loopback proxy; the proxy holds the live credentials, refreshes them transparently, and re-signs each request as it passes through. A run is then limited by how long Canopy stays reachable to reissue credentials, not by the lifetime of one issuance.
+Static credentials passed by environment are an adequate stopgap for genuinely short operations (init, stats, listing snapshots, rotation, inspection), but not for these.
+The proxy removes the time bound: kopia holds only meaningless static dummy keys and points at the loopback proxy; the proxy holds the live credentials, refreshes them transparently, and re-signs each request as it passes through.
+A run is then limited by how long Canopy stays reachable to reissue credentials, not by the lifetime of one issuance.
 
 ## Shape
 
-kopia is configured to use S3 against the proxy: a loopback endpoint (`127.0.0.1:<ephemeral-port>`), TLS disabled on that leg, and fixed dummy access/secret keys. The proxy accepts those requests, discards their dummy signature, re-signs the request with the current real credentials for the true region and the `s3` service, and forwards it to the real S3 host over TLS. The response is streamed back verbatim. Each request is signed independently with whatever credentials are current at that moment, so a credential refresh between two requests is invisible to kopia.
+kopia is configured to use S3 against the proxy: a loopback endpoint (`127.0.0.1:<ephemeral-port>`), TLS disabled on that leg, and fixed dummy access/secret keys.
+The proxy accepts those requests, discards their dummy signature, re-signs the request with the current real credentials for the true region and the `s3` service, and forwards it to the real S3 host over TLS.
+The response is streamed back verbatim.
+Each request is signed independently with whatever credentials are current at that moment, so a credential refresh between two requests is invisible to kopia.
 
 The proxy is a forward proxy in spirit but a re-signing reverse proxy in mechanics: it owns the upstream target (bucket host, region) and the credentials; kopia owns nothing but the dummy keys and the loopback address.
 
 ## Credentials are pluggable
 
-The credential source is the one integration seam. Credentials come from a pluggable provider that yields the current access key, secret key, and session token and refreshes itself ahead of expiry; the proxy asks the provider for current credentials per request (cheap when unexpired) and never blocks the request path on a network round-trip it can avoid.
+The credential source is the one integration seam.
+Credentials come from a pluggable provider that yields the current access key, secret key, and session token and refreshes itself ahead of expiry; the proxy asks the provider for current credentials per request (cheap when unexpired) and never blocks the request path on a network round-trip it can avoid.
 
 - **Canopy** plugs an in-process assume-role provider (the pod assumes the group's role and refreshes the underlying identity), so a run is not capped at the chained-session ceiling.
 - **bestool** plugs a provider backed by Canopy's issue-credentials endpoint, fetching on first use and again as expiry approaches, for the `backup` (write-without-delete) or `restore` (read-only) purpose.
@@ -29,28 +39,45 @@ The proxy carries neither Canopy nor bestool specifics beyond this seam.
 
 ## Signing
 
-Every object PUT arrives over the loopback leg with a chunked streaming payload signature (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD`): the body is a sequence of chunks, each prefixed on the wire by a per-chunk signature chained from the request's seed signature and keyed to the signing key. The proxy re-derives this whole chain with the live signing key; swapping the `Authorization` header alone does not suffice, as the in-body chunk signatures are keyed to the credentials too.
+Every object PUT arrives over the loopback leg with a chunked streaming payload signature (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD`): the body is a sequence of chunks, each prefixed on the wire by a per-chunk signature chained from the request's seed signature and keyed to the signing key.
+The proxy re-derives this whole chain with the live signing key; swapping the `Authorization` header alone does not suffice, as the in-body chunk signatures are keyed to the credentials too.
 
-For each PUT the proxy computes a fresh seed signature for the re-signed request, derives the signing key from the live credentials, then walks the body chunk by chunk recomputing each chunk signature — `HMAC-SHA256(signing_key, "AWS4-HMAC-SHA256-PAYLOAD\n" + amz_date + "\n" + scope + "\n" + previous_signature + "\n" + SHA256("") + "\n" + SHA256(chunk_data))`, seeded by the request signature and chained through to the terminating zero-length chunk. Chunk sizes are copied from the incoming framing verbatim, so the re-encoded body is the same byte length and `Content-Length` is unchanged.
+For each PUT the proxy computes a fresh seed signature for the re-signed request, derives the signing key from the live credentials, then walks the body chunk by chunk recomputing each chunk signature — `HMAC-SHA256(signing_key, "AWS4-HMAC-SHA256-PAYLOAD\n" + amz_date + "\n" + scope + "\n" + previous_signature + "\n" + SHA256("") + "\n" + SHA256(chunk_data))`, seeded by the request signature and chained through to the terminating zero-length chunk.
+Chunk sizes are copied from the incoming framing verbatim, so the re-encoded body is the same byte length and `Content-Length` is unchanged.
 
-GET, HEAD and DELETE carry no body and are re-signed by recomputing the `Authorization` header alone. The proxy handles single-object PUT, GET, HEAD, DELETE and bucket listing — the operations kopia performs; multipart upload is out of scope, kopia's pack blobs being small enough to send as single PUTs.
+GET, HEAD and DELETE carry no body and are re-signed by recomputing the `Authorization` header alone.
+The proxy handles single-object PUT, GET, HEAD, DELETE and bucket listing — the operations kopia performs; multipart upload is out of scope, kopia's pack blobs being small enough to send as single PUTs.
 
-Bodies stream both ways — the proxy never holds a whole object. Chunks are self-framing, so it parses and re-emits the request body one chunk at a time; the only buffer is the current chunk, capped at an explicit ceiling far above kopia's 64 KiB so an unexpectedly large chunk (or an unterminated chunk header) is rejected rather than buffered without bound. Responses are streamed through verbatim.
+Bodies stream both ways — the proxy never holds a whole object.
+Chunks are self-framing, so it parses and re-emits the request body one chunk at a time; the only buffer is the current chunk, capped at an explicit ceiling far above kopia's 64 KiB so an unexpectedly large chunk (or an unterminated chunk header) is rejected rather than buffered without bound.
+Responses are streamed through verbatim.
 
-The signed header set is `host`, `x-amz-date`, `x-amz-content-sha256`, and `x-amz-decoded-content-length` on streaming PUTs; for STS credentials `x-amz-security-token` is added before signing so it is covered by the signature; `content-type`, `content-md5` and `content-encoding` are signed when present. A credential refresh between two requests changes only the key material the next request is signed with — kopia's view does not change.
+The signed header set is `host`, `x-amz-date`, `x-amz-content-sha256`, and `x-amz-decoded-content-length` on streaming PUTs; for STS credentials `x-amz-security-token` is added before signing so it is covered by the signature; `content-type`, `content-md5` and `content-encoding` are signed when present.
+A credential refresh between two requests changes only the key material the next request is signed with — kopia's view does not change.
 
 ## Network path
 
-The signature binds a request to a host and region, not to a route, so the address the proxy connects to is a separate axis from what it signs: the connection target and the signed host/region are independent settings. This leaves the egress path open without touching how requests are signed — S3 can be reached directly, over a Tailscale subnet router into a VPC, or through an S3 interface endpoint (PrivateLink) with private DNS, all while the signed host and region stay the canonical S3 values. The only constraint is that whatever finally reaches S3 carries the host and signature S3 validates: an L3 route that forwards the request unchanged is transparent; a hop that terminates TLS must preserve the `Host` header or re-sign. The upstream TLS leg validates the endpoint's certificate against the host the proxy connects to, so a connection target whose name differs from the signed host needs a certificate that covers it.
+The signature binds a request to a host and region, not to a route, so the address the proxy connects to is a separate axis from what it signs: the connection target and the signed host/region are independent settings.
+This leaves the egress path open without touching how requests are signed — S3 can be reached directly, over a Tailscale subnet router into a VPC, or through an S3 interface endpoint (PrivateLink) with private DNS, all while the signed host and region stay the canonical S3 values.
+The only constraint is that whatever finally reaches S3 carries the host and signature S3 validates: an L3 route that forwards the request unchanged is transparent; a hop that terminates TLS must preserve the `Host` header or re-sign.
+The upstream TLS leg validates the endpoint's certificate against the host the proxy connects to, so a connection target whose name differs from the signed host needs a certificate that covers it.
 
 ## Lifecycle and concurrency
 
-The proxy binds an ephemeral loopback port and lives for the operation it serves. bestool runs one per backup or restore run; Canopy's backups pod runs many groups concurrently, each with its own role, bucket, and region, so the proxy must support cheap, independent instances (one per op, each with its own provider and upstream target) rather than a single shared singleton — or, if multiplexed, must key cleanly on the per-op target and credentials. Spawning and tearing one down per op must be inexpensive.
+The proxy binds an ephemeral loopback port and lives for the operation it serves.
+bestool runs one per backup or restore run; Canopy's backups pod runs many groups concurrently, each with its own role, bucket, and region, so the proxy must support cheap, independent instances (one per op, each with its own provider and upstream target) rather than a single shared singleton — or, if multiplexed, must key cleanly on the per-op target and credentials.
+Spawning and tearing one down per op must be inexpensive.
+
+
 
 ## Security
 
-The proxy binds a loopback literal only and is never exposed off-host. The dummy keys kopia carries are meaningless on their own; the real credentials live only in the proxy's process memory and are never written to disk or logged. Ambient AWS environment variables that could let the host's own credentials shadow the dummy keys are scrubbed from kopia's environment. The loopback leg runs without TLS (trusted, same host); the upstream leg to S3 is always TLS.
+The proxy binds a loopback literal only and is never exposed off-host.
+The dummy keys kopia carries are meaningless on their own; the real credentials live only in the proxy's process memory and are never written to disk or logged.
+Ambient AWS environment variables that could let the host's own credentials shadow the dummy keys are scrubbed from kopia's environment.
+The loopback leg runs without TLS (trusted, same host); the upstream leg to S3 is always TLS.
 
 ## Observability
 
-The proxy logs credential refreshes, upstream S3 errors, and lifecycle (bind, shutdown), but never credential material. A refresh failure (Canopy unreachable, assume-role denied) surfaces as a failed request to kopia with enough context to distinguish "lost credentials mid-run" from an ordinary S3 error.
+The proxy logs credential refreshes, upstream S3 errors, and lifecycle (bind, shutdown), but never credential material.
+A refresh failure (Canopy unreachable, assume-role denied) surfaces as a failed request to kopia with enough context to distinguish "lost credentials mid-run" from an ordinary S3 error.

--- a/.workhorse/specs/tamanu/doctor.md
+++ b/.workhorse/specs/tamanu/doctor.md
@@ -4,58 +4,91 @@ id: DOC
 
 # Tamanu doctor
 
-The `bestool tamanu doctor` command gathers server facts and runs a set of health checks against a Tamanu install, then renders the outcome for a human operator or as a machine-readable payload. Checks may pass, be skipped, warn, fail, or be broken (the check itself errored). This spec describes how the command selects checks, where the sweep data comes from, and how results are displayed.
+The `bestool tamanu doctor` command gathers server facts and runs a set of health checks against a Tamanu install, then renders the outcome for a human operator or as a machine-readable payload.
+Checks may pass, be skipped, warn, fail, or be broken (the check itself errored).
+This spec describes how the command selects checks, where the sweep data comes from, and how results are displayed.
 
 ## Checks and outcomes
 
-The command runs a fixed registry of named checks covering both host-level concerns (disk, memory, time sync, and so on) and Tamanu-specific concerns (database, HTTP, services, certificates, sync state). Each check resolves to exactly one of five outcomes: pass, skip, warning, broken, or fail. Every check produces a one-line summary; checks with a skip, warning, broken, or fail outcome also carry a reason.
+The command runs a fixed registry of named checks covering both host-level concerns (disk, memory, time sync, and so on) and Tamanu-specific concerns (database, HTTP, services, certificates, sync state).
+Each check resolves to exactly one of five outcomes: pass, skip, warning, broken, or fail.
+Every check produces a one-line summary; checks with a skip, warning, broken, or fail outcome also carry a reason.
 
-The overall outcome of the sweep is failing if any check failed, degraded if any check warned or broke without any failing, and healthy otherwise. Skipped checks do not degrade the overall outcome.
+The overall outcome of the sweep is failing if any check failed, degraded if any check warned or broke without any failing, and healthy otherwise.
+Skipped checks do not degrade the overall outcome.
 
 ## Selecting checks
 
-`--check NAME` restricts the sweep to the named check and is repeatable to select several. `--skip NAME` excludes the named check, is repeatable, and applies after `--check`. With no selection flags, every check in the registry runs. An unknown check name in either flag is a fatal error that lists the known check names.
+`--check NAME` restricts the sweep to the named check and is repeatable to select several.
+`--skip NAME` excludes the named check, is repeatable, and applies after `--check`.
+With no selection flags, every check in the registry runs.
+An unknown check name in either flag is a fatal error that lists the known check names.
 
 ## Tamanu install context
 
-When a Tamanu install is present on the host, the sweep runs against it: install-dependent checks (configuration, local HTTP, services, certificates, backup) and database-dependent checks both run. When no install is present but a Tamanu database URL is configured via the environment, the sweep runs against that database — database-dependent checks run and install-dependent checks skip. When neither is present, only host-level checks run and the command warns that no Tamanu was found on this host.
+When a Tamanu install is present on the host, the sweep runs against it: install-dependent checks (configuration, local HTTP, services, certificates, backup) and database-dependent checks both run.
+When no install is present but a Tamanu database URL is configured via the environment, the sweep runs against that database — database-dependent checks run and install-dependent checks skip.
+When neither is present, only host-level checks run and the command warns that no Tamanu was found on this host.
 
 ## Sweep source
 
-By default, the command reads the most recent sweep cached by the alertd daemon on the same host. `--fresh` asks the daemon to recompute and streams the per-check results back as they complete. `--no-daemon` skips the daemon integration and computes the sweep locally. If the daemon cannot be reached or returns an error, the command falls back to computing the sweep locally.
+By default, the command reads the most recent sweep cached by the alertd daemon on the same host.
+`--fresh` asks the daemon to recompute and streams the per-check results back as they complete.
+`--no-daemon` skips the daemon integration and computes the sweep locally.
+If the daemon cannot be reached or returns an error, the command falls back to computing the sweep locally.
 
 A source note in both the live display and the final rendered output identifies whether the data was computed locally, streamed from the daemon, or read from the daemon's last cached sweep, and how long ago a cached sweep was computed.
 
 ## Grouping and ordering
 
-Checks are grouped by outcome. Groups appear top-to-bottom in increasing severity: passing, skipped, warning, broken, failing — so the most urgent checks sit closest to the result line and the shell prompt. Within each group, checks are ordered alphabetically by name. The same grouping and ordering apply during the live sweep and in the final rendered output.
+Checks are grouped by outcome.
+Groups appear top-to-bottom in increasing severity: passing, skipped, warning, broken, failing — so the most urgent checks sit closest to the result line and the shell prompt.
+Within each group, checks are ordered alphabetically by name.
+The same grouping and ordering apply during the live sweep and in the final rendered output.
 
 ## Live execution in an interactive terminal
 
-When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep. Every selected check appears as a row in the list from the start of the sweep, in a pending state. A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary. As each check completes, its row moves to its grouped-and-ordered position.
+When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep.
+Every selected check appears as a row in the list from the start of the sweep, in a pending state.
+A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary.
+As each check completes, its row moves to its grouped-and-ordered position.
 
-A footer line shows an animated spinner together with a running count of how many checks have completed out of the total. The source note appears in the TUI as dimmed text.
+A footer line shows an animated spinner together with a running count of how many checks have completed out of the total.
+The source note appears in the TUI as dimmed text.
 
-On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits. If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit.
+On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits.
+If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit.
 
 ## Final rendered output
 
-The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position. A blank line separates the check list from the result line. The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks. The source note appears as dimmed text below the result line. The result line is always shown, even when the displayed check list is empty.
+The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position.
+A blank line separates the check list from the result line.
+The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks.
+The source note appears as dimmed text below the result line.
+The result line is always shown, even when the displayed check list is empty.
 
 ## Only-failing filter
 
-The command accepts `--only-failing` and its short form `-F`. With the filter set, only checks with warning, broken, or failing outcomes appear in the displayed list and the final output. The grouping and ordering rules still apply, so displayed checks are ordered warning, then broken, then failing.
+The command accepts `--only-failing` and its short form `-F`.
+With the filter set, only checks with warning, broken, or failing outcomes appear in the displayed list and the final output.
+The grouping and ordering rules still apply, so displayed checks are ordered warning, then broken, then failing.
 
-In the live TUI under the filter, pending and running rows remain visible for every selected check; once a check's outcome is known, it stays in the list only if it warned, broke, or failed. The footer count under the filter still tracks completion against the full set of selected checks. When every selected check passes or is skipped, the displayed list is empty and the result line is shown on its own.
+In the live TUI under the filter, pending and running rows remain visible for every selected check; once a check's outcome is known, it stays in the list only if it warned, broke, or failed.
+The footer count under the filter still tracks completion against the full set of selected checks.
+When every selected check passes or is skipped, the displayed list is empty and the result line is shown on its own.
 
 ## Non-interactive output
 
-When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner. Non-interactive output follows the same grouping, ordering, source note, result line, and only-failing filter rules.
+When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner.
+Non-interactive output follows the same grouping, ordering, source note, result line, and only-failing filter rules.
 
 ## JSON output
 
-When JSON output is requested, the command emits a machine-readable payload and suppresses the human-readable rendering. The payload contains the sweep's wire data, a source field naming where the data came from, and a computed-at timestamp when the source is the daemon's last cached sweep. The only-failing filter does not affect JSON output: every selected check is included.
+When JSON output is requested, the command emits a machine-readable payload and suppresses the human-readable rendering.
+The payload contains the sweep's wire data, a source field naming where the data came from, and a computed-at timestamp when the source is the daemon's last cached sweep.
+The only-failing filter does not affect JSON output: every selected check is included.
 
 ## Exit code
 
-The command exits non-zero when the overall outcome is failing, and zero otherwise. An exit caused by user interruption is non-zero regardless of partial results.
+The command exits non-zero when the overall outcome is failing, and zero otherwise.
+An exit caused by user interruption is non-zero regardless of partial results.


### PR DESCRIPTION
🤖 Documents the backup definition file format in spec. The def file is an interface operators and configuration management write, so per the spec rules its TOML shape belongs in the spec: the common fields (`type`, `[tags]`, ordered `[[pre]]`/`[[post]]` hooks) and the two method tables — `[simple]` (`path`) and `[postgresql]` (`cluster` + optional `data_dir`/`version`/`port`/`socket`).
