### PR TITLE
fix(canopy): stage postgres backups in a root-owned StateDirectory

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -32,7 +32,11 @@ use super::method::{PostgresqlConfig, Prepared, Teardown};
 pub(super) fn stable_source_dir(backup_type: &str) -> PathBuf {
 	#[cfg(unix)]
 	{
-		PathBuf::from("/var/lib/kopia/bestool-backup").join(backup_type)
+		// Under the daemon's root-owned StateDirectory (/var/lib/bestool), not the
+		// kopia user's home: the daemon (root, without DAC write-override) creates
+		// the snapshot mount / base-backup staging here, then hands it to the kopia
+		// user. /var/lib/bestool is world-traversable so kopia can still read in.
+		PathBuf::from("/var/lib/bestool/backup-source").join(backup_type)
 	}
 	#[cfg(not(unix))]
 	{

--- a/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
@@ -73,6 +73,11 @@ pub async fn prepare(
 			.wrap_err_with(|| format!("creating {}", parent.display()))?;
 	}
 
+	// pg_basebackup runs as the postgres user (peer auth) and creates its own
+	// output dir, so the root-owned staging must be writable by postgres first.
+	#[cfg(unix)]
+	make_writable_by_postgres(&root).await?;
+
 	info!(dest = %dest.display(), "streaming pg_basebackup");
 	let mut cmd = super::pg_command(&super::postgres_bin("pg_basebackup", &resolved.data_dir));
 	cmd.args(basebackup_args(&dest, socket, port));
@@ -97,6 +102,25 @@ pub async fn teardown(root: PathBuf) -> Result<()> {
 		.await
 		.into_diagnostic()
 		.wrap_err_with(|| format!("removing base backup at {}", root.display()))
+}
+
+/// Hand the (root-created) staging to the postgres user so pg_basebackup, which
+/// runs as postgres, can create its output dir and write into it. Required —
+/// without it the stream fails to create its target.
+#[cfg(unix)]
+async fn make_writable_by_postgres(root: &Path) -> Result<()> {
+	let status = tokio::process::Command::new("chown")
+		.args(["-R", "postgres:postgres"])
+		.arg(root)
+		.stdin(Stdio::null())
+		.status()
+		.await
+		.into_diagnostic()
+		.wrap_err("handing the base backup staging to the postgres user")?;
+	if !status.success() {
+		bail!("chown of base backup staging to postgres failed ({status})");
+	}
+	Ok(())
 }
 
 /// pg_basebackup writes files owned by postgres and mode 0600; hand them to the

--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -18,13 +18,13 @@ use tracing::{info, warn};
 
 use super::{resolve::ResolvedCluster, sys};
 
-/// Directory the per-run top-level mounts live in. Under `/var/lib/kopia` (not
-/// `/mnt`) so it sits within the daemon's one writable path — `/mnt` is
-/// read-only under the unit's `ProtectSystem=strict`.
-const TOPLEVEL_MOUNT_DIR: &str = "/var/lib/kopia";
+/// Directory the per-run top-level mounts live in: the daemon's root-owned
+/// StateDirectory. Not `/mnt` (read-only under `ProtectSystem=strict`) nor
+/// `/var/lib/kopia` (the kopia user's home, which root can't write).
+const TOPLEVEL_MOUNT_DIR: &str = "/var/lib/bestool";
 
 /// Where the reaper looks for / makes per-run top-level mounts.
-const TOPLEVEL_MOUNT_PREFIX: &str = "/var/lib/kopia/bestool-btrfs-toplevel";
+const TOPLEVEL_MOUNT_PREFIX: &str = "/var/lib/bestool/bestool-btrfs-toplevel";
 
 /// Infix marking our ephemeral snapshot subvolumes, so the reaper's glob can
 /// never match a live subvolume.
@@ -196,7 +196,7 @@ mod tests {
 	fn toplevel_mount_path() {
 		assert_eq!(
 			toplevel_mount(7),
-			PathBuf::from("/var/lib/kopia/bestool-btrfs-toplevel.7")
+			PathBuf::from("/var/lib/bestool/bestool-btrfs-toplevel.7")
 		);
 	}
 }

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -54,13 +54,17 @@ ProtectHome=read-only
 CacheDirectory=bestool
 # Point the `dirs` crate's cache at /var/cache/bestool (the CacheDirectory).
 Environment=XDG_CACHE_HOME=%C
+# Root-owned scratch for backups: the daemon (root, without DAC write-override)
+# creates the postgres snapshot mounts and the base-backup staging here, under
+# /var/lib/bestool, then hands them to the kopia user — it can't write into the
+# kopia user's own home below.
+StateDirectory=bestool
 # bestool writes to its config dir, which ProtectSystem=strict otherwise
 # locks read-only along with the rest of /etc.
 ReadWritePaths=/etc/bestool
-# Everything kopia touches lives under its home, /var/lib/kopia: the repo config
-# (.config/kopia), the cache and logs (.cache/kopia, since we run kopia as the
-# kopia user with HOME there), and the postgres snapshot/base-backup staging
-# (bestool-backup). All of it must be writable.
+# The kopia user's home: its repo config (.config/kopia) and its cache and logs
+# (.cache/kopia, since we run kopia as the kopia user with HOME here). kopia
+# writes the cache, so this must be writable.
 ReadWritePaths=/var/lib/kopia
 # podman cp's tempdir lands in a private /tmp.
 PrivateTmp=yes


### PR DESCRIPTION
🤖 postgres backups failed creating their working dirs:

```
WARN snapshot backend unavailable (creating /var/lib/kopia/bestool-btrfs-toplevel.<pid>); falling back to pg_basebackup
ERROR backup failed: creating /var/lib/kopia/bestool-backup/tamanu-postgres/18
```

The btrfs snapshot mount and the pg_basebackup staging were created under `/var/lib/kopia` — but that's the **kopia user's home**, and the daemon runs as root with only `CAP_DAC_READ_SEARCH` (read traversal, *not* write-override), so it can't `mkdir` there. The daemon's scratch shouldn't live in the kopia user's home anyway.

Move it to a **root-owned `StateDirectory`** (`/var/lib/bestool`):

- `StateDirectory=bestool` in the unit (root-owned, writable, world-traversable).
- `stable_source_dir` and the btrfs top-level mount now live under `/var/lib/bestool/...`.
- pg_basebackup runs as the **postgres** user (peer auth) and creates its own output dir, so the root-created staging is chowned to postgres before the stream, then to kopia after (as before).

`/var/lib/bestool` is `0755` root, so the kopia user (which runs kopia) still traverses in to read the idmapped snapshot mount / chowned base backup. `/var/lib/kopia` stays in `ReadWritePaths` purely for the kopia user's own config + cache.

Runtime depends on #563 (`CAP_CHOWN` for the postgres/kopia chowns). Not runtime-verifiable here (no btrfs/postgres/sandbox); tests/clippy/Windows-compile clean. Wants an on-host check that `tamanu-postgres` now takes its btrfs snapshot under `/var/lib/bestool` and snapshots it as the kopia user.
