### PR TITLE
fix(canopy): reclaim staging ownership before removing it

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
@@ -61,10 +61,7 @@ pub async fn prepare(
 
 	// pg_basebackup requires an empty target; clear leftovers from a crashed run.
 	if root.exists() {
-		tokio::fs::remove_dir_all(&root)
-			.await
-			.into_diagnostic()
-			.wrap_err_with(|| format!("clearing stale base backup at {}", root.display()))?;
+		remove_staging(&root).await?;
 	}
 	if let Some(parent) = dest.parent() {
 		tokio::fs::create_dir_all(parent)
@@ -98,7 +95,23 @@ pub async fn prepare(
 
 /// Remove the streamed base backup (a full copy; reclaim the space).
 pub async fn teardown(root: PathBuf) -> Result<()> {
-	tokio::fs::remove_dir_all(&root)
+	remove_staging(&root).await
+}
+
+/// Delete a staging tree the daemon had handed to postgres/kopia. Reclaim
+/// ownership first: root holds CAP_CHOWN but not DAC write-override, so it can't
+/// unlink files inside postgres-/kopia-owned directories otherwise.
+async fn remove_staging(root: &Path) -> Result<()> {
+	#[cfg(unix)]
+	{
+		let _ = tokio::process::Command::new("chown")
+			.args(["-R", "root:root"])
+			.arg(root)
+			.stdin(Stdio::null())
+			.status()
+			.await;
+	}
+	tokio::fs::remove_dir_all(root)
 		.await
 		.into_diagnostic()
 		.wrap_err_with(|| format!("removing base backup at {}", root.display()))

--- a/crates/bestool/src/actions/canopy/backup/simple.rs
+++ b/crates/bestool/src/actions/canopy/backup/simple.rs
@@ -61,10 +61,20 @@ pub async fn teardown(cleanup: Cleanup) -> Result<()> {
 			Ok(())
 		}
 		#[cfg(target_os = "linux")]
-		Cleanup::Copy(dir) => tokio::fs::remove_dir_all(&dir)
-			.await
-			.into_diagnostic()
-			.wrap_err_with(|| format!("removing simple backup copy at {}", dir.display())),
+		Cleanup::Copy(dir) => {
+			// The copy was chowned to the kopia user; reclaim it before removing,
+			// since root (CAP_CHOWN, no DAC write-override) can't otherwise unlink
+			// files inside kopia-owned directories.
+			let _ = tokio::process::Command::new("chown")
+				.args(["-R", "root:root"])
+				.arg(&dir)
+				.status()
+				.await;
+			tokio::fs::remove_dir_all(&dir)
+				.await
+				.into_diagnostic()
+				.wrap_err_with(|| format!("removing simple backup copy at {}", dir.display()))
+		}
 	}
 }
 


### PR DESCRIPTION
🤖 Backup cleanup failed once the staging had been handed off:

```
ERROR backup failed: clearing stale base backup at /var/lib/bestool/backup-source/tamanu-postgres: Operation not permitted
```

The staging is chowned to **postgres** (so pg_basebackup can write it) and/or the **kopia** user (so kopia can read it). By cleanup time it's owned by them — and the daemon runs as root with `CAP_CHOWN` but **not** DAC write-override, so it can't unlink files inside postgres-/kopia-owned directories. `remove_dir_all` → EPERM.

Fix: `chown -R root:root` to reclaim the tree (we have `CAP_CHOWN`), then remove. Applied to:
- the postgres base-backup staging (stale-clear at prepare, and teardown), and
- the `simple` method's `cp`-fallback copy teardown (same bug, landed in #565).

This unblocks the **pg_basebackup fallback** end-to-end, so postgres backups work even while the btrfs snapshot path is still blocked by the sandbox (separate issue — see below).

Tests/clippy/Windows clean.
