### PR TITLE
ci: keep the rust-cache warm for PRs (and quiet a Windows warning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+# Cache strategy: only the default branch writes the rust-cache; PRs and the
+# merge queue restore it read-only (the `save-if` on every rust-cache step
+# below). The repo has a 10 GB cache cap — letting every branch save its own
+# large caches evicts the others, so PRs end up rebuilding from scratch. Pinning
+# writes to main keeps one warm set everyone restores from.
 jobs:
   test:
     strategy:
@@ -69,6 +74,8 @@ jobs:
           database: ci
           ssl: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test
         env:
           DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
@@ -83,6 +90,8 @@ jobs:
           rustup toolchain install --profile minimal --no-self-update stable
           rustup default stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Contract tests against live canopy
         run: cargo test -p bestool --lib canopy_contract -- --ignored
 
@@ -96,6 +105,8 @@ jobs:
           rustup toolchain install --profile minimal --no-self-update stable
           rustup default stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build alertd tests
         run: cargo test -p bestool-alertd --lib --no-run --message-format=json > alertd-tests.json
       - name: Run doctor checks in a postgres-less network namespace
@@ -122,6 +133,8 @@ jobs:
           rustup toolchain install --profile minimal --no-self-update stable
           rustup default stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Start MinIO
         run: |
           docker run -d --name minio -p 9000:9000 \
@@ -165,6 +178,8 @@ jobs:
         with:
           tool: just
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets --all-features
 
   check-docs:
@@ -177,6 +192,8 @@ jobs:
           rustup toolchain install --profile minimal --no-self-update stable
           rustup default stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Generate USAGE.md files
         run: ./update-usage.sh
       - name: Check for changes

--- a/.github/workflows/release-algae.yml
+++ b/.github/workflows/release-algae.yml
@@ -73,6 +73,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: algae-${{ matrix.target }}
+          # Release builds run on one-shot tags; don't persist tag-scoped
+          # caches PRs can't reuse and that crowd out CI's under the 10 GB cap.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.81.8
         with:
           tool: cargo-zigbuild,cargo-auditable

--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -74,6 +74,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: bestool-${{ matrix.target }}
+          # Release builds run on one-shot tags; don't persist tag-scoped
+          # caches PRs can't reuse and that crowd out CI's under the 10 GB cap.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.81.8
         with:
           tool: cargo-zigbuild,cargo-auditable

--- a/.github/workflows/release-psql.yml
+++ b/.github/workflows/release-psql.yml
@@ -72,6 +72,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: psql-${{ matrix.target }}
+          # Release builds run on one-shot tags; don't persist tag-scoped
+          # caches PRs can't reuse and that crowd out CI's under the 10 GB cap.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.81.8
         with:
           tool: cargo-zigbuild,cargo-auditable

--- a/crates/alertd/src/doctor/checks/external_users.rs
+++ b/crates/alertd/src/doctor/checks/external_users.rs
@@ -31,11 +31,10 @@
 //! Where logind can't answer, utmp's own dead records (`who --dead`) stand in:
 //! an entry whose tty has a dead record newer than its login time is dropped.
 
-use std::{
-	collections::{HashMap, HashSet},
-	path::PathBuf,
-	time::Duration,
-};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
+// HashSet only backs the live-tty lookups, which are unix- (or test-) only.
+#[cfg(any(test, unix))]
+use std::collections::HashSet;
 
 use jiff::{Timestamp, civil::DateTime, tz::TimeZone};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
🤖 Windows CI rebuilds from scratch every PR because its rust-cache is missing. The cause isn't the runner — it's cache eviction.

The repo sits at the **10 GB Actions cache cap**. `main` has a cache for every CI job *except* `test-Windows` (the largest, so LRU drops it first), and ~4 GB is squatted by one-shot **release-tag** build caches (`v0-rust-bestool-<target>-build-…` on `refs/tags/v*`) that PRs can never reuse. So every branch and every release saving its own large caches evicts the others, and PRs find nothing to restore.

Two changes:

- **CI** (`ci.yml`): `save-if: ${{ github.ref == 'refs/heads/main' }}` on every rust-cache step — only `main` writes the cache; PRs and the merge queue restore it read-only. One warm set everyone shares, instead of N competing ones.
- **Release workflows** (`release-bestool`/`algae`/`psql`): same `save-if`. They only run on tags, so they now never persist a cache — and they couldn't reuse one anyway (each tag is branch-scoped and starts cold regardless), so nothing is lost, but ~4 GB is freed for the CI caches.

Also gates the `HashSet` import in `external_users.rs` to its `unix`/`test` users, silencing the unused-import warning that prints in the Windows build.

Net effect: `main` builds the cache once; PRs (Windows included) restore it instead of building cold.
