### PR TITLE
fix(alertd): let snapshot backups run under the daemon sandbox

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -18,8 +18,13 @@ use tracing::{info, warn};
 
 use super::{resolve::ResolvedCluster, sys};
 
+/// Directory the per-run top-level mounts live in. Under `/var/lib/kopia` (not
+/// `/mnt`) so it sits within the daemon's one writable path — `/mnt` is
+/// read-only under the unit's `ProtectSystem=strict`.
+const TOPLEVEL_MOUNT_DIR: &str = "/var/lib/kopia";
+
 /// Where the reaper looks for / makes per-run top-level mounts.
-const TOPLEVEL_MOUNT_PREFIX: &str = "/mnt/bestool-btrfs-toplevel";
+const TOPLEVEL_MOUNT_PREFIX: &str = "/var/lib/kopia/bestool-btrfs-toplevel";
 
 /// Infix marking our ephemeral snapshot subvolumes, so the reaper's glob can
 /// never match a live subvolume.
@@ -143,7 +148,7 @@ pub async fn teardown(mounts: Mounts) -> Result<()> {
 async fn reap_stale(fsdev: &str, kopia_mount: &Path) {
 	sys::umount(kopia_mount).await;
 
-	if let Ok(entries) = sys::glob_prefix("/mnt", "bestool-btrfs-toplevel.") {
+	if let Ok(entries) = sys::glob_prefix(TOPLEVEL_MOUNT_DIR, "bestool-btrfs-toplevel.") {
 		for stale in entries {
 			sys::umount(&stale).await;
 			sys::rmdir(&stale).await;
@@ -191,7 +196,7 @@ mod tests {
 	fn toplevel_mount_path() {
 		assert_eq!(
 			toplevel_mount(7),
-			PathBuf::from("/mnt/bestool-btrfs-toplevel.7")
+			PathBuf::from("/var/lib/kopia/bestool-btrfs-toplevel.7")
 		);
 	}
 }

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -79,11 +79,21 @@ ProtectHostname=yes
 # but NOT ProcSubset=pid — sysinfo needs /proc/meminfo and /proc/loadavg.
 ProtectProc=invisible
 
-PrivateDevices=yes
-# safe only because CONTAINER_HOST points at the (remote) rootful podman.
-RestrictNamespaces=yes
+# no, not yes: postgres snapshot backups (btrfs/thin-LVM) mount the snapshot
+# block device (/dev/disk/by-uuid/*, /dev/<vg>/<lv>) read-only for kopia, which
+# a private /dev would hide. The container work still goes to the remote rootful
+# podman, so no local device node is needed for that.
+PrivateDevices=no
+# user only (not yes = block all): the read-only snapshot is mounted with
+# X-mount.idmap so the kopia user can read postgres-owned files, and an
+# idmapped mount creates a user namespace. No other namespace type is allowed —
+# the container work still goes to the remote rootful podman.
+RestrictNamespaces=user
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 SystemCallFilter=@system-service
+# @mount (mount/umount/mount_setattr/…): snapshot backups mount the snapshot
+# read-only for kopia and unmount it afterwards; without it mount() is EPERM.
+SystemCallFilter=@mount
 SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
 LockPersonality=yes


### PR DESCRIPTION
🤖 Stacked on #554.

The btrfs/thin-LVM snapshot backends never actually ran under the daemon's `ProtectSystem=strict` sandbox — `prepare()` caught the failure and fell back to `pg_basebackup` (correct, but a full copy each run). Three sandbox guards blocked the snapshot path:

- **`/mnt` is read-only.** The btrfs per-run top-level mount lived at `/mnt/bestool-btrfs-toplevel.<pid>`. Moved it under `/var/lib/kopia` (the daemon's one writable path, from #554). LVM was already fine — it only mounts at `/var/lib/kopia/...`.
- **Private `/dev` hid the snapshot block devices.** `mount /dev/disk/by-uuid/...` (btrfs) and `/dev/<vg>/<lv>` (LVM) can't resolve under `PrivateDevices=yes` → set `PrivateDevices=no`.
- **`mount` was filtered out, and idmapped mounts need a user namespace.** `SystemCallFilter=@system-service` excludes `@mount`, and `X-mount.idmap` (so the kopia user can read postgres-owned files) creates a user namespace blocked by `RestrictNamespaces=yes`. Added `SystemCallFilter=@mount` and narrowed `RestrictNamespaces=yes` → `RestrictNamespaces=user`.

This is a real reduction of the daemon's hardening (the unit still keeps `CAP_SYS_ADMIN`, `ProtectSystem=strict`, `NoNewPrivileges`, kernel/clock/hostname protections, etc.). It's the trade-off for running snapshot backups in-process rather than in a separate unit.

kopia still runs as root here; the kopia-user switch (which actually exercises the idmap) follows in a stacked PR.

Not runtime-verifiable from my environment (no btrfs host / sandbox) — the unit tests cover the path relocation; the sandbox directives need a real host to confirm.
