### PR TITLE
feat(alertd): run canopy backups as the kopia user under the hardened daemon

### DIFF
--- a/crates/alertd/src/doctor/checks/kopia_backup.rs
+++ b/crates/alertd/src/doctor/checks/kopia_backup.rs
@@ -108,6 +108,7 @@ async fn run_linux() -> Check {
 fn elevation_label(e: &Elevation) -> &'static str {
 	match e {
 		Elevation::Direct => "direct",
+		Elevation::SetPriv => "setpriv",
 		Elevation::Sudo => "sudo",
 		Elevation::Skip(_) => "skip",
 	}

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -22,7 +22,7 @@ use bestool_canopy::{
 	registration::Registration,
 };
 use bestool_kopia::{
-	S3KopiaEnv, args_policy_set_ignores, args_repository_connect_s3, args_snapshot_create,
+	RunAs, S3KopiaEnv, args_policy_set_ignores, args_repository_connect_s3, args_snapshot_create,
 	build_kopia_command_with_s3, find_kopia_binary,
 	proxy::{self, RunningProxy, S3ProxyConfig},
 };
@@ -302,8 +302,9 @@ pub(super) async fn connect_repo(
 	target: &bestool_canopy::BackupTarget,
 	endpoint: &str,
 	server_id: &str,
+	run_as: RunAs,
 ) -> Result<()> {
-	let mut connect = build_kopia_command_with_s3(kopia, s3env).map_err(|e| miette!("{e}"))?;
+	let mut connect = build_kopia_command_with_s3(kopia, s3env, run_as).map_err(|e| miette!("{e}"))?;
 	args_repository_connect_s3(
 		&mut connect,
 		&target.bucket,
@@ -533,20 +534,39 @@ async fn snapshot(
 		.into_diagnostic()
 		.wrap_err("creating transient kopia config dir")?;
 	let config_path = config_dir.path().join("repository.config");
+
+	// When kopia runs as the kopia user (not us), it writes and reads this config
+	// itself, so hand the dir to that user. Root-owned 0700 tempdir would deny it.
+	#[cfg(target_os = "linux")]
+	if let Some(user) = bestool_kopia::kopia_run_as_user() {
+		let status = tokio::process::Command::new("chown")
+			.arg("-R")
+			.arg(format!("{user}:{user}"))
+			.arg(config_dir.path())
+			.status()
+			.await
+			.into_diagnostic()
+			.wrap_err("handing the transient kopia config dir to the kopia user")?;
+		if !status.success() {
+			bail!("chown of transient kopia config dir to {user} failed ({status})");
+		}
+	}
 	let s3env = S3KopiaEnv {
 		password: &conn.password,
 		config_path: &config_path,
 	};
 
-	connect_repo(&kopia, &s3env, target, &conn.endpoint, server_id).await?;
+	connect_repo(&kopia, &s3env, target, &conn.endpoint, server_id, RunAs::KopiaUser).await?;
 
 	if !ignore.is_empty() {
-		let mut policy = build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
+		let mut policy =
+			build_kopia_command_with_s3(&kopia, &s3env, RunAs::KopiaUser).map_err(|e| miette!("{e}"))?;
 		args_policy_set_ignores(&mut policy, source_path, ignore);
 		run_kopia(policy, "policy set").await?;
 	}
 
-	let mut create = build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
+	let mut create =
+		build_kopia_command_with_s3(&kopia, &s3env, RunAs::KopiaUser).map_err(|e| miette!("{e}"))?;
 	// Force kopia's progress output (it stays silent on a non-TTY otherwise) and
 	// stream it, but only when someone's watching — a local run discards stderr.
 	let stdout = if progress.is_some() {

--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -18,8 +18,13 @@ use tracing::{info, warn};
 
 use super::{resolve::ResolvedCluster, sys};
 
+/// Directory the per-run top-level mounts live in. Under `/var/lib/kopia` (not
+/// `/mnt`) so it sits within the daemon's one writable path — `/mnt` is
+/// read-only under the unit's `ProtectSystem=strict`.
+const TOPLEVEL_MOUNT_DIR: &str = "/var/lib/kopia";
+
 /// Where the reaper looks for / makes per-run top-level mounts.
-const TOPLEVEL_MOUNT_PREFIX: &str = "/mnt/bestool-btrfs-toplevel";
+const TOPLEVEL_MOUNT_PREFIX: &str = "/var/lib/kopia/bestool-btrfs-toplevel";
 
 /// Infix marking our ephemeral snapshot subvolumes, so the reaper's glob can
 /// never match a live subvolume.
@@ -143,7 +148,7 @@ pub async fn teardown(mounts: Mounts) -> Result<()> {
 async fn reap_stale(fsdev: &str, kopia_mount: &Path) {
 	sys::umount(kopia_mount).await;
 
-	if let Ok(entries) = sys::glob_prefix("/mnt", "bestool-btrfs-toplevel.") {
+	if let Ok(entries) = sys::glob_prefix(TOPLEVEL_MOUNT_DIR, "bestool-btrfs-toplevel.") {
 		for stale in entries {
 			sys::umount(&stale).await;
 			sys::rmdir(&stale).await;
@@ -191,7 +196,7 @@ mod tests {
 	fn toplevel_mount_path() {
 		assert_eq!(
 			toplevel_mount(7),
-			PathBuf::from("/mnt/bestool-btrfs-toplevel.7")
+			PathBuf::from("/var/lib/kopia/bestool-btrfs-toplevel.7")
 		);
 	}
 }

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -13,8 +13,8 @@ use std::{
 
 use bestool_canopy::{Purpose, TargetOutcome};
 use bestool_kopia::{
-	S3KopiaEnv, Snapshot, args_snapshot_list, args_snapshot_restore, build_kopia_command_with_s3,
-	find_kopia_binary,
+	RunAs, S3KopiaEnv, Snapshot, args_snapshot_list, args_snapshot_restore,
+	build_kopia_command_with_s3, find_kopia_binary,
 };
 use clap::Parser;
 use miette::{Context as _, IntoDiagnostic as _, Result, bail, miette};
@@ -114,7 +114,15 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		config_path: &config_path,
 	};
 	let kopia = find_kopia_binary(None).ok_or_else(|| miette!("could not find the kopia binary"))?;
-	connect_repo(&kopia, &s3env, &target, &proxy.endpoint(), &server_id).await?;
+	connect_repo(
+		&kopia,
+		&s3env,
+		&target,
+		&proxy.endpoint(),
+		&server_id,
+		RunAs::CurrentUser,
+	)
+	.await?;
 
 	// Select the snapshot to restore.
 	let snapshots = list_snapshots(&kopia, &s3env).await?;
@@ -138,8 +146,8 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 	if staging.exists() {
 		tokio::fs::remove_dir_all(&staging).await.ok();
 	}
-	let mut restore_cmd =
-		build_kopia_command_with_s3(&kopia, &s3env).map_err(|e| miette!("{e}"))?;
+	let mut restore_cmd = build_kopia_command_with_s3(&kopia, &s3env, RunAs::CurrentUser)
+		.map_err(|e| miette!("{e}"))?;
 	args_snapshot_restore(&mut restore_cmd, &snapshot.id, &staging);
 	run_kopia(restore_cmd, "snapshot restore").await?;
 
@@ -152,7 +160,8 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 }
 
 async fn list_snapshots(kopia: &std::path::Path, s3env: &S3KopiaEnv<'_>) -> Result<Vec<Snapshot>> {
-	let mut cmd = build_kopia_command_with_s3(kopia, s3env).map_err(|e| miette!("{e}"))?;
+	let mut cmd = build_kopia_command_with_s3(kopia, s3env, RunAs::CurrentUser)
+		.map_err(|e| miette!("{e}"))?;
 	args_snapshot_list(&mut cmd);
 	let stdout = run_kopia(cmd, "snapshot list").await?;
 	serde_json::from_str(stdout.trim())

--- a/crates/bestool/src/actions/kopia/common.rs
+++ b/crates/bestool/src/actions/kopia/common.rs
@@ -41,6 +41,10 @@ pub fn maybe_reexec_as_kopia(args: &KopiaArgs) -> Result<()> {
 	}
 	match linux_elevation() {
 		Elevation::Direct => Ok(()),
+		Elevation::SetPriv => {
+			debug!("re-executing under setpriv as {LINUX_KOPIA_USER}");
+			exec_under_setpriv(LINUX_KOPIA_USER)
+		}
 		Elevation::Sudo => {
 			debug!("re-executing under sudo -u {LINUX_KOPIA_USER}");
 			exec_under_sudo(LINUX_KOPIA_USER)
@@ -52,21 +56,44 @@ pub fn maybe_reexec_as_kopia(args: &KopiaArgs) -> Result<()> {
 	}
 }
 
-/// Replace the current process with `sudo -u <user> -- <argv>`. Only
-/// returns if the exec itself failed.
+/// Replace the current process with the given elevation wrapper around our own
+/// argv, running as the kopia user's home so kopia's config/cache resolve there.
+/// Only returns if the exec itself failed.
 #[cfg(unix)]
-fn exec_under_sudo(user: &str) -> Result<()> {
+fn exec_as_kopia(mut cmd: std::process::Command) -> Result<()> {
 	use std::os::unix::process::CommandExt;
 
 	let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
 	let Some((exe, rest)) = argv.split_first() else {
 		return Err(miette!("no argv to re-exec"));
 	};
-
-	let mut cmd = std::process::Command::new("sudo");
-	cmd.arg("-u").arg(user).arg("--").arg(exe).args(rest);
+	cmd.arg(exe).args(rest);
+	cmd.env("HOME", bestool_kopia::LINUX_KOPIA_HOME);
+	cmd.env_remove("XDG_CACHE_HOME");
 	let err = cmd.exec();
-	Err(miette!("failed to re-exec under sudo: {err}"))
+	Err(miette!("failed to re-exec as the kopia user: {err}"))
+}
+
+/// `setpriv --reuid <user> --regid <user> --init-groups -- <argv>` (root drops
+/// privileges; works under NoNewPrivileges where sudo can't).
+#[cfg(unix)]
+fn exec_under_setpriv(user: &str) -> Result<()> {
+	let mut cmd = std::process::Command::new("setpriv");
+	cmd.args(["--reuid", user, "--regid", user, "--init-groups", "--"]);
+	exec_as_kopia(cmd)
+}
+
+#[cfg(not(unix))]
+fn exec_under_setpriv(_user: &str) -> Result<()> {
+	Err(miette!("setpriv re-exec only supported on Unix"))
+}
+
+/// `sudo -u <user> -- <argv>` (non-root escalation).
+#[cfg(unix)]
+fn exec_under_sudo(user: &str) -> Result<()> {
+	let mut cmd = std::process::Command::new("sudo");
+	cmd.arg("-u").arg(user).arg("--");
+	exec_as_kopia(cmd)
 }
 
 #[cfg(not(unix))]

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -8,10 +8,11 @@
 //! - [`find_kopia_binary`] / [`find_windows_kopia_binary`] /
 //!   [`find_windows_kopia_config`]: locate kopia and (on Windows) the per-user
 //!   repository config from KopiaUI's standard install locations.
-//! - [`linux_elevation`]: decide whether/how to elevate to the `kopia` system
-//!   user on Linux. Returns [`Elevation::Sudo`] when we're not the kopia user
-//!   and the system kopia install is present, [`Elevation::Direct`] when we
-//!   already have access, [`Elevation::Skip`] otherwise.
+//! - [`linux_elevation`]: decide how to run kopia as the `kopia` system user on
+//!   Linux — [`Elevation::SetPriv`] (drop from root) or [`Elevation::Sudo`]
+//!   (escalate as a mortal) when the system install is present,
+//!   [`Elevation::Direct`] when we already have access, [`Elevation::Skip`]
+//!   otherwise.
 //! - [`Snapshot`] and [`fetch_snapshots`]: deserialise `kopia snapshot list
 //!   --json` output into a typed shape.
 //! - [`SnapshotFilter`] / [`build_filter`]: in-process filtering of a snapshot
@@ -35,6 +36,11 @@ pub mod proxy;
 
 /// System user that owns the Linux kopia install.
 pub const LINUX_KOPIA_USER: &str = "kopia";
+
+/// Home directory of the [`LINUX_KOPIA_USER`]. Kopia derives its config
+/// (`$HOME/.config/kopia`) and cache/logs (`$HOME/.cache/kopia`) from it, so we
+/// set `HOME` to this when running kopia as that user.
+pub const LINUX_KOPIA_HOME: &str = "/var/lib/kopia";
 
 /// Standard location of the system kopia repository config on Linux. Owned
 /// by the [`LINUX_KOPIA_USER`].
@@ -122,32 +128,48 @@ pub fn current_username() -> Option<String> {
 	whoami::username().ok()
 }
 
-/// What to do about elevation on Linux when we want to run kopia.
-#[derive(Debug)]
+/// How to run kopia as the [`LINUX_KOPIA_USER`] on Linux.
+#[derive(Debug, PartialEq, Eq)]
 pub enum Elevation {
 	/// Run as the current user — either we're already the kopia user, or
 	/// there's no system kopia install (the operator's running their own).
 	Direct,
-	/// Wrap the kopia invocation in `sudo -u kopia --`. Used whenever we're
-	/// running as a different user and the system kopia install exists; if
-	/// `sudo` isn't allowed (no NOPASSWD rule, no TTY), the resulting kopia
-	/// invocation will fail and the caller surfaces that as a Skip.
+	/// We're root: drop to the kopia user with `setpriv`. A privilege *drop*,
+	/// so it works under the daemon's `NoNewPrivileges` (where `sudo`, which
+	/// must be able to gain privileges, refuses to run).
+	SetPriv,
+	/// We're a non-root user: elevate to the kopia user with `sudo -u kopia`.
+	/// If `sudo` isn't allowed (no NOPASSWD rule, no TTY), the kopia invocation
+	/// fails and the caller surfaces that as a Skip.
 	Sudo,
 	/// We can't elevate. The caller should bail with a reason.
 	Skip(String),
 }
 
-/// Decide how to invoke kopia on Linux given the current user and whether
-/// the system kopia install is present (and accessible).
+/// Whether the current process's effective uid is 0. No `libc` in the tree, so
+/// ask `id -u` (the backup code resolves uids the same way).
+#[cfg(target_os = "linux")]
+fn is_root() -> bool {
+	std::process::Command::new("id")
+		.arg("-u")
+		.output()
+		.ok()
+		.filter(|o| o.status.success())
+		.and_then(|o| String::from_utf8(o.stdout).ok())
+		.map(|s| s.trim() == "0")
+		.unwrap_or(false)
+}
+
+/// Decide how to invoke kopia on Linux. We always run kopia *as the kopia user*,
+/// never as whoever we happen to be, so the repo config/cache stay owned by that
+/// user and the snapshot's idmapped files are readable.
 ///
-/// Logic:
-/// - If we're the kopia user, run directly.
-/// - Else, probe the system kopia config:
-///   - Not found (ENOENT): no system install. Run directly as current user;
-///     they're presumably running their own kopia under their own config.
-///   - Permission denied (EACCES): exists, owned by kopia user. Elevate via
-///     `sudo -u kopia`.
-///   - Readable: exists and we can read it (unusual mode). Run directly.
+/// - If we're already the kopia user, run directly.
+/// - Else probe the system kopia config:
+///   - Not found (ENOENT): no system install. Run directly as the current user
+///     (they're running their own kopia under their own config).
+///   - Exists (readable as root, or EACCES as a mortal): run as the kopia user —
+///     `setpriv` when we're root, `sudo` otherwise.
 #[cfg(target_os = "linux")]
 pub fn linux_elevation() -> Elevation {
 	let Some(user) = current_username() else {
@@ -158,11 +180,19 @@ pub fn linux_elevation() -> Elevation {
 		return Elevation::Direct;
 	}
 
-	match std::fs::metadata(LINUX_KOPIA_CONFIG) {
-		Ok(_) => Elevation::Direct,
-		Err(err) if err.kind() == std::io::ErrorKind::NotFound => Elevation::Direct,
-		Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => Elevation::Sudo,
-		Err(err) => Elevation::Skip(format!("checking {LINUX_KOPIA_CONFIG}: {err}")),
+	let exists = match std::fs::metadata(LINUX_KOPIA_CONFIG) {
+		Ok(_) => true,
+		Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+		Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => true,
+		Err(err) => return Elevation::Skip(format!("checking {LINUX_KOPIA_CONFIG}: {err}")),
+	};
+	if !exists {
+		return Elevation::Direct;
+	}
+	if is_root() {
+		Elevation::SetPriv
+	} else {
+		Elevation::Sudo
 	}
 }
 
@@ -171,27 +201,76 @@ pub fn linux_elevation() -> Elevation {
 	Elevation::Direct
 }
 
+/// The user kopia will actually run as, when that differs from the current user
+/// — so a caller can hand it ownership of transient files (e.g. the per-run
+/// config). `None` when kopia runs as the current user, or off Linux.
+pub fn kopia_run_as_user() -> Option<&'static str> {
+	match linux_elevation() {
+		Elevation::SetPriv | Elevation::Sudo => Some(LINUX_KOPIA_USER),
+		Elevation::Direct | Elevation::Skip(_) => None,
+	}
+}
+
+/// `setpriv --reuid kopia --regid kopia --init-groups -- <kopia>`, with the
+/// kopia user's environment. setpriv only swaps credentials and leaves the
+/// environment untouched, so set `HOME` (kopia reads its config/cache relative
+/// to it) and drop the inherited `XDG_CACHE_HOME` (so the cache lands in
+/// `$HOME/.cache`, not the daemon's read-only `/var/cache`).
+#[cfg(target_os = "linux")]
+fn setpriv_as_kopia(kopia: &Path) -> Command {
+	let mut c = Command::new("setpriv");
+	c.args([
+		"--reuid",
+		LINUX_KOPIA_USER,
+		"--regid",
+		LINUX_KOPIA_USER,
+		"--init-groups",
+		"--",
+	]);
+	c.arg(kopia);
+	c.env("HOME", LINUX_KOPIA_HOME);
+	c.env_remove("XDG_CACHE_HOME");
+	c
+}
+
+/// `sudo -H -u kopia [--preserve-env=…] -- <kopia>`. `-H` sets `HOME` to the
+/// kopia user's home; `env_reset` (sudo's default) drops the rest, so any vars
+/// kopia needs are forwarded via `--preserve-env`.
+#[cfg(target_os = "linux")]
+fn sudo_as_kopia(kopia: &Path, preserve_env: Option<&str>) -> Command {
+	let mut c = Command::new("sudo");
+	c.arg("-H");
+	if let Some(keys) = preserve_env {
+		c.arg(format!("--preserve-env={keys}"));
+	}
+	c.arg("-u").arg(LINUX_KOPIA_USER).arg("--").arg(kopia);
+	c
+}
+
+/// Build the base kopia command for a given elevation (Linux).
+#[cfg(target_os = "linux")]
+fn command_for(kopia: &Path, elevation: Elevation) -> Result<Command, String> {
+	Ok(match elevation {
+		Elevation::Direct => Command::new(kopia),
+		Elevation::SetPriv => setpriv_as_kopia(kopia),
+		Elevation::Sudo => sudo_as_kopia(kopia, None),
+		Elevation::Skip(reason) => return Err(reason),
+	})
+}
+
 /// Build a `Command` that runs the kopia binary, elevated to the kopia user
 /// if the current platform/user requires it (Linux only).
 ///
-/// On non-Linux platforms or when no elevation is needed, this is just
-/// `Command::new(kopia)`. On Linux with [`Elevation::Sudo`], it returns
-/// `sudo -u kopia -- <kopia>`. [`Elevation::Skip`] is propagated as an
-/// `Err` whose message is the Skip reason.
+/// On non-Linux platforms this is just `Command::new(kopia)`. [`Elevation::Skip`]
+/// is propagated as an `Err` whose message is the Skip reason.
+#[cfg(target_os = "linux")]
 pub fn build_kopia_command(kopia: &Path) -> Result<Command, String> {
-	if cfg!(target_os = "linux") {
-		match linux_elevation() {
-			Elevation::Direct => Ok(Command::new(kopia)),
-			Elevation::Sudo => {
-				let mut c = Command::new("sudo");
-				c.arg("-u").arg(LINUX_KOPIA_USER).arg("--").arg(kopia);
-				Ok(c)
-			}
-			Elevation::Skip(reason) => Err(reason),
-		}
-	} else {
-		Ok(Command::new(kopia))
-	}
+	command_for(kopia, linux_elevation())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn build_kopia_command(kopia: &Path) -> Result<Command, String> {
+	Ok(Command::new(kopia))
 }
 
 /// Ambient AWS credential environment variables, scrubbed from kopia's
@@ -230,6 +309,7 @@ impl S3KopiaEnv<'_> {
 	}
 
 	/// The keys to forward across a `sudo` env reset (`--preserve-env=…`).
+	#[cfg(target_os = "linux")]
 	fn preserve_env_keys(&self) -> String {
 		self.vars()
 			.iter()
@@ -239,38 +319,78 @@ impl S3KopiaEnv<'_> {
 	}
 }
 
-/// Build a kopia [`Command`] for the canopy-managed S3 repo, which is reached
-/// through the loopback re-signing proxy.
-///
-/// On Linux, kopia runs as the [`LINUX_KOPIA_USER`] via `sudo` when needed;
-/// `sudo`'s `env_reset` drops the parent environment (so the
-/// [`S3_SHADOWING_ENV_VARS`] never reach kopia) and the password/config vars are
-/// forwarded explicitly via `--preserve-env`. Run directly, the child inherits
-/// our environment, so the shadowing vars are removed explicitly instead.
-pub fn build_kopia_command_with_s3(kopia: &Path, env: &S3KopiaEnv<'_>) -> Result<Command, String> {
-	let mut cmd = if cfg!(target_os = "linux") {
-		match linux_elevation() {
-			Elevation::Direct => Command::new(kopia),
-			Elevation::Sudo => {
-				let mut c = Command::new("sudo");
-				c.arg(format!("--preserve-env={}", env.preserve_env_keys()));
-				c.arg("-u").arg(LINUX_KOPIA_USER).arg("--").arg(kopia);
-				c
-			}
-			Elevation::Skip(reason) => return Err(reason),
-		}
-	} else {
-		Command::new(kopia)
-	};
-
-	// Under sudo, env_reset already dropped these; removing them here covers the
-	// direct (inherited-environment) path.
+/// Apply the canopy S3 repo environment to a kopia command: scrub the ambient
+/// AWS vars (so they can't shadow the dummy proxy keys) and set the password /
+/// transient-config vars. `setpriv` leaves the environment intact and sudo's
+/// `env_reset` drops the AWS vars already — removing them here covers both and
+/// the direct (inherited-environment) path.
+fn apply_s3_env(cmd: &mut Command, env: &S3KopiaEnv<'_>) {
 	for key in S3_SHADOWING_ENV_VARS {
 		cmd.env_remove(key);
 	}
 	for (key, value) in env.vars() {
 		cmd.env(key, value);
 	}
+}
+
+/// Build a kopia [`Command`] for the canopy-managed S3 repo, which is reached
+/// through the loopback re-signing proxy.
+///
+/// On Linux, kopia runs as the [`LINUX_KOPIA_USER`] (`setpriv` when we're root,
+/// `sudo` otherwise). Under sudo the password/config vars are forwarded across
+/// `env_reset` via `--preserve-env`; under setpriv the environment is intact.
+#[cfg(target_os = "linux")]
+fn command_for_s3(
+	kopia: &Path,
+	env: &S3KopiaEnv<'_>,
+	elevation: Elevation,
+) -> Result<Command, String> {
+	let mut cmd = match elevation {
+		Elevation::Direct => Command::new(kopia),
+		Elevation::SetPriv => setpriv_as_kopia(kopia),
+		Elevation::Sudo => sudo_as_kopia(kopia, Some(&env.preserve_env_keys())),
+		Elevation::Skip(reason) => return Err(reason),
+	};
+	apply_s3_env(&mut cmd, env);
+	Ok(cmd)
+}
+
+/// Which user a canopy-managed kopia command should run as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunAs {
+	/// The kopia user (backup): keeps the repo cache owned by that user and lets
+	/// it read the snapshot's idmapped, postgres-owned files. Elevates per
+	/// [`linux_elevation`].
+	KopiaUser,
+	/// The current user (restore): the command writes destinations the kopia
+	/// user can't reach (e.g. a staging dir beside a postgres data directory),
+	/// and the caller already runs with enough privilege (root).
+	CurrentUser,
+}
+
+/// Build a kopia [`Command`] for the canopy-managed S3 repo, reached through the
+/// loopback re-signing proxy, running as `run_as` (see [`RunAs`]).
+#[cfg(target_os = "linux")]
+pub fn build_kopia_command_with_s3(
+	kopia: &Path,
+	env: &S3KopiaEnv<'_>,
+	run_as: RunAs,
+) -> Result<Command, String> {
+	let elevation = match run_as {
+		RunAs::KopiaUser => linux_elevation(),
+		RunAs::CurrentUser => Elevation::Direct,
+	};
+	command_for_s3(kopia, env, elevation)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn build_kopia_command_with_s3(
+	kopia: &Path,
+	env: &S3KopiaEnv<'_>,
+	_run_as: RunAs,
+) -> Result<Command, String> {
+	let mut cmd = Command::new(kopia);
+	apply_s3_env(&mut cmd, env);
 	Ok(cmd)
 }
 
@@ -749,6 +869,101 @@ mod tests {
 			.collect()
 	}
 
+	#[cfg(target_os = "linux")]
+	fn env_of(cmd: &Command) -> std::collections::HashMap<String, Option<String>> {
+		cmd.get_envs()
+			.map(|(k, v)| {
+				(
+					k.to_string_lossy().into_owned(),
+					v.map(|v| v.to_string_lossy().into_owned()),
+				)
+			})
+			.collect()
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn setpriv_elevation_runs_kopia_as_the_kopia_user() {
+		let cmd = command_for(Path::new("/usr/bin/kopia"), Elevation::SetPriv).unwrap();
+		assert_eq!(cmd.get_program(), "setpriv");
+		let args = args_of(&cmd);
+		assert_eq!(
+			args,
+			vec![
+				"--reuid",
+				LINUX_KOPIA_USER,
+				"--regid",
+				LINUX_KOPIA_USER,
+				"--init-groups",
+				"--",
+				"/usr/bin/kopia",
+			]
+		);
+		let env = env_of(&cmd);
+		assert_eq!(env.get("HOME"), Some(&Some(LINUX_KOPIA_HOME.to_owned())));
+		// XDG_CACHE_HOME is explicitly cleared so the cache lands under $HOME.
+		assert_eq!(env.get("XDG_CACHE_HOME"), Some(&None));
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn sudo_elevation_sets_home_and_targets_the_kopia_user() {
+		let cmd = command_for(Path::new("/usr/bin/kopia"), Elevation::Sudo).unwrap();
+		assert_eq!(cmd.get_program(), "sudo");
+		assert_eq!(
+			args_of(&cmd),
+			vec!["-H", "-u", LINUX_KOPIA_USER, "--", "/usr/bin/kopia"]
+		);
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn direct_elevation_runs_kopia_unwrapped() {
+		let cmd = command_for(Path::new("/usr/bin/kopia"), Elevation::Direct).unwrap();
+		assert_eq!(cmd.get_program(), "/usr/bin/kopia");
+		assert!(args_of(&cmd).is_empty());
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn s3_setpriv_carries_secrets_and_scrubs_aws() {
+		let env = S3KopiaEnv {
+			password: "hunter2",
+			config_path: Path::new("/tmp/x/repository.config"),
+		};
+		let cmd = command_for_s3(Path::new("/usr/bin/kopia"), &env, Elevation::SetPriv).unwrap();
+		assert_eq!(cmd.get_program(), "setpriv");
+		let envs = env_of(&cmd);
+		assert_eq!(
+			envs.get("KOPIA_PASSWORD"),
+			Some(&Some("hunter2".to_owned()))
+		);
+		assert_eq!(
+			envs.get("KOPIA_CONFIG_PATH"),
+			Some(&Some("/tmp/x/repository.config".to_owned()))
+		);
+		// The ambient AWS vars are scrubbed so they can't shadow the proxy keys.
+		for key in S3_SHADOWING_ENV_VARS {
+			assert_eq!(envs.get(key), Some(&None), "{key} should be removed");
+		}
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn s3_sudo_preserves_the_secret_env_across_env_reset() {
+		let env = S3KopiaEnv {
+			password: "hunter2",
+			config_path: Path::new("/tmp/x/repository.config"),
+		};
+		let cmd = command_for_s3(Path::new("/usr/bin/kopia"), &env, Elevation::Sudo).unwrap();
+		assert_eq!(cmd.get_program(), "sudo");
+		assert!(
+			args_of(&cmd)
+				.iter()
+				.any(|a| a == "--preserve-env=KOPIA_PASSWORD,KOPIA_CONFIG_PATH")
+		);
+	}
+
 	#[test]
 	fn repository_connect_s3_args_are_in_order() {
 		let mut cmd = Command::new("kopia");
@@ -847,7 +1062,9 @@ mod tests {
 			password: "repo-pass",
 			config_path: Path::new("/run/bestool/kopia.config"),
 		};
-		let cmd = build_kopia_command_with_s3(Path::new("/usr/bin/kopia"), &env).unwrap();
+		let cmd =
+			build_kopia_command_with_s3(Path::new("/usr/bin/kopia"), &env, RunAs::CurrentUser)
+				.unwrap();
 		let envs: std::collections::HashMap<String, Option<String>> = cmd
 			.get_envs()
 			.map(|(k, v)| {
@@ -872,6 +1089,7 @@ mod tests {
 		}
 	}
 
+	#[cfg(target_os = "linux")]
 	#[test]
 	fn preserve_env_keys_lists_repo_vars() {
 		let env = S3KopiaEnv {

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -36,9 +36,10 @@ Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
 # root set. As uid 0 the kernel grants the whole bounding set into the effective
 # set on exec (and the btrfs child below re-derives it the same way), so listing
 # the caps here is enough and AmbientCapabilities stays empty.
-#   - CAP_DAC_READ_SEARCH: root reads any file (e.g. kopia's mode-0600 repo
-#     config) without also gaining DAC write-override. Without it kopia flips to
-#     wanting sudo, which NoNewPrivileges then blocks.
+#   - CAP_DAC_READ_SEARCH: lets root read other-owned, mode-0600 files the
+#     doctor checks inspect (e.g. a service's TLS key) without also gaining DAC
+#     write-override. (Kopia no longer needs this — it runs as the kopia user
+#     and reads its own config.)
 #   - CAP_SYS_ADMIN: the btrfs disk-stats doctor check shells out to `btrfs
 #     device stats`, whose device-info ioctls return EPERM without it.
 # CAP_SYS_ADMIN is broad (near root-equivalent), so the Protect*/seccomp/
@@ -56,6 +57,11 @@ Environment=XDG_CACHE_HOME=%C
 # bestool writes to its config dir, which ProtectSystem=strict otherwise
 # locks read-only along with the rest of /etc.
 ReadWritePaths=/etc/bestool
+# Everything kopia touches lives under its home, /var/lib/kopia: the repo config
+# (.config/kopia), the cache and logs (.cache/kopia, since we run kopia as the
+# kopia user with HOME there), and the postgres snapshot/base-backup staging
+# (bestool-backup). All of it must be writable.
+ReadWritePaths=/var/lib/kopia
 # podman cp's tempdir lands in a private /tmp.
 PrivateTmp=yes
 
@@ -69,11 +75,21 @@ ProtectHostname=yes
 # but NOT ProcSubset=pid — sysinfo needs /proc/meminfo and /proc/loadavg.
 ProtectProc=invisible
 
-PrivateDevices=yes
-# safe only because CONTAINER_HOST points at the (remote) rootful podman.
-RestrictNamespaces=yes
+# postgres snapshot backups (btrfs/thin-LVM) mount the snapshot block device
+# (/dev/disk/by-uuid/*, /dev/<vg>/<lv>) read-only for kopia; a private /dev
+# would hide it. The container work still goes to the remote rootful podman, so
+# nothing else here needs a real device node.
+PrivateDevices=no
+# The read-only snapshot is mounted with X-mount.idmap so the kopia user can
+# read postgres-owned files, and an idmapped mount creates a user namespace;
+# this allows that one type and no other. The container work still goes to the
+# remote rootful podman, so no other namespace is needed.
+RestrictNamespaces=user
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 SystemCallFilter=@system-service
+# @mount (mount/umount/mount_setattr/…): snapshot backups mount the snapshot
+# read-only for kopia and unmount it afterwards; without it mount() is EPERM.
+SystemCallFilter=@mount
 SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
 LockPersonality=yes


### PR DESCRIPTION
🤖 Supersedes #554 and #555 (both closed). This is the no-root-kopia version: rather than ship the `/var/cache/kopia` root-cache hack and then orphan it, kopia runs as the kopia user from the start.

## Run kopia as the kopia user

The daemon ran kopia as **root** — root can stat the kopia config, so `linux_elevation()` returned `Direct` and kopia ran as whoever we were (root in the daemon). That orphaned a root-owned `/var/cache/kopia` and left the idmap mounts (`X-mount.idmap`) and the `chown … kopia:kopia` of base backups — built precisely so the *kopia user* can read the snapshot — doing nothing.

Now:

- `linux_elevation()` drops to the kopia user with **`setpriv`** when we're root (a privilege *drop*, so it works under `NoNewPrivileges`, where `sudo` refuses to run because it must be able to *gain* privileges), or `sudo -u kopia` when we're a mortal.
- kopia's `HOME` is set to `/var/lib/kopia` (and the inherited `XDG_CACHE_HOME` dropped), so its cache and logs land under the writable kopia home rather than `/var/cache/kopia`.
- the transient per-run repo config is `chown`ed to the kopia user so it can read and write it.
- **restore** deliberately keeps running kopia as the *current* user: it writes a staging dir beside the postgres-owned target that the kopia user can't reach, and is already run with enough privilege (root). New `RunAs` enum makes backup (`KopiaUser`) vs restore (`CurrentUser`) explicit.

## Let snapshot backups run under the sandbox

The btrfs/thin-LVM snapshot backends previously failed under `ProtectSystem=strict` and fell back to `pg_basebackup`. Three guards lifted:

- `ReadWritePaths=/var/lib/kopia` — repo config, cache, and snapshot/base-backup staging all live there.
- the btrfs per-run top-level mount moves off the read-only `/mnt` into `/var/lib/kopia`.
- `PrivateDevices=no` (mount the snapshot block device), `SystemCallFilter=@mount`, `RestrictNamespaces=user` (idmapped mounts create a user namespace).

This is a real reduction of the daemon's hardening — it already holds `CAP_SYS_ADMIN`, and the rest (`ProtectSystem=strict`, `NoNewPrivileges`, kernel/clock/hostname protections, the seccomp allowlist) stays. The `CAP_DAC_READ_SEARCH` comment is updated since its kopia rationale is gone (the cap stays for doctor checks that read other-owned files).

## Verification

Unit tests cover the command construction per elevation (`setpriv`/`sudo`/direct, env scrubbing, secret forwarding) and the btrfs path relocation. clippy/fmt clean; `x86_64-pc-windows-gnu` compiles. The privileged paths — `setpriv` drop, idmapped mount under the sandbox, the kopia user's home being writable for its cache — need a real host to confirm; flagging since I can't exercise them here.

Deployment note: the kopia user's home `/var/lib/kopia` must be writable by that user (for `~/.cache`).
