### PR TITLE
fix(canopy): don't require a device id to back up

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -350,10 +350,12 @@ pub async fn run_backup(
 		.server_id
 		.clone()
 		.ok_or_else(|| miette!("registration has no server id"))?;
-	let device_id = reg
-		.device_id
-		.clone()
-		.ok_or_else(|| miette!("registration has no device id"))?;
+	// device_id is only a snapshot tag: canopy authenticates by the device cert,
+	// the report doesn't carry it, and restore selects by server + type, not
+	// device. Legacy-migrated registrations have no device_id (it's only set by
+	// `canopy register` enrolment), so tag the snapshot when we know it and just
+	// omit the tag otherwise.
+	let device_id = reg.device_id.clone();
 	let base_url = base_url_of(&reg)?;
 
 	let client = build_client(&device_key).await?;
@@ -383,7 +385,16 @@ pub async fn run_backup(
 		password: target.repo_password.0.clone(),
 	};
 	let outcome =
-		run_kopia_backup(&def, &target, &conn, &server_id, &device_id, &run_id, &progress).await;
+		run_kopia_backup(
+			&def,
+			&target,
+			&conn,
+			&server_id,
+			device_id.as_deref(),
+			&run_id,
+			&progress,
+		)
+		.await;
 	emit(&progress, BackupEvent::Phase("report"));
 
 	// Report whatever happened, then surface the original error (if any).
@@ -435,7 +446,7 @@ async fn run_kopia_backup(
 	target: &bestool_canopy::BackupTarget,
 	conn: &RepoConn,
 	server_id: &str,
-	device_id: &str,
+	device_id: Option<&str>,
 	run_id: &str,
 	progress: &Option<BackupProgress>,
 ) -> Result<SnapshotResult> {
@@ -642,13 +653,15 @@ async fn run_hook(hook: &Hook) -> Result<()> {
 fn assemble_tags(
 	def_tags: &BTreeMap<String, String>,
 	extra_tags: &BTreeMap<String, String>,
-	device_id: &str,
+	device_id: Option<&str>,
 	run_id: &str,
 	backup_type: &str,
 ) -> BTreeMap<String, String> {
 	let mut tags = def_tags.clone();
 	tags.extend(extra_tags.iter().map(|(k, v)| (k.clone(), v.clone())));
-	tags.insert("canopy-device".to_owned(), device_id.to_owned());
+	if let Some(device_id) = device_id {
+		tags.insert("canopy-device".to_owned(), device_id.to_owned());
+	}
 	tags.insert("canopy-run".to_owned(), run_id.to_owned());
 	tags.insert("canopy-type".to_owned(), backup_type.to_owned());
 	tags
@@ -781,11 +794,37 @@ mod tests {
 		let mut extra = BTreeMap::new();
 		extra.insert("pg-version".to_owned(), "16".to_owned());
 
-		let tags = assemble_tags(&def_tags, &extra, "device-uuid", "run-uuid", "tamanu-postgres");
+		let tags = assemble_tags(
+			&def_tags,
+			&extra,
+			Some("device-uuid"),
+			"run-uuid",
+			"tamanu-postgres",
+		);
 
 		assert_eq!(tags.get("app").map(String::as_str), Some("tamanu"));
 		assert_eq!(tags.get("pg-version").map(String::as_str), Some("16"));
 		assert_eq!(tags.get("canopy-device").map(String::as_str), Some("device-uuid"));
+		assert_eq!(tags.get("canopy-run").map(String::as_str), Some("run-uuid"));
+		assert_eq!(
+			tags.get("canopy-type").map(String::as_str),
+			Some("tamanu-postgres")
+		);
+	}
+
+	#[test]
+	fn assemble_tags_omits_device_when_absent() {
+		// A legacy-migrated host has no device id; the snapshot is still tagged
+		// with run and type, just without canopy-device.
+		let tags = assemble_tags(
+			&BTreeMap::new(),
+			&BTreeMap::new(),
+			None,
+			"run-uuid",
+			"tamanu-postgres",
+		);
+
+		assert!(!tags.contains_key("canopy-device"));
 		assert_eq!(tags.get("canopy-run").map(String::as_str), Some("run-uuid"));
 		assert_eq!(
 			tags.get("canopy-type").map(String::as_str),


### PR DESCRIPTION
🤖 **Root cause of the silent backup failures.** `run_backup` aborted with:

```
Error:   × registration has no device id
```

…right after `starting backup` and before contacting canopy — which is why the daemon's scheduled runs produced no `backup_report` and no snapshot, yet looked like they'd "started".

`device_id` is only ever set by `canopy register` enrolment. A legacy-migrated registration is built from the old `/etc/tamanu` files (`migrate_from_legacy` in `registration.rs`) with the server id and device key but **no device id** — so backups on every legacy-migrated host failed this check silently, every cycle.

But `device_id` isn't load-bearing:
- it's **not** in `BackupReport` — canopy authenticates by the device cert (SPKI), so it already knows the device;
- restore selects snapshots by `source.host == server_id` and the `canopy-type` tag, **not** `canopy-device`;
- its only use is the informational `canopy-device` kopia snapshot tag.

So this makes it optional: tag the snapshot with `canopy-device` when the registration has a device id, and omit the tag otherwise. A legacy-migrated host now backs up successfully; its snapshots just don't carry the (informational) device tag. No warning — there's currently no way to *fetch* or *set* a device id for a migrated device (canopy returns it only at enrolment), so a nag would be unactionable; recovery, if the tag is ever wanted, is re-running `bestool canopy register`.

Note: small overlap with #545 — both touch the `device_id` binding in `run_backup`. Whichever merges second needs a trivial resolve.
