### PR TITLE
feat(tamanu): invert doctor replay filter and improve the live TUI

### DIFF
--- a/.workhorse/specs/tamanu/doctor.md
+++ b/.workhorse/specs/tamanu/doctor.md
@@ -51,10 +51,14 @@ The same grouping and ordering apply during the live sweep and in the final rend
 When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep.
 Every selected check appears as a row in the list from the start of the sweep, in a pending state.
 A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary.
-As each check completes, its row moves to its grouped-and-ordered position.
+As each check completes, its row moves to its grouped-and-ordered position; a check that completes as skipped is removed from the live list entirely.
+
+When the list of rows is taller than the terminal, the operator can scroll it from the keyboard, and the footer indicates how many rows are hidden above and below the viewport.
 
 A footer line shows an animated spinner together with a running count of how many checks have completed out of the total.
 The source note appears in the TUI as dimmed text.
+
+The sweep continues gathering server facts after the last check completes; the live display stays up and the footer indicates that the sweep is finalising until the sweep fully returns, so the final output appears immediately when the live display tears down rather than after a gap.
 
 On completion, the TUI tears down and the final rendered output is written to the terminal's normal scrollback so it remains visible after the command exits.
 If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and whatever results have been collected so far are written to scrollback before exit.
@@ -63,30 +67,29 @@ If the user interrupts the command (Ctrl+C), the TUI tears down cleanly and what
 
 The final output lists each displayed check on its own row with a coloured outcome tag, the check name, and a one-line summary, in grouped-and-ordered position.
 A blank line separates the check list from the result line.
-The result line gives an overall outcome — healthy, degraded, or failing — and counts of failed, warning, broken, and skipped checks.
+The result line gives an overall outcome — healthy, degraded, or failing — and counts of passed, failed, warning, broken, and skipped checks across the whole sweep, regardless of which checks the replay filter displays.
 The source note appears as dimmed text below the result line.
 The result line is always shown, even when the displayed check list is empty.
 
-## Only-failing filter
+## Result replay filter
 
-The command accepts `--only-failing` and its short form `-F`.
-With the filter set, only checks with warning, broken, or failing outcomes appear in the displayed list and the final output.
-The grouping and ordering rules still apply, so displayed checks are ordered warning, then broken, then failing.
+By default the final rendered output lists only checks with warning, broken, or failing outcomes; passing and skipped checks are omitted.
+`--all` and its short form `-a` instead include every selected check in the output.
+The grouping and ordering rules still apply, so without `--all` the displayed checks are ordered warning, then broken, then failing.
 
-In the live TUI under the filter, pending and running rows remain visible for every selected check; once a check's outcome is known, it stays in the list only if it warned, broke, or failed.
-The footer count under the filter still tracks completion against the full set of selected checks.
-When every selected check passes or is skipped, the displayed list is empty and the result line is shown on its own.
+The filter applies only to the final rendered output, never to the live TUI: passing checks stay visible in the live display even though they are omitted from the default output (skipped checks drop from the live display as described above).
+When no check warns, breaks, or fails and `--all` is not set, the displayed list is empty and the result line is shown on its own.
 
 ## Non-interactive output
 
 When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner.
-Non-interactive output follows the same grouping, ordering, source note, result line, and only-failing filter rules.
+Non-interactive output follows the same grouping, ordering, source note, result line, and replay filter rules.
 
 ## JSON output
 
 When JSON output is requested, the command emits a machine-readable payload and suppresses the human-readable rendering.
 The payload contains the sweep's wire data, a source field naming where the data came from, and a computed-at timestamp when the source is the daemon's last cached sweep.
-The only-failing filter does not affect JSON output: every selected check is included.
+The replay filter does not affect JSON output: every selected check is included.
 
 ## Exit code
 

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1866,7 +1866,9 @@ Exit code 0 on HEALTHY or DEGRADED, 1 on FAILING, 130 on interrupt.
 * `--json` — Emit the JSON wire payload instead of the human-readable render
 * `--check <NAME>` — Run only the named check(s). Repeatable. Defaults to all
 * `--skip <NAME>` — Skip the named check(s). Repeatable. Applied after `--check`
-* `-F`, `--only-failing` — Hide passing and skipped checks; show only warning, broken, and failing
+* `-a`, `--all` — Show every check in the result replay, including passing and skipped.
+
+   By default the replay lists only warning, broken, and failing checks; the live progress view always shows every check regardless.
 * `--fresh` — Force a fresh sweep. With alertd running, asks the daemon to recompute and streams the results back as they come in; without alertd, runs the checks locally exactly like before
 * `--no-daemon` — Skip the alertd integration entirely and always compute locally.
 

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -46,9 +46,12 @@ pub struct DoctorArgs {
 	#[arg(long = "skip", value_name = "NAME")]
 	pub skip: Vec<String>,
 
-	/// Hide passing and skipped checks; show only warning, broken, and failing.
-	#[arg(long = "only-failing", short = 'F')]
-	pub only_failing: bool,
+	/// Show every check in the result replay, including passing and skipped.
+	///
+	/// By default the replay lists only warning, broken, and failing checks; the
+	/// live progress view always shows every check regardless.
+	#[arg(long, short = 'a')]
+	pub all: bool,
 
 	/// Force a fresh sweep. With alertd running, asks the daemon to recompute
 	/// and streams the results back as they come in; without alertd, runs the
@@ -136,7 +139,7 @@ async fn run_local_sweep(
 	live_tty: bool,
 ) -> Result<SweepOutcome> {
 	let selected_names = selected_names(&args.only, &args.skip)?;
-	let (progress, tui_handle) = setup_progress(live_tty, &selected_names, args, SweepSource::Local);
+	let (progress, tui_handle) = setup_progress(live_tty, &selected_names, SweepSource::Local);
 
 	let sweep_args_only = args.only.clone();
 	let sweep_args_skip = args.skip.clone();
@@ -196,12 +199,7 @@ async fn run_daemon_recompute(
 	}
 
 	let selected_names = selected_names(&args.only, &args.skip)?;
-	let (progress, tui_handle) = setup_progress(
-		live_tty,
-		&selected_names,
-		args,
-		SweepSource::DaemonStreamed,
-	);
+	let (progress, tui_handle) = setup_progress(live_tty, &selected_names, SweepSource::DaemonStreamed);
 
 	let stream_handle = tokio::spawn(drain_recompute_stream(response, progress));
 
@@ -410,7 +408,6 @@ fn results_from_wire(payload: &Value) -> Vec<(Check, bool)> {
 fn setup_progress(
 	live_tty: bool,
 	selected_names: &[&'static str],
-	args: &DoctorArgs,
 	source: SweepSource,
 ) -> (
 	Option<ProgressSender>,
@@ -421,8 +418,7 @@ fn setup_progress(
 	}
 	let (tx, rx) = mpsc::unbounded_channel();
 	let names = selected_names.to_vec();
-	let only_failing = args.only_failing;
-	let handle = tokio::spawn(tui::run_tui(names, only_failing, source, rx));
+	let handle = tokio::spawn(tui::run_tui(names, source, rx));
 	(Some(tx), Some(handle))
 }
 
@@ -490,8 +486,8 @@ fn emit_output(
 		return Ok(());
 	}
 
-	let displayed = order::filter_and_sort(&sweep.results, args.only_failing);
-	render::render_plain(&mut out, &displayed, sweep.overall, source, use_colours)
+	let sorted = order::filter_and_sort(&sweep.results, true);
+	render::render_plain(&mut out, &sorted, args.all, sweep.overall, source, use_colours)
 		.into_diagnostic()?;
 	Ok(())
 }
@@ -544,24 +540,24 @@ mod tests {
 	}
 
 	#[test]
-	fn doctor_args_only_failing_short_flag() {
+	fn doctor_args_all_short_flag() {
 		use clap::Parser;
-		let parsed = DoctorArgs::parse_from(["doctor", "-F"]);
-		assert!(parsed.only_failing);
+		let parsed = DoctorArgs::parse_from(["doctor", "-a"]);
+		assert!(parsed.all);
 	}
 
 	#[test]
-	fn doctor_args_only_failing_long_flag() {
+	fn doctor_args_all_long_flag() {
 		use clap::Parser;
-		let parsed = DoctorArgs::parse_from(["doctor", "--only-failing"]);
-		assert!(parsed.only_failing);
+		let parsed = DoctorArgs::parse_from(["doctor", "--all"]);
+		assert!(parsed.all);
 	}
 
 	#[test]
-	fn doctor_args_default_is_no_filter() {
+	fn doctor_args_default_filters_replay() {
 		use clap::Parser;
 		let parsed = DoctorArgs::parse_from(["doctor"]);
-		assert!(!parsed.only_failing);
+		assert!(!parsed.all);
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/tamanu/doctor/order.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/order.rs
@@ -12,10 +12,11 @@ pub fn severity_key(status: &CheckStatus) -> u8 {
 	}
 }
 
-/// Whether a completed check should appear in human-readable output under the
-/// given `only_failing` filter. The filter hides pass and skip outcomes.
-pub fn keep_under_filter(status: &CheckStatus, only_failing: bool) -> bool {
-	if !only_failing {
+/// Whether a completed check should appear in the result replay. By default the
+/// replay shows only warning, broken, and failing checks; `--all` shows
+/// everything (the live progress view always shows every check regardless).
+pub fn keep_in_replay(status: &CheckStatus, show_all: bool) -> bool {
+	if show_all {
 		return true;
 	}
 	matches!(
@@ -33,11 +34,11 @@ pub fn sort_grouped(results: &mut [(Check, bool)]) {
 	});
 }
 
-/// Filter `results` by the `only_failing` flag, leaving them sorted.
-pub fn filter_and_sort(results: &[(Check, bool)], only_failing: bool) -> Vec<(Check, bool)> {
+/// Filter `results` for the replay by the `show_all` flag, leaving them sorted.
+pub fn filter_and_sort(results: &[(Check, bool)], show_all: bool) -> Vec<(Check, bool)> {
 	let mut out: Vec<(Check, bool)> = results
 		.iter()
-		.filter(|(c, _)| keep_under_filter(&c.status, only_failing))
+		.filter(|(c, _)| keep_in_replay(&c.status, show_all))
 		.cloned()
 		.collect();
 	sort_grouped(&mut out);
@@ -102,25 +103,25 @@ mod tests {
 	}
 
 	#[test]
-	fn keep_under_filter_hides_pass_and_skip() {
-		assert!(!keep_under_filter(&CheckStatus::Pass, true));
-		assert!(!keep_under_filter(&CheckStatus::Skip("".into()), true));
-		assert!(keep_under_filter(&CheckStatus::Warning("".into()), true));
-		assert!(keep_under_filter(&CheckStatus::Broken("".into()), true));
-		assert!(keep_under_filter(&CheckStatus::Fail("".into()), true));
+	fn keep_in_replay_default_hides_pass_and_skip() {
+		assert!(!keep_in_replay(&CheckStatus::Pass, false));
+		assert!(!keep_in_replay(&CheckStatus::Skip("".into()), false));
+		assert!(keep_in_replay(&CheckStatus::Warning("".into()), false));
+		assert!(keep_in_replay(&CheckStatus::Broken("".into()), false));
+		assert!(keep_in_replay(&CheckStatus::Fail("".into()), false));
 	}
 
 	#[test]
-	fn keep_under_filter_off_keeps_everything() {
-		assert!(keep_under_filter(&CheckStatus::Pass, false));
-		assert!(keep_under_filter(&CheckStatus::Skip("".into()), false));
-		assert!(keep_under_filter(&CheckStatus::Warning("".into()), false));
-		assert!(keep_under_filter(&CheckStatus::Broken("".into()), false));
-		assert!(keep_under_filter(&CheckStatus::Fail("".into()), false));
+	fn keep_in_replay_show_all_keeps_everything() {
+		assert!(keep_in_replay(&CheckStatus::Pass, true));
+		assert!(keep_in_replay(&CheckStatus::Skip("".into()), true));
+		assert!(keep_in_replay(&CheckStatus::Warning("".into()), true));
+		assert!(keep_in_replay(&CheckStatus::Broken("".into()), true));
+		assert!(keep_in_replay(&CheckStatus::Fail("".into()), true));
 	}
 
 	#[test]
-	fn filter_and_sort_with_only_failing_drops_pass_and_skip() {
+	fn filter_and_sort_default_drops_pass_and_skip() {
 		let input = vec![
 			pass("a"),
 			warn("b"),
@@ -129,7 +130,7 @@ mod tests {
 			broken("e"),
 			pass("f"),
 		];
-		let out = filter_and_sort(&input, true);
+		let out = filter_and_sort(&input, false);
 		let names: Vec<&str> = out.iter().map(|(c, _)| c.name).collect();
 		assert_eq!(names, vec!["b", "e", "d"]);
 	}

--- a/crates/bestool/src/actions/tamanu/doctor/render.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/render.rs
@@ -4,29 +4,34 @@ use owo_colors::OwoColorize;
 
 use bestool_alertd::doctor::check::{Check, CheckStatus, OverallResult};
 
-use super::SweepSource;
-
-/// Width to pad check names to within a rendered list.
-fn name_width(results: &[(Check, bool)]) -> usize {
-	results.iter().map(|(c, _)| c.name.len()).max().unwrap_or(0)
-}
+use super::{SweepSource, order};
 
 /// Render the full human-readable output: grouped check list, blank line,
-/// result line, and dimmed source note. The check list may be empty (under the
-/// `--only-failing` filter on a clean sweep); the result line is shown
-/// regardless.
+/// result line, and dimmed source note. `results` is the complete, sorted set;
+/// the displayed list hides passing and skipped checks unless `show_all` is set
+/// (so a clean sweep shows nothing), but the result line always counts the full
+/// set regardless of what is displayed.
 pub fn render_plain<W: Write>(
 	out: &mut W,
 	results: &[(Check, bool)],
+	show_all: bool,
 	overall: OverallResult,
 	source: &SweepSource,
 	use_colours: bool,
 ) -> io::Result<()> {
-	let width = name_width(results);
-	for (check, _) in results {
+	let displayed: Vec<&(Check, bool)> = results
+		.iter()
+		.filter(|(c, _)| order::keep_in_replay(&c.status, show_all))
+		.collect();
+	let width = displayed
+		.iter()
+		.map(|(c, _)| c.name.len())
+		.max()
+		.unwrap_or(0);
+	for (check, _) in &displayed {
 		write_check_line(out, check, width, use_colours)?;
 	}
-	if !results.is_empty() {
+	if !displayed.is_empty() {
 		writeln!(out)?;
 	}
 	write_result_line(out, results, overall, use_colours)?;
@@ -80,10 +85,11 @@ pub fn write_result_line<W: Write>(
 	overall: OverallResult,
 	use_colours: bool,
 ) -> io::Result<()> {
-	let (mut warnings, mut fails, mut skips, mut brokens) = (0usize, 0usize, 0usize, 0usize);
+	let (mut passes, mut warnings, mut fails, mut skips, mut brokens) =
+		(0usize, 0usize, 0usize, 0usize, 0usize);
 	for (check, _) in results {
 		match &check.status {
-			CheckStatus::Pass => {}
+			CheckStatus::Pass => passes += 1,
 			CheckStatus::Skip(_) => skips += 1,
 			CheckStatus::Warning(_) => warnings += 1,
 			CheckStatus::Fail(_) => fails += 1,
@@ -96,19 +102,9 @@ pub fn write_result_line<W: Write>(
 		OverallResult::Degraded => colour_warn(use_colours, label),
 		OverallResult::Failing => colour_fail(use_colours, label),
 	};
-	let broken_suffix = if brokens > 0 {
-		format!(", {brokens} broken")
-	} else {
-		String::new()
-	};
-	let skip_suffix = if skips > 0 {
-		format!(", {skips} skipped")
-	} else {
-		String::new()
-	};
 	writeln!(
 		out,
-		"Result: {label_coloured} ({fails} failed, {warnings} warning{plural}{broken_suffix}{skip_suffix})",
+		"Result: {label_coloured} ({passes} passed, {fails} failed, {warnings} warning{plural}, {brokens} broken, {skips} skipped)",
 		plural = if warnings == 1 { "" } else { "s" },
 	)
 }
@@ -209,10 +205,10 @@ mod tests {
 	#[test]
 	fn render_plain_lists_results_in_severity_order() {
 		let raw = vec![fail("z-fail"), pass("a-pass"), warn("m-warn")];
-		let sorted = filter_and_sort(&raw, false);
+		let sorted = filter_and_sort(&raw, true);
 		let overall = OverallResult::from_checks(&sorted.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let mut buf = Vec::new();
-		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		render_plain(&mut buf, &sorted, true, overall, &SweepSource::Local, false).unwrap();
 		let out = String::from_utf8(buf).unwrap();
 		let pass_pos = out.find("a-pass").unwrap();
 		let warn_pos = out.find("m-warn").unwrap();
@@ -224,25 +220,28 @@ mod tests {
 	}
 
 	#[test]
-	fn render_plain_only_failing_shows_just_result_line_when_clean() {
+	fn render_plain_default_shows_just_result_line_when_clean() {
 		let raw = vec![pass("a"), pass("b"), skip("c")];
 		let sorted = filter_and_sort(&raw, true);
 		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let mut buf = Vec::new();
-		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		render_plain(&mut buf, &sorted, false, overall, &SweepSource::Local, false).unwrap();
 		let out = String::from_utf8(buf).unwrap();
 		assert!(!out.contains("PASS"));
 		assert!(!out.contains("SKIP"));
 		assert!(out.contains("HEALTHY"));
+		// The result line still reports the full counts even though nothing is listed.
+		assert!(out.contains("2 passed"));
+		assert!(out.contains("1 skipped"));
 	}
 
 	#[test]
-	fn render_plain_only_failing_keeps_warn_broken_fail() {
+	fn render_plain_default_keeps_warn_broken_fail() {
 		let raw = vec![pass("a"), warn("b"), broken("c"), fail("d"), skip("e")];
 		let sorted = filter_and_sort(&raw, true);
 		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let mut buf = Vec::new();
-		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		render_plain(&mut buf, &sorted, false, overall, &SweepSource::Local, false).unwrap();
 		let out = String::from_utf8(buf).unwrap();
 		assert!(out.contains("WARN"));
 		assert!(out.contains("BRKN"));
@@ -260,10 +259,10 @@ mod tests {
 	#[test]
 	fn render_plain_no_server_id_header() {
 		let raw = vec![pass("a")];
-		let sorted = filter_and_sort(&raw, false);
+		let sorted = filter_and_sort(&raw, true);
 		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let mut buf = Vec::new();
-		render_plain(&mut buf, &sorted, overall, &SweepSource::Local, false).unwrap();
+		render_plain(&mut buf, &sorted, true, overall, &SweepSource::Local, false).unwrap();
 		let out = String::from_utf8(buf).unwrap();
 		assert!(!out.contains("server-id"));
 		assert!(!out.contains("Server:"));
@@ -272,21 +271,24 @@ mod tests {
 	#[test]
 	fn render_plain_includes_source_note_for_daemon_streamed() {
 		let raw = vec![pass("a")];
-		let sorted = filter_and_sort(&raw, false);
+		let sorted = filter_and_sort(&raw, true);
 		let overall = OverallResult::from_checks(&raw.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let mut buf = Vec::new();
-		render_plain(&mut buf, &sorted, overall, &SweepSource::DaemonStreamed, false).unwrap();
+		render_plain(&mut buf, &sorted, false, overall, &SweepSource::DaemonStreamed, false).unwrap();
 		let out = String::from_utf8(buf).unwrap();
 		assert!(out.contains("alertd daemon"));
 	}
 
 	#[test]
-	fn result_line_lists_broken_and_skipped_counts() {
+	fn result_line_always_lists_every_count() {
 		let results = vec![broken("a"), skip("b"), pass("c")];
 		let overall = OverallResult::from_checks(&results.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>());
 		let mut buf = Vec::new();
 		write_result_line(&mut buf, &results, overall, false).unwrap();
 		let out = String::from_utf8(buf).unwrap();
+		assert!(out.contains("1 passed"));
+		assert!(out.contains("0 failed"));
+		assert!(out.contains("0 warnings"));
 		assert!(out.contains("1 broken"));
 		assert!(out.contains("1 skipped"));
 		assert!(out.contains("DEGRADED"));

--- a/crates/bestool/src/actions/tamanu/doctor/tui.rs
+++ b/crates/bestool/src/actions/tamanu/doctor/tui.rs
@@ -10,7 +10,7 @@ use crossterm::{
 	style::{Attribute, Color, ResetColor, SetAttribute, SetForegroundColor},
 	terminal::{
 		Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
-		enable_raw_mode,
+		enable_raw_mode, size,
 	},
 };
 use miette::{IntoDiagnostic, Result};
@@ -43,6 +43,24 @@ struct TuiRow {
 pub struct TuiOutcome {
 	pub results: Vec<(Check, bool)>,
 	pub interrupted: bool,
+}
+
+/// Vertical scroll position for the row list when it is taller than the
+/// terminal. `offset` is the number of body lines hidden above the viewport;
+/// `viewport` and `max` are the dimensions from the last draw, used to clamp
+/// keyboard scrolling.
+#[derive(Default)]
+struct Scroll {
+	offset: usize,
+	viewport: usize,
+	max: usize,
+}
+
+impl Scroll {
+	fn by(&mut self, delta: i64) {
+		let next = (self.offset as i64).saturating_add(delta).clamp(0, self.max as i64);
+		self.offset = next as usize;
+	}
 }
 
 /// A single styled segment within a rendered line.
@@ -105,7 +123,6 @@ impl Drop for TerminalGuard {
 /// and every selected check has been seen) or the user interrupts (Ctrl+C / q).
 pub async fn run_tui(
 	selected_names: Vec<&'static str>,
-	only_failing: bool,
 	source: SweepSource,
 	mut progress_rx: UnboundedReceiver<DoctorEvent>,
 ) -> Result<TuiOutcome> {
@@ -118,40 +135,43 @@ pub async fn run_tui(
 		})
 		.collect();
 	let mut spinner = 0usize;
-	let mut interrupted = false;
+	let interrupted;
+	let mut scroll = Scroll::default();
 
 	let mut guard = TerminalGuard::new().into_diagnostic()?;
 
 	loop {
 		drain_progress(&mut progress_rx, &mut rows);
+		let finalising = all_completed(&rows);
 
 		draw(
 			&mut guard.stdout,
 			&rows,
 			total,
 			&source,
-			only_failing,
 			spinner,
+			finalising,
+			&mut scroll,
 		)
 		.into_diagnostic()?;
 
-		if all_completed(&rows) {
+		// The sweep keeps working after the last check reports (gathering server
+		// facts and probing connectivity); its progress sender drops only when it
+		// fully returns. Stay up until the channel closes so the replay prints the
+		// instant the terminal is restored, rather than after a visible gap.
+		if progress_rx.is_closed() && progress_rx.is_empty() {
+			// All checks done means a clean finish; anything less means the sweep
+			// ended early (error or abort) and the caller should exit non-zero.
+			interrupted = !finalising;
 			break;
 		}
 
-		if poll_for_quit(TICK).into_diagnostic()? {
+		if poll_input(TICK, &mut scroll).into_diagnostic()? {
 			interrupted = true;
 			break;
 		}
 
 		spinner = (spinner + 1) % SPINNER_FRAMES.len();
-
-		if progress_rx.is_closed() && progress_rx.is_empty() && !all_completed(&rows) {
-			// Sweep ended early (error or aborted) without producing all results.
-			// Treat as interrupted so the caller exits non-zero.
-			interrupted = true;
-			break;
-		}
 	}
 
 	drop(guard);
@@ -186,9 +206,9 @@ fn all_completed(rows: &[TuiRow]) -> bool {
 	rows.iter().all(|r| matches!(r.state, RowState::Completed(_)))
 }
 
-/// Poll keyboard events for up to `timeout`. Returns true if the user pressed a
-/// quit chord (Ctrl+C or q).
-fn poll_for_quit(timeout: Duration) -> io::Result<bool> {
+/// Poll keyboard events for up to `timeout`, applying scroll keys to `scroll`.
+/// Returns true if the user pressed a quit chord (Ctrl+C or q).
+fn poll_input(timeout: Duration, scroll: &mut Scroll) -> io::Result<bool> {
 	if !event::poll(timeout)? {
 		return Ok(false);
 	}
@@ -199,9 +219,18 @@ fn poll_for_quit(timeout: Duration) -> io::Result<bool> {
 		{
 			let ctrl_c =
 				matches!(code, KeyCode::Char('c')) && modifiers.contains(KeyModifiers::CONTROL);
-			let q = matches!(code, KeyCode::Char('q'));
-			if ctrl_c || q {
+			if ctrl_c || matches!(code, KeyCode::Char('q')) {
 				return Ok(true);
+			}
+			let page = scroll.viewport.max(1) as i64;
+			match code {
+				KeyCode::Up | KeyCode::Char('k') => scroll.by(-1),
+				KeyCode::Down | KeyCode::Char('j') => scroll.by(1),
+				KeyCode::PageUp => scroll.by(-page),
+				KeyCode::PageDown | KeyCode::Char(' ') => scroll.by(page),
+				KeyCode::Home | KeyCode::Char('g') => scroll.by(i64::MIN),
+				KeyCode::End | KeyCode::Char('G') => scroll.by(i64::MAX),
+				_ => {}
 			}
 		}
 	}
@@ -213,22 +242,43 @@ fn draw(
 	rows: &[TuiRow],
 	total: usize,
 	source: &SweepSource,
-	only_failing: bool,
 	spinner: usize,
+	finalising: bool,
+	scroll: &mut Scroll,
 ) -> io::Result<()> {
-	queue!(out, MoveTo(0, 0), Clear(ClearType::All))?;
+	let term_rows = size().map(|(_, r)| r as usize).unwrap_or(24).max(2);
 
-	let mut lines: Vec<StyledLine> = Vec::new();
+	let mut body: Vec<StyledLine> = Vec::new();
 	if let Some(line) = source_line(source) {
-		lines.push(line);
+		body.push(line);
 	}
-	lines.extend(build_rows(rows, only_failing, spinner));
-	lines.push(footer_line(rows, total, spinner));
+	body.extend(build_rows(rows, spinner));
 
-	for line in lines {
-		write_line(out, &line)?;
+	// Reserve the last terminal row for the always-visible footer.
+	let viewport = term_rows - 1;
+	scroll.viewport = viewport;
+	scroll.max = body.len().saturating_sub(viewport);
+	scroll.offset = scroll.offset.min(scroll.max);
+
+	let end = (scroll.offset + viewport).min(body.len());
+	let visible = &body[scroll.offset..end];
+
+	// Redraw in place rather than clearing the whole screen first: clearing to
+	// end-of-line per row and filling the rest of the viewport avoids the flash
+	// that a full clear produces on every tick.
+	queue!(out, MoveTo(0, 0))?;
+	for line in visible {
+		write_line(out, line)?;
+		queue!(out, Clear(ClearType::UntilNewLine))?;
 		out.write_all(b"\r\n")?;
 	}
+	for _ in visible.len()..viewport {
+		queue!(out, Clear(ClearType::UntilNewLine))?;
+		out.write_all(b"\r\n")?;
+	}
+
+	write_line(out, &footer_line(rows, total, spinner, finalising, scroll))?;
+	queue!(out, Clear(ClearType::UntilNewLine))?;
 	out.flush()
 }
 
@@ -263,14 +313,16 @@ fn source_line(source: &SweepSource) -> Option<StyledLine> {
 	Some(vec![dim(text)])
 }
 
-fn build_rows(rows: &[TuiRow], only_failing: bool, spinner: usize) -> Vec<StyledLine> {
+fn build_rows(rows: &[TuiRow], spinner: usize) -> Vec<StyledLine> {
 	let name_width = rows.iter().map(|r| r.name.len()).max().unwrap_or(0);
 
+	// Skipped checks drop out of the live list once their outcome is known;
+	// pending and running rows stay until they resolve.
 	let mut ordered: Vec<&TuiRow> = rows
 		.iter()
 		.filter(|row| match &row.state {
 			RowState::Running => true,
-			RowState::Completed(check) => order::keep_under_filter(&check.status, only_failing),
+			RowState::Completed(check) => !matches!(check.status, CheckStatus::Skip(_)),
 		})
 		.collect();
 	ordered.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)).then_with(|| a.name.cmp(b.name)));
@@ -350,13 +402,32 @@ fn tag_for(check: &Check) -> (&'static str, Color) {
 	}
 }
 
-fn footer_line(rows: &[TuiRow], total: usize, spinner: usize) -> StyledLine {
+fn footer_line(
+	rows: &[TuiRow],
+	total: usize,
+	spinner: usize,
+	finalising: bool,
+	scroll: &Scroll,
+) -> StyledLine {
 	let completed = rows
 		.iter()
 		.filter(|r| matches!(r.state, RowState::Completed(_)))
 		.count();
 	let frame = SPINNER_FRAMES[spinner % SPINNER_FRAMES.len()];
-	vec![dim(format!("{frame} {completed} / {total} complete"))]
+	let status = if finalising {
+		format!("{frame} finalising… ({completed} / {total} checks done)")
+	} else {
+		format!("{frame} {completed} / {total} complete")
+	};
+	let mut line = vec![dim(status)];
+	if scroll.max > 0 {
+		let above = scroll.offset;
+		let below = scroll.max - scroll.offset;
+		line.push(dim(format!(
+			"   ↑/↓ scroll ({above} above, {below} below)"
+		)));
+	}
+	line
 }
 
 #[cfg(test)]
@@ -368,7 +439,7 @@ mod tests {
 	}
 
 	#[test]
-	fn build_rows_orders_running_then_pass_skip_warn_broken_fail() {
+	fn build_rows_orders_running_then_pass_warn_broken_fail() {
 		let rows = vec![
 			TuiRow {
 				name: "z-fail",
@@ -387,15 +458,11 @@ mod tests {
 				state: RowState::Running,
 			},
 			TuiRow {
-				name: "b-skip",
-				state: RowState::Completed(Check::skip("b-skip", "n/a", "r")),
-			},
-			TuiRow {
 				name: "c-broken",
 				state: RowState::Completed(Check::broken("c-broken", "broke", "r")),
 			},
 		];
-		let lines = build_rows(&rows, false, 0);
+		let lines = build_rows(&rows, 0);
 		let joined: Vec<String> = lines.iter().map(line_text).collect();
 		let positions = |needle: &str| {
 			joined
@@ -404,14 +471,13 @@ mod tests {
 				.unwrap_or_else(|| panic!("missing {needle}"))
 		};
 		assert!(positions("k-run") < positions("a-pass"));
-		assert!(positions("a-pass") < positions("b-skip"));
-		assert!(positions("b-skip") < positions("m-warn"));
+		assert!(positions("a-pass") < positions("m-warn"));
 		assert!(positions("m-warn") < positions("c-broken"));
 		assert!(positions("c-broken") < positions("z-fail"));
 	}
 
 	#[test]
-	fn build_rows_only_failing_drops_completed_pass_and_skip_but_keeps_running() {
+	fn build_rows_drops_completed_skip_but_keeps_pass_and_running() {
 		let rows = vec![
 			TuiRow {
 				name: "a-pass",
@@ -430,11 +496,11 @@ mod tests {
 				state: RowState::Running,
 			},
 		];
-		let lines = build_rows(&rows, true, 0);
+		let lines = build_rows(&rows, 0);
 		let joined: Vec<String> = lines.iter().map(line_text).collect();
 		assert!(joined.iter().any(|s| s.contains("d-run")));
 		assert!(joined.iter().any(|s| s.contains("c-warn")));
-		assert!(!joined.iter().any(|s| s.contains("a-pass")));
+		assert!(joined.iter().any(|s| s.contains("a-pass")));
 		assert!(!joined.iter().any(|s| s.contains("b-skip")));
 	}
 
@@ -454,7 +520,54 @@ mod tests {
 				state: RowState::Running,
 			},
 		];
-		let line = footer_line(&rows, 3, 0);
+		let line = footer_line(&rows, 3, 0, false, &Scroll::default());
 		assert!(line_text(&line).contains("2 / 3 complete"));
+	}
+
+	#[test]
+	fn footer_shows_finalising_when_all_done() {
+		let rows = vec![TuiRow {
+			name: "a",
+			state: RowState::Completed(Check::pass("a", "ok")),
+		}];
+		let line = footer_line(&rows, 1, 0, true, &Scroll::default());
+		assert!(line_text(&line).contains("finalising"));
+	}
+
+	#[test]
+	fn footer_shows_scroll_hint_only_when_scrollable() {
+		let rows = vec![TuiRow {
+			name: "a",
+			state: RowState::Running,
+		}];
+		let none = footer_line(&rows, 1, 0, false, &Scroll::default());
+		assert!(!line_text(&none).contains("scroll"));
+
+		let scroll = Scroll {
+			offset: 2,
+			viewport: 5,
+			max: 7,
+		};
+		let some = footer_line(&rows, 1, 0, false, &scroll);
+		let text = line_text(&some);
+		assert!(text.contains("2 above"));
+		assert!(text.contains("5 below"));
+	}
+
+	#[test]
+	fn scroll_by_clamps_to_range() {
+		let mut s = Scroll {
+			offset: 0,
+			viewport: 5,
+			max: 4,
+		};
+		s.by(-1);
+		assert_eq!(s.offset, 0);
+		s.by(2);
+		assert_eq!(s.offset, 2);
+		s.by(100);
+		assert_eq!(s.offset, 4);
+		s.by(i64::MIN);
+		assert_eq!(s.offset, 0);
 	}
 }


### PR DESCRIPTION
🤖 Inverts the `tamanu doctor` result filter and reworks the live TUI.

## Filter

Replaces `--only-failing`/`-F` with `--all`/`-a`. By default the result replay now lists only warning, broken, and failing checks; `--all` includes every selected check. The filter applies only to the final output — the live progress view shows every check regardless.

## Live TUI

- Skipped checks drop from the live list once they resolve (pending and running rows stay until they complete).
- The list scrolls from the keyboard when it is taller than the terminal, and the footer shows how many rows are hidden above and below the viewport.
- Redraws in place instead of clearing the whole screen each tick, removing the flicker.
- Stays up while the sweep finalises server facts after the last check completes, showing a finalising state in the footer, so the final output prints the instant the display tears down rather than after a visible gap.

## Result line

Always reports the full passed/failed/warning/broken/skipped counts across the whole sweep, regardless of which checks the replay filter displays.

Spec in `.workhorse/specs/tamanu/doctor.md` and the generated `USAGE.md` are updated to match.
