### PR TITLE
feat(alertd): show configured and running backups in status

### DIFF
--- a/crates/alertd/src/backup.rs
+++ b/crates/alertd/src/backup.rs
@@ -56,6 +56,10 @@ pub struct RunningBackup {
 pub struct BackupRegistry {
 	runner: BackupRunner,
 	running: Mutex<HashMap<String, Arc<RunHandle>>>,
+	/// The backup types configured on this host, refreshed by the capabilities
+	/// task as it (re-)reads the backups dir. Surfaced in the daemon's status so
+	/// an operator can see what's registered without listing the config dir.
+	configured: Mutex<Vec<String>>,
 }
 
 impl BackupRegistry {
@@ -63,7 +67,20 @@ impl BackupRegistry {
 		Arc::new(Self {
 			runner,
 			running: Mutex::new(HashMap::new()),
+			configured: Mutex::new(Vec::new()),
 		})
+	}
+
+	/// Record the configured backup types (called by the capabilities task each
+	/// time it reads the backups dir).
+	pub async fn set_configured(&self, mut types: Vec<String>) {
+		types.sort();
+		*self.configured.lock().await = types;
+	}
+
+	/// The configured backup types, for the status endpoint.
+	pub async fn configured(&self) -> Vec<String> {
+		self.configured.lock().await.clone()
 	}
 
 	/// Start a run for `backup_type`, or attach to the one already in flight.

--- a/crates/alertd/src/commands/status.rs
+++ b/crates/alertd/src/commands/status.rs
@@ -85,6 +85,27 @@ pub async fn get_status(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
 		println!("Watchdog:  disabled");
 	}
 
+	if status.backups_configured.is_empty() {
+		println!("Backups:   none configured");
+	} else {
+		println!("Backups:   {}", status.backups_configured.join(", "));
+	}
+	if !status.backups_running.is_empty() {
+		println!("  running: {}", status.backups_running.len());
+		for backup in &status.backups_running {
+			let phase = backup
+				.latest
+				.get("event")
+				.and_then(serde_json::Value::as_str)
+				.unwrap_or("?");
+			let run_id = backup.run_id.as_deref().unwrap_or("-");
+			println!(
+				"           - {} [{phase}] run {run_id}, started {}",
+				backup.r#type, backup.started_at
+			);
+		}
+	}
+
 	if !healthy {
 		std::process::exit(1);
 	}

--- a/crates/alertd/src/http_server/endpoints/status.rs
+++ b/crates/alertd/src/http_server/endpoints/status.rs
@@ -5,9 +5,9 @@ use axum::{Json, extract::State, response::IntoResponse};
 use crate::http_server::{state::ServerState, types::StatusResponse};
 
 pub async fn handle_status(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
-	let backups_running = match &state.backups {
-		Some(registry) => registry.running().await,
-		None => Vec::new(),
+	let (backups_running, backups_configured) = match &state.backups {
+		Some(registry) => (registry.running().await, registry.configured().await),
+		None => (Vec::new(), Vec::new()),
 	};
 	let status = StatusResponse {
 		name: "bestool-alertd".to_string(),
@@ -15,6 +15,7 @@ pub async fn handle_status(State(state): State<Arc<ServerState>>) -> impl IntoRe
 		started_at: state.started_at.to_string(),
 		pid: state.pid,
 		backups_running,
+		backups_configured,
 	};
 	Json(status)
 }

--- a/crates/alertd/src/http_server/types.rs
+++ b/crates/alertd/src/http_server/types.rs
@@ -10,4 +10,8 @@ pub struct StatusResponse {
 	/// backups aren't compiled in).
 	#[serde(default)]
 	pub backups_running: Vec<crate::RunningBackup>,
+	/// Backup types configured on this host (empty when none, or when backups
+	/// aren't compiled in).
+	#[serde(default)]
+	pub backups_configured: Vec<String>,
 }

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -217,14 +217,12 @@ fn with_daemon_tasks(
 		let doctor = doctor.with_backup_dispatch(backup_dispatch(registry.clone()));
 		let config = config
 			.with_backups(registry.clone())
-			.with_task(Arc::new(bestool_alertd::BackupTask::new(registry)));
+			.with_task(Arc::new(bestool_alertd::BackupTask::new(registry.clone())))
+			.with_task(Arc::new(backup::BackupCapabilitiesTask::new(registry)));
 		(config, doctor)
 	};
 
-	let config = config.with_task(Arc::new(doctor));
-	#[cfg(feature = "canopy-backup")]
-	let config = config.with_task(Arc::new(backup::BackupCapabilitiesTask));
-	config
+	config.with_task(Arc::new(doctor))
 }
 
 /// The in-process backup trigger: routes each type canopy requests via
@@ -322,7 +320,7 @@ fn backup_runner() -> bestool_alertd::BackupRunner {
 /// new def in `/etc/bestool/backups` is picked up without restarting the daemon.
 #[cfg(feature = "canopy-backup")]
 mod backup {
-	use std::time::Duration;
+	use std::{sync::Arc, time::Duration};
 
 	use futures::future::BoxFuture;
 	use miette::{IntoDiagnostic as _, Result};
@@ -335,15 +333,32 @@ mod backup {
 	/// missed event still converges.
 	const REREGISTER_INTERVAL: Duration = Duration::from_secs(3600);
 
-	pub(super) struct BackupCapabilitiesTask;
+	pub(super) struct BackupCapabilitiesTask {
+		registry: Arc<bestool_alertd::BackupRegistry>,
+	}
 
-	/// Load the configured backup types and register them with canopy.
-	async fn register(ctx: &bestool_alertd::TaskContext) -> Result<()> {
+	impl BackupCapabilitiesTask {
+		pub(super) fn new(registry: Arc<bestool_alertd::BackupRegistry>) -> Self {
+			Self { registry }
+		}
+	}
+
+	/// Load the configured backup types, record them for the daemon's status, and
+	/// register them with canopy.
+	///
+	/// The configured types are recorded even when there's no canopy client or no
+	/// defs, so the status reflects the host's config regardless of connectivity.
+	async fn register(
+		registry: &bestool_alertd::BackupRegistry,
+		ctx: &bestool_alertd::TaskContext,
+	) -> Result<()> {
+		let defs = config::load_dir(&config::backups_dir()).await?;
+		let types: Vec<String> = defs.into_iter().map(|d| d.r#type).collect();
+		registry.set_configured(types.clone()).await;
+
 		let Some(client) = ctx.canopy_client.as_ref() else {
 			return Ok(());
 		};
-		let defs = config::load_dir(&config::backups_dir()).await?;
-		let types: Vec<String> = defs.into_iter().map(|d| d.r#type).collect();
 		if types.is_empty() {
 			return Ok(());
 		}
@@ -354,9 +369,13 @@ mod backup {
 	}
 
 	/// Re-register, logging the trigger; failures are warned, never fatal.
-	async fn reregister(reason: &str, ctx: &bestool_alertd::TaskContext) {
+	async fn reregister(
+		reason: &str,
+		registry: &bestool_alertd::BackupRegistry,
+		ctx: &bestool_alertd::TaskContext,
+	) {
 		info!(reason, "registering backup capabilities");
-		if let Err(err) = register(ctx).await {
+		if let Err(err) = register(registry, ctx).await {
 			warn!("registering backup capabilities failed (will retry): {err}");
 		}
 	}
@@ -438,7 +457,7 @@ mod backup {
 
 		fn run<'a>(&'a self, ctx: &'a bestool_alertd::TaskContext) -> BoxFuture<'a, Result<()>> {
 			Box::pin(async move {
-				reregister("startup", ctx).await;
+				reregister("startup", &self.registry, ctx).await;
 
 				let (tx, rx) = mpsc::unbounded_channel();
 				// Held for the task's lifetime so events keep arriving. `None` when
@@ -449,7 +468,7 @@ mod backup {
 				// bump on the reload channel; we also re-register on a backups-dir
 				// change and a periodic safety-net tick.
 				event_loop(rx, ctx.reload.clone(), REREGISTER_INTERVAL, |reason| {
-					reregister(reason, ctx)
+					reregister(reason, &self.registry, ctx)
 				})
 				.await;
 				Ok(())


### PR DESCRIPTION
🤖 Two gaps in backup visibility, both closed here:

- `/status` carried nothing about which backups are **configured** — you had to `ls /etc/bestool/backups` on the host to find out.
- The human-readable `bestool alertd status` stopped at the watchdog line and never showed `backups_running` either, even though it was already in the JSON.

The registry now also tracks the configured backup types — refreshed by the capabilities task each time it reads the backups dir, **regardless of canopy connectivity** — and `/status` carries them as `backups_configured` alongside `backups_running`. The status command renders:

```
Watchdog:  10m 0s
Backups:   caddy-config, postgres-config, tamanu-config, tamanu-postgres
  running: 1
           - tamanu-postgres [snapshot] run ba5c9f5b-…, started 2026-06-24T11:27:18Z
```

`Backups:   none configured` when there are no defs; the `running:` block only appears when something is in flight.

Both `backups_configured` and `backups_running` are `#[serde(default)]`, so an older CLI talking to a newer daemon (or vice versa) still parses.
