### PR TITLE
fix(alertd): grant the capabilities to run kopia as the kopia user

### DIFF
--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -36,6 +36,9 @@ Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
 # root set. As uid 0 the kernel grants the whole bounding set into the effective
 # set on exec (and the btrfs child below re-derives it the same way), so listing
 # the caps here is enough and AmbientCapabilities stays empty.
+#   - CAP_SETUID / CAP_SETGID: drop to the kopia user with `setpriv` to run kopia
+#     unprivileged (the daemon is the privileged supervisor, kopia the worker).
+#     setresuid/setresgid/setgroups return EPERM without these even as uid 0.
 #   - CAP_CHOWN: hand backup artifacts to the kopia user before running kopia as
 #     it — the transient per-run repo config, and (postgres) the base-backup
 #     files. Without it the chown returns EPERM even as uid 0.
@@ -46,7 +49,7 @@ Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
 #     device stats`, whose device-info ioctls return EPERM without it.
 # CAP_SYS_ADMIN is broad (near root-equivalent), so the Protect*/seccomp/
 # namespace directives below carry the hardening here, not the capability set.
-CapabilityBoundingSet=CAP_CHOWN CAP_DAC_READ_SEARCH CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_READ_SEARCH CAP_SETGID CAP_SETUID CAP_SYS_ADMIN
 AmbientCapabilities=
 NoNewPrivileges=yes
 

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -36,15 +36,17 @@ Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
 # root set. As uid 0 the kernel grants the whole bounding set into the effective
 # set on exec (and the btrfs child below re-derives it the same way), so listing
 # the caps here is enough and AmbientCapabilities stays empty.
+#   - CAP_CHOWN: hand backup artifacts to the kopia user before running kopia as
+#     it — the transient per-run repo config, and (postgres) the base-backup
+#     files. Without it the chown returns EPERM even as uid 0.
 #   - CAP_DAC_READ_SEARCH: lets root read other-owned, mode-0600 files the
 #     doctor checks inspect (e.g. a service's TLS key) without also gaining DAC
-#     write-override. (Kopia no longer needs this — it runs as the kopia user
-#     and reads its own config.)
+#     write-override.
 #   - CAP_SYS_ADMIN: the btrfs disk-stats doctor check shells out to `btrfs
 #     device stats`, whose device-info ioctls return EPERM without it.
 # CAP_SYS_ADMIN is broad (near root-equivalent), so the Protect*/seccomp/
 # namespace directives below carry the hardening here, not the capability set.
-CapabilityBoundingSet=CAP_DAC_READ_SEARCH CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_READ_SEARCH CAP_SYS_ADMIN
 AmbientCapabilities=
 NoNewPrivileges=yes
 


### PR DESCRIPTION
🤖 Follow-up to #561. With the elevation fix live, canopy backups try to run kopia as the kopia user — and hit the daemon's restricted capability set, one cap at a time as deployed:

```
chown ... '/tmp/.tmpXXXX': Operation not permitted          # missing CAP_CHOWN
setpriv: setresuid failed: Operation not permitted          # missing CAP_SETUID/SETGID
```

The daemon runs uid 0 but with a bounding set of just `CAP_DAC_READ_SEARCH CAP_SYS_ADMIN` under `NoNewPrivileges`, so even as root it can't change file ownership or drop uid/gid. Running kopia unprivileged needs:

- `CAP_CHOWN` — hand the transient repo config (and, postgres, the base-backup files) to the kopia user.
- `CAP_SETUID` / `CAP_SETGID` — `setpriv` drops to the kopia user via setresuid/setresgid/setgroups.

This is the privilege-separation model: the daemon is the privileged supervisor that sets up an **unprivileged** kopia worker. Given it already holds `CAP_SYS_ADMIN`, these don't materially change its posture.
