### PR TITLE
fix(alertd): give kopia backups writable cache and state under the sandbox

### DIFF
--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -50,12 +50,22 @@ NoNewPrivileges=yes
 ProtectSystem=strict
 # read-only, NOT `yes`: a tamanu install may live under /home.
 ProtectHome=read-only
-CacheDirectory=bestool
-# Point the `dirs` crate's cache at /var/cache/bestool (the CacheDirectory).
+# Two managed cache dirs under /var/cache (everything else there is read-only
+# under ProtectSystem=strict): `bestool` for our own cache, and `kopia` because
+# kopia derives its log/cache directory from XDG_CACHE_HOME (set to /var/cache
+# below) as <XDG_CACHE_HOME>/kopia, i.e. /var/cache/kopia — without this it
+# fails the backup with "mkdir /var/cache/kopia: read-only file system".
+CacheDirectory=bestool kopia
+# XDG_CACHE_HOME=/var/cache: the `dirs` crate appends "bestool" (→ the bestool
+# CacheDirectory) and kopia appends "kopia" (→ the kopia CacheDirectory above).
 Environment=XDG_CACHE_HOME=%C
 # bestool writes to its config dir, which ProtectSystem=strict otherwise
 # locks read-only along with the rest of /etc.
 ReadWritePaths=/etc/bestool
+# The canopy-managed kopia repo config lives at /var/lib/kopia/.config, and
+# postgres backups stage their snapshot/base-backup under
+# /var/lib/kopia/bestool-backup before kopia reads it — both need to be writable.
+ReadWritePaths=/var/lib/kopia
 # podman cp's tempdir lands in a private /tmp.
 PrivateTmp=yes
 


### PR DESCRIPTION
🤖 Canopy-managed backups failed under the daemon's `ProtectSystem=strict` sandbox, which makes `/var/cache` and `/var/lib` read-only except for explicitly-allowed paths:

```
backup failed: kopia repository connect failed: Unable to create logs directory: mkdir /var/cache/kopia: read-only file system
backup failed: creating /var/lib/kopia/bestool-backup/tamanu-postgres/18 ... read-only file system
```

Two causes:

- The daemon runs kopia directly as root, so kopia inherits `XDG_CACHE_HOME` (set to `/var/cache` in the unit) and derives its log/cache directory as `<XDG_CACHE_HOME>/kopia` = `/var/cache/kopia`. Only the `bestool` `CacheDirectory` (`/var/cache/bestool`) was writable, so kopia couldn't create its log dir.
- Postgres backups stage their snapshot / base backup under `/var/lib/kopia/bestool-backup` (a stable path kopia reads from), and `/var/lib/kopia` wasn't in `ReadWritePaths`.

Fix, both in the unit:

- Add a `kopia` `CacheDirectory`, so systemd creates and grants write to `/var/cache/kopia` — exactly where kopia puts its logs/cache given `XDG_CACHE_HOME=/var/cache`.
- Add `ReadWritePaths=/var/lib/kopia` for the repo config (`/var/lib/kopia/.config`) and the backup staging (`/var/lib/kopia/bestool-backup`).

Note: this covers the base-backup and config paths reported. The btrfs/LVM snapshot path also mounts at `/mnt/bestool-btrfs-toplevel.<pid>`, and `/mnt` is read-only under `ProtectSystem=strict` (plus mount propagation in the unit's namespace is its own question) — that path isn't addressed here and likely needs separate work; flagging rather than guessing at it.
