### PR TITLE
fix(canopy): run simple backups as the current user, not the kopia user

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -504,6 +504,7 @@ async fn run_kopia_backup(
 		server_id,
 		&tags,
 		&prepared.ignore,
+		def.method.kopia_run_as(),
 		progress,
 	)
 	.await;
@@ -518,6 +519,10 @@ async fn run_kopia_backup(
 }
 
 /// Connect to the repo and create the snapshot.
+#[expect(
+	clippy::too_many_arguments,
+	reason = "a run's snapshot is parameterised by target, connection, source, tags, ignores, and run-as; bundling them buys little"
+)]
 async fn snapshot(
 	target: &bestool_canopy::BackupTarget,
 	conn: &RepoConn,
@@ -525,6 +530,7 @@ async fn snapshot(
 	server_id: &str,
 	tags: &BTreeMap<String, String>,
 	ignore: &[String],
+	run_as: RunAs,
 	progress: &Option<BackupProgress>,
 ) -> Result<SnapshotResult> {
 	let kopia = find_kopia_binary(None).ok_or_else(|| miette!("could not find the kopia binary"))?;
@@ -537,8 +543,11 @@ async fn snapshot(
 
 	// When kopia runs as the kopia user (not us), it writes and reads this config
 	// itself, so hand the dir to that user. Root-owned 0700 tempdir would deny it.
+	// Only for the kopia-user path; a CurrentUser run owns the dir already.
 	#[cfg(target_os = "linux")]
-	if let Some(user) = bestool_kopia::kopia_run_as_user() {
+	if let Some(user) =
+		bestool_kopia::kopia_run_as_user().filter(|_| run_as == RunAs::KopiaUser)
+	{
 		let status = tokio::process::Command::new("chown")
 			.arg("-R")
 			.arg(format!("{user}:{user}"))
@@ -556,17 +565,17 @@ async fn snapshot(
 		config_path: &config_path,
 	};
 
-	connect_repo(&kopia, &s3env, target, &conn.endpoint, server_id, RunAs::KopiaUser).await?;
+	connect_repo(&kopia, &s3env, target, &conn.endpoint, server_id, run_as).await?;
 
 	if !ignore.is_empty() {
 		let mut policy =
-			build_kopia_command_with_s3(&kopia, &s3env, RunAs::KopiaUser).map_err(|e| miette!("{e}"))?;
+			build_kopia_command_with_s3(&kopia, &s3env, run_as).map_err(|e| miette!("{e}"))?;
 		args_policy_set_ignores(&mut policy, source_path, ignore);
 		run_kopia(policy, "policy set").await?;
 	}
 
 	let mut create =
-		build_kopia_command_with_s3(&kopia, &s3env, RunAs::KopiaUser).map_err(|e| miette!("{e}"))?;
+		build_kopia_command_with_s3(&kopia, &s3env, run_as).map_err(|e| miette!("{e}"))?;
 	// Force kopia's progress output (it stays silent on a non-TTY otherwise) and
 	// stream it, but only when someone's watching — a local run discards stderr.
 	let stdout = if progress.is_some() {

--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -91,6 +91,20 @@ impl Method {
 		}
 	}
 
+	/// Which user kopia should run as for this method.
+	///
+	/// `simple` reads arbitrary source paths whose owners/modes we don't control
+	/// (e.g. postgres' `pg_hba.conf`, mode 0640) — only root (via the daemon's
+	/// `CAP_DAC_READ_SEARCH`) can read them all, so it runs as the current user.
+	/// `postgresql` exposes the cluster through an idmapped snapshot / a base
+	/// backup chowned to the kopia user, so kopia reads it unprivileged.
+	pub fn kopia_run_as(&self) -> bestool_kopia::RunAs {
+		match self {
+			Method::Simple(_) => bestool_kopia::RunAs::CurrentUser,
+			Method::Postgresql(_) => bestool_kopia::RunAs::KopiaUser,
+		}
+	}
+
 	/// Produce the source kopia will snapshot. `backup_type` is the def's label,
 	/// used by methods that key stable paths on it (e.g. btrfs mount points).
 	pub async fn prepare(&self, backup_type: &str) -> Result<Prepared> {

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -201,6 +201,14 @@ pub fn linux_elevation() -> Elevation {
 	Elevation::Direct
 }
 
+/// A writable cache/log dir for kopia when it runs as the current user (root)
+/// under the daemon sandbox, where /var/cache is read-only and /var/lib/kopia
+/// belongs to the kopia user. Honours `$TMPDIR` and the unit's `PrivateTmp`.
+#[cfg(target_os = "linux")]
+fn current_user_cache_dir() -> std::ffi::OsString {
+	std::env::temp_dir().join("bestool-kopia").into_os_string()
+}
+
 /// Whether the kopia system user exists (via `id -u kopia`).
 #[cfg(target_os = "linux")]
 fn kopia_user_exists() -> bool {
@@ -391,13 +399,13 @@ fn command_for_s3(
 ) -> Result<Command, String> {
 	let mut cmd = match elevation {
 		Elevation::Direct => {
-			// Even unelevated, pin kopia's home to the kopia user's so its cache
-			// and logs land in the writable /var/lib/kopia rather than the
-			// daemon's read-only /var/cache (where the inherited XDG_CACHE_HOME
-			// would otherwise put them).
+			// Running unelevated (the `simple` method as root, which must read
+			// arbitrary source files). Point kopia's cache and logs at a writable
+			// temp dir: the inherited XDG_CACHE_HOME=/var/cache is read-only under
+			// the daemon sandbox, and /var/lib/kopia isn't writable by root (it's
+			// the kopia user's). The cache is rebuilt as needed, so ephemeral is fine.
 			let mut c = Command::new(kopia);
-			c.env("HOME", LINUX_KOPIA_HOME);
-			c.env_remove("XDG_CACHE_HOME");
+			c.env("XDG_CACHE_HOME", current_user_cache_dir());
 			c
 		}
 		Elevation::SetPriv => setpriv_as_kopia(kopia),
@@ -979,9 +987,9 @@ mod tests {
 
 	#[cfg(target_os = "linux")]
 	#[test]
-	fn s3_direct_still_pins_the_cache_home() {
-		// Unelevated (no kopia user / we are it), the canopy command must still
-		// move kopia's cache off the daemon's read-only /var/cache to its home.
+	fn s3_direct_moves_cache_off_var_cache() {
+		// Unelevated (the `simple` method as root), the canopy command must move
+		// kopia's cache off the daemon's read-only /var/cache to a writable dir.
 		let env = S3KopiaEnv {
 			password: "hunter2",
 			config_path: Path::new("/tmp/x/repository.config"),
@@ -989,8 +997,12 @@ mod tests {
 		let cmd = command_for_s3(Path::new("/usr/bin/kopia"), &env, Elevation::Direct).unwrap();
 		assert_eq!(cmd.get_program(), "/usr/bin/kopia");
 		let envs = env_of(&cmd);
-		assert_eq!(envs.get("HOME"), Some(&Some(LINUX_KOPIA_HOME.to_owned())));
-		assert_eq!(envs.get("XDG_CACHE_HOME"), Some(&None));
+		let cache = envs
+			.get("XDG_CACHE_HOME")
+			.and_then(|v| v.clone())
+			.expect("XDG_CACHE_HOME set");
+		assert!(cache.ends_with("bestool-kopia"), "cache dir: {cache}");
+		assert_ne!(cache, "/var/cache");
 	}
 
 	#[cfg(target_os = "linux")]


### PR DESCRIPTION
🤖 With kopia running as the kopia user, a `simple` backup of postgres config failed:

```
Error when processing "18/main/pg_hba.conf": ... permission denied
```

`pg_hba.conf`/`pg_ident.conf` are mode `0640 postgres:postgres`; the unprivileged kopia user can't read them. (`caddy-config` succeeded because caddy's files are world-readable.)

The `simple` method backs up **arbitrary** source paths whose owners/modes we don't control, so it needs to run as a user that can read them all — root, via the daemon's `CAP_DAC_READ_SEARCH`. The `postgresql` method is different: it exposes the cluster through an idmapped snapshot (or a base backup chowned to the kopia user), which is kopia-readable by design.

So run kopia **per method**:

- `Method::kopia_run_as()` → `simple` ⇒ `CurrentUser` (root), `postgresql` ⇒ `KopiaUser`.
- Threaded through `snapshot`/`connect_repo`/the kopia builders; the transient-config chown to the kopia user only happens on the `KopiaUser` path (a `CurrentUser` run owns the dir already).
- The current-user (root) kopia points `XDG_CACHE_HOME` at `$TMPDIR/bestool-kopia` — `/var/cache` is read-only under the sandbox and `/var/lib/kopia` belongs to the kopia user, so root needs a writable cache without `CAP_DAC_OVERRIDE`.

Net: the privilege-separation win stays on the bulk database data (`postgresql` runs unprivileged via the idmap); the `simple` config backups run as root, which is what reading arbitrary system files requires.

Independent of #563 (the kopia-user capabilities) — this fixes the `simple` backups on its own; #563 enables the `postgresql` path.
