### PR TITLE
feat(alertd): include version and canopy transport in systemd status

### DIFF
--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -265,11 +265,24 @@ pub async fn run_with_shutdown(
 
 	info!("daemon started successfully");
 	// Tell systemd (Type=notify[-reload]) we're up; no-op when not under systemd.
+	// The status line surfaces the running version and the canopy transport
+	// (which is fixed at startup), so `systemctl status` shows them at a glance.
 	#[cfg(unix)]
-	let _ = sd_notify::notify(&[
-		sd_notify::NotifyState::Ready,
-		sd_notify::NotifyState::Status("monitoring"),
-	]);
+	{
+		let canopy = match &ctx.canopy_client {
+			Some(client) if client.is_tailscale().await => "canopy via tailscale",
+			Some(_) => "canopy via mTLS",
+			None => "canopy not connected",
+		};
+		let status = format!(
+			"monitoring; bestool {}; {canopy}",
+			daemon_config.binary_version
+		);
+		let _ = sd_notify::notify(&[
+			sd_notify::NotifyState::Ready,
+			sd_notify::NotifyState::Status(&status),
+		]);
+	}
 
 	// Block until the first lifecycle event arrives: a shutdown signal, or the
 	// watchdog firing. `None` means every sender was dropped, which we treat as

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -86,6 +86,12 @@ pub struct DaemonConfig {
 	/// Backup run registry, set when backups are compiled in. Surfaced via the
 	/// daemon's status so an operator can see what's backing up right now.
 	pub backups: Option<Arc<BackupRegistry>>,
+
+	/// Version of the running `bestool` binary, shown in the systemd status line.
+	///
+	/// Distinct from this crate's own [`VERSION`]: `bestool` and `bestool-alertd`
+	/// are versioned independently, so the caller threads in its own version.
+	pub binary_version: String,
 }
 
 impl fmt::Debug for DaemonConfig {
@@ -94,6 +100,7 @@ impl fmt::Debug for DaemonConfig {
 			.field("database_url", &self.database_url)
 			.field("device_key_pem", &self.device_key_pem)
 			.field("tamanu_version", &self.tamanu_version)
+			.field("binary_version", &self.binary_version)
 			.field("no_server", &self.no_server)
 			.field("server_addrs", &self.server_addrs)
 			.field("watchdog_timeout", &self.watchdog_timeout)
@@ -125,7 +132,16 @@ impl DaemonConfig {
 			watchdog_timeout: Some(Duration::from_secs(10 * 60)),
 			background_tasks: Vec::new(),
 			backups: None,
+			// Fallback only; the binary sets its own version via
+			// `with_binary_version`. This crate's version differs from bestool's.
+			binary_version: VERSION.to_string(),
 		}
+	}
+
+	/// Set the running binary's (bestool's) version for the status line.
+	pub fn with_binary_version(mut self, version: String) -> Self {
+		self.binary_version = version;
+		self
 	}
 
 	pub fn with_task(mut self, task: Arc<dyn BackgroundTask>) -> Self {

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -616,6 +616,7 @@ async fn build_config(ctx: &Context, daemon: DaemonArgs) -> Result<bestool_alert
 		tamanu.as_ref().map(|t| t.database_url.clone()),
 		tamanu_version,
 	)
+	.with_binary_version(env!("CARGO_PKG_VERSION").to_string())
 	.with_no_server(no_server)
 	.with_server_addrs(server_addr)
 	.with_watchdog_timeout(watchdog);
@@ -663,6 +664,7 @@ async fn build_config(_ctx: &Context, daemon: DaemonArgs) -> Result<bestool_aler
 	// Canopy requires a version on every request; `0.0.0` is the agreed
 	// sentinel for hosts with no Tamanu.
 	let base = bestool_alertd::DaemonConfig::new(None, None, "0.0.0".to_string())
+		.with_binary_version(env!("CARGO_PKG_VERSION").to_string())
 		.with_no_server(no_server)
 		.with_server_addrs(server_addr)
 		.with_watchdog_timeout(watchdog);


### PR DESCRIPTION
🤖 The systemd `Status:` line (shown by `systemctl status`) was a static `monitoring`. This makes it carry the running bestool version and the canopy transport, so a glance at the unit tells you what's deployed and how it's reaching canopy:

```
Status: "monitoring; bestool 1.29.0; canopy via tailscale"
```

The version is the **bestool binary's**, threaded into `DaemonConfig` via `with_binary_version`. `bestool` and `bestool-alertd` are versioned independently, so the alertd crate's own `CARGO_PKG_VERSION` (currently `12.0.0`) would be the wrong number — the daemon takes the binary's version explicitly.

The transport is one of `canopy via tailscale`, `canopy via mTLS`, or `canopy not connected`. It's decided once at startup (`CanopyClient::new` probes tailscale then falls back to mTLS) and isn't re-probed during the daemon's lifetime, so building the status string once at the `Ready`/`Status` notify is accurate.
