### PR TITLE
fix(canopy): give simple backups a kopia-readable view (bindfs) so kopia stays non-root

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod method;
 pub mod postgresql;
 pub mod provider;
+mod simple;
 
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 

--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -221,6 +221,10 @@ pub(super) fn with_extension_suffix(path: &Path, suffix: &str) -> PathBuf {
 mod tests {
 	use super::*;
 
+	// On Linux the simple method prepares a kopia-readable *view* (bindfs/copy),
+	// which needs a real source, root, and the kopia user — so it's exercised
+	// on-host, not here. Off Linux it still snapshots the path in place.
+	#[cfg(not(target_os = "linux"))]
 	#[tokio::test]
 	async fn simple_prepare_returns_its_path_and_no_tags() {
 		let method = Method::Simple(SimpleConfig {

--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -32,8 +32,8 @@ pub struct Prepared {
 /// What [`Method::cleanup`] has to undo for a prepared source.
 #[derive(Debug)]
 pub(super) enum Teardown {
-	/// Nothing to release (e.g. the simple method).
-	Nothing,
+	/// The simple method's kopia-readable view (bindfs mount or copy).
+	Simple(super::simple::Cleanup),
 	/// A btrfs snapshot + its mounts.
 	Btrfs(super::postgresql::btrfs::Mounts),
 	/// A thin-LVM snapshot + its mount.
@@ -95,12 +95,15 @@ impl Method {
 	/// used by methods that key stable paths on it (e.g. btrfs mount points).
 	pub async fn prepare(&self, backup_type: &str) -> Result<Prepared> {
 		match self {
-			Method::Simple(config) => Ok(Prepared {
-				path: config.path.clone(),
-				extra_tags: BTreeMap::new(),
-				ignore: Vec::new(),
-				teardown: Teardown::Nothing,
-			}),
+			Method::Simple(config) => {
+				let (path, cleanup) = super::simple::prepare(&config.path, backup_type).await?;
+				Ok(Prepared {
+					path,
+					extra_tags: BTreeMap::new(),
+					ignore: Vec::new(),
+					teardown: Teardown::Simple(cleanup),
+				})
+			}
 			Method::Postgresql(config) => super::postgresql::prepare(config, backup_type).await,
 		}
 	}
@@ -108,7 +111,7 @@ impl Method {
 	/// Release whatever `prepare` set up (snapshot, mount, staging dir).
 	pub async fn cleanup(&self, prepared: Prepared) -> Result<()> {
 		match prepared.teardown {
-			Teardown::Nothing => Ok(()),
+			Teardown::Simple(cleanup) => super::simple::teardown(cleanup).await,
 			Teardown::Btrfs(mounts) => super::postgresql::btrfs::teardown(mounts).await,
 			Teardown::Lvm(snapshot) => super::postgresql::lvm::teardown(snapshot).await,
 			Teardown::Vss(shadow) => super::postgresql::vss::teardown(shadow).await,

--- a/crates/bestool/src/actions/canopy/backup/simple.rs
+++ b/crates/bestool/src/actions/canopy/backup/simple.rs
@@ -1,0 +1,177 @@
+//! Source preparation for the `simple` method.
+//!
+//! `simple` backs up an arbitrary path whose files may be owned by users the
+//! kopia user can't read (e.g. postgres' `pg_hba.conf`, mode 0640). So the
+//! privileged daemon first exposes a kopia-readable *view* of the source, then
+//! kopia snapshots that view unprivileged:
+//!   - `bindfs --force-user=kopia` presents the whole tree as kopia-owned — no
+//!     copy, any filesystem, any ownership. Preferred.
+//!   - failing that (bindfs absent or unusable), a root copy chowned to the
+//!     kopia user: a universal but heavier fallback.
+//!
+//! The view lives under the daemon's `CacheDirectory` (`/var/cache/bestool`,
+//! root-owned and world-traversable) so root can create it and the kopia user
+//! can still reach the view inside it. On non-Linux there's no kopia user —
+//! kopia runs as the current user and snapshots the source in place.
+
+use std::path::{Path, PathBuf};
+
+use miette::Result;
+#[cfg(target_os = "linux")]
+use miette::{Context as _, IntoDiagnostic as _, bail};
+
+/// Teardown for a prepared `simple` source, undone by [`teardown`].
+#[derive(Debug)]
+pub enum Cleanup {
+	/// Snapshotted in place; nothing to release (non-Linux, where there's no
+	/// kopia user and kopia runs as the current user).
+	#[cfg(not(target_os = "linux"))]
+	Nothing,
+	/// A bindfs view to unmount and remove.
+	#[cfg(target_os = "linux")]
+	Bindfs(PathBuf),
+	/// A copied tree to remove.
+	#[cfg(target_os = "linux")]
+	Copy(PathBuf),
+}
+
+/// Expose `source` as something the kopia user can read; returns the path kopia
+/// should snapshot and the teardown to undo it.
+pub async fn prepare(source: &Path, backup_type: &str) -> Result<(PathBuf, Cleanup)> {
+	#[cfg(target_os = "linux")]
+	{
+		prepare_linux(source, backup_type).await
+	}
+	#[cfg(not(target_os = "linux"))]
+	{
+		let _ = backup_type;
+		Ok((source.to_path_buf(), Cleanup::Nothing))
+	}
+}
+
+/// Release whatever [`prepare`] set up.
+pub async fn teardown(cleanup: Cleanup) -> Result<()> {
+	match cleanup {
+		#[cfg(not(target_os = "linux"))]
+		Cleanup::Nothing => Ok(()),
+		#[cfg(target_os = "linux")]
+		Cleanup::Bindfs(view) => {
+			unmount(&view).await;
+			let _ = tokio::fs::remove_dir_all(&view).await;
+			Ok(())
+		}
+		#[cfg(target_os = "linux")]
+		Cleanup::Copy(dir) => tokio::fs::remove_dir_all(&dir)
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("removing simple backup copy at {}", dir.display())),
+	}
+}
+
+/// Where the kopia-readable view is exposed: under the daemon's CacheDirectory,
+/// keyed by backup type so kopia's source identity is stable per type.
+#[cfg(target_os = "linux")]
+fn view_dir(backup_type: &str) -> PathBuf {
+	dirs::cache_dir()
+		.unwrap_or_else(|| PathBuf::from("/var/cache"))
+		.join("bestool")
+		.join("backup-source")
+		.join(backup_type)
+}
+
+#[cfg(target_os = "linux")]
+async fn prepare_linux(source: &Path, backup_type: &str) -> Result<(PathBuf, Cleanup)> {
+	use bestool_kopia::LINUX_KOPIA_USER;
+	use tokio::process::Command;
+
+	let view = view_dir(backup_type);
+	// Clear any leftover from a crashed run (a stale bindfs mount, or a copy).
+	unmount(&view).await;
+	if view.exists() {
+		let _ = tokio::fs::remove_dir_all(&view).await;
+	}
+	tokio::fs::create_dir_all(&view)
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("creating simple backup view dir {}", view.display()))?;
+
+	// Preferred: a read-only bindfs view presenting the tree as kopia-owned.
+	match Command::new("bindfs")
+		.arg("-r")
+		.arg(format!("--force-user={LINUX_KOPIA_USER}"))
+		.arg(format!("--force-group={LINUX_KOPIA_USER}"))
+		.arg("-o")
+		.arg("allow_other")
+		.arg(source)
+		.arg(&view)
+		.status()
+		.await
+	{
+		Ok(status) if status.success() => {
+			tracing::info!(source = %source.display(), view = %view.display(), "bindfs view for simple backup");
+			return Ok((view.clone(), Cleanup::Bindfs(view)));
+		}
+		Ok(status) => {
+			tracing::warn!(%status, "bindfs failed; copying the source instead");
+			unmount(&view).await;
+		}
+		Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+			tracing::warn!("bindfs not installed; copying the source instead");
+		}
+		Err(err) => return Err(err).into_diagnostic().wrap_err("spawning bindfs"),
+	}
+
+	// Fallback: copy the tree and hand it to the kopia user.
+	copy_to_kopia(source, &view).await?;
+	Ok((view.clone(), Cleanup::Copy(view)))
+}
+
+/// `cp -a` the source contents into `dest`, then chown the lot to the kopia user.
+#[cfg(target_os = "linux")]
+async fn copy_to_kopia(source: &Path, dest: &Path) -> Result<()> {
+	use bestool_kopia::LINUX_KOPIA_USER;
+	use tokio::process::Command;
+
+	let status = Command::new("cp")
+		.arg("-a")
+		.arg(format!("{}/.", source.display()))
+		.arg(dest)
+		.status()
+		.await
+		.into_diagnostic()
+		.wrap_err("spawning cp for the simple backup copy")?;
+	if !status.success() {
+		bail!("copying simple backup source {} failed ({status})", source.display());
+	}
+
+	let status = Command::new("chown")
+		.arg("-R")
+		.arg(format!("{LINUX_KOPIA_USER}:{LINUX_KOPIA_USER}"))
+		.arg(dest)
+		.status()
+		.await
+		.into_diagnostic()
+		.wrap_err("chowning the simple backup copy to the kopia user")?;
+	if !status.success() {
+		bail!("chowning the simple backup copy to {LINUX_KOPIA_USER} failed ({status})");
+	}
+	Ok(())
+}
+
+/// Best-effort unmount of a bindfs view (FUSE, so `fusermount -u`, else `umount`).
+#[cfg(target_os = "linux")]
+async fn unmount(view: &Path) {
+	let unmounted = tokio::process::Command::new("fusermount")
+		.arg("-u")
+		.arg(view)
+		.status()
+		.await
+		.map(|s| s.success())
+		.unwrap_or(false);
+	if !unmounted {
+		let _ = tokio::process::Command::new("umount")
+			.arg(view)
+			.status()
+			.await;
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/simple.rs
+++ b/crates/bestool/src/actions/canopy/backup/simple.rs
@@ -132,8 +132,11 @@ async fn copy_to_kopia(source: &Path, dest: &Path) -> Result<()> {
 	use bestool_kopia::LINUX_KOPIA_USER;
 	use tokio::process::Command;
 
+	// --reflink=auto: a cheap CoW clone where the filesystem supports it (btrfs,
+	// xfs w/ reflink), falling back to a full copy elsewhere.
 	let status = Command::new("cp")
 		.arg("-a")
+		.arg("--reflink=auto")
 		.arg(format!("{}/.", source.display()))
 		.arg(dest)
 		.status()


### PR DESCRIPTION
🤖 Keeps kopia running as the **kopia user** for `simple` backups too (replaces the "run simple as root" approach — #564, closed).

A `simple` backup snapshots an arbitrary path whose files the unprivileged kopia user can't always read — e.g. `pg_hba.conf`/`pg_ident.conf` are `0640 postgres:postgres`, which is exactly what failed (`caddy-config` worked only because caddy's config is world-readable). Rather than run kopia as root for these, the privileged daemon exposes a **kopia-readable view** of the source and kopia snapshots that unprivileged:

- **bindfs** `-r --force-user=kopia --force-group=kopia -o allow_other` presents the whole tree as kopia-owned — no copy, any filesystem, any ownership. (idmapped mounts can't do this: their uid map is bijective, so multiple real owners can't collapse onto the single kopia uid. bindfs can.) Preferred, and works for large sources since it's a view, not a copy.
- **fallback**: if bindfs isn't installed/usable, a root `cp -a` + `chown -R kopia` — universal but heavier.

The view lives under the daemon's `CacheDirectory` (`/var/cache/bestool/backup-source/<type>`, root-owned and world-traversable) so root can create it and the kopia user can reach the view inside. On non-Linux there's no kopia user, so kopia snapshots the path in place.

**Dependencies / deployment:**
- Needs **bindfs** installed on hosts for the no-copy path (else it falls back to copy). FUSE access is already covered by the sandbox changes (`PrivateDevices=no` → `/dev/fuse`, `@mount`).
- Runtime depends on #563 (the `CAP_CHOWN`/`SETUID`/`SETGID` that let the daemon run kopia as the kopia user and chown the copy/transient config).

Not runtime-verifiable from my environment (no bindfs/FUSE/kopia/sandbox here); the cross-platform compile + clippy are clean. Needs an on-host check that a `simple` backup of `/etc/postgresql` now snapshots via the bindfs view as the kopia user.
