### PR TITLE
fix(canopy): snapshot the btrfs subvolume via the read-write top-level mount

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -56,6 +56,16 @@ fn toplevel_mount(pid: u32) -> PathBuf {
 	PathBuf::from(format!("{TOPLEVEL_MOUNT_PREFIX}.{pid}"))
 }
 
+/// The subvolume's path within the filesystem, parsed from `findmnt -o SOURCE`
+/// (e.g. `/dev/disk/by-uuid/…[/@postgresql]` → `@postgresql`). `None` when the
+/// data dir lives on the top-level subvolume (no `[…]` suffix).
+fn subvol_rel_path(source: &str) -> Option<String> {
+	let start = source.find('[')?;
+	let end = source.rfind(']')?;
+	let sub = source.get(start + 1..end)?.trim_start_matches('/');
+	(!sub.is_empty()).then(|| sub.to_owned())
+}
+
 /// Take the snapshot and mount it; returns the kopia source path and the
 /// teardown state. Caller must always pass the result to [`teardown`].
 pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(PathBuf, Mounts)> {
@@ -66,6 +76,11 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 		"/dev/disk/by-uuid/{}",
 		sys::findmnt_field("UUID", &resolved.data_dir).await?
 	);
+	// The subvolume's path within the fs (from findmnt SOURCE), so we can snapshot
+	// it through our own read-write top-level mount rather than its live mount: the
+	// daemon's ProtectSystem=strict makes the live mount read-only, and btrfs
+	// refuses to snapshot a source on a read-only mount.
+	let subvol = subvol_rel_path(&sys::findmnt_field("SOURCE", &resolved.data_dir).await?);
 	let map = sys::postgres_to_kopia_idmap().await?;
 
 	let kopia_mount = stable_kopia_mount(backup_type);
@@ -89,6 +104,13 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 	)
 	.await?;
 
+	// Snapshot the subvolume via the read-write top-level mount (see `subvol`),
+	// not its read-only live mount. The top-level subvolume itself when there's
+	// no nested subvol.
+	let snapshot_source = match &subvol {
+		Some(sub) => toplevel_mount.join(sub),
+		None => toplevel_mount.clone(),
+	};
 	info!(snapshot = %snapshot_path.display(), "creating read-only btrfs snapshot");
 	sys::run_ok(
 		"btrfs",
@@ -96,7 +118,7 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 			"subvolume",
 			"snapshot",
 			"-r",
-			sys::path(&base_mount),
+			sys::path(&snapshot_source),
 			sys::path(&snapshot_path),
 		],
 	)
@@ -174,6 +196,21 @@ async fn reap_stale(fsdev: &str, kopia_mount: &Path) {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn subvol_rel_path_parses_findmnt_source() {
+		assert_eq!(
+			subvol_rel_path("/dev/disk/by-uuid/abc[/@postgresql]").as_deref(),
+			Some("@postgresql")
+		);
+		assert_eq!(
+			subvol_rel_path("/dev/mapper/vg-lv[/@/var/lib/postgresql]").as_deref(),
+			Some("@/var/lib/postgresql")
+		);
+		// No subvol bracket (top-level subvolume) → None.
+		assert_eq!(subvol_rel_path("/dev/sda2"), None);
+		assert_eq!(subvol_rel_path("/dev/sda2[/]"), None);
+	}
 
 	#[test]
 	fn snapshot_name_carries_reaper_infix() {

--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -56,16 +56,6 @@ fn toplevel_mount(pid: u32) -> PathBuf {
 	PathBuf::from(format!("{TOPLEVEL_MOUNT_PREFIX}.{pid}"))
 }
 
-/// The subvolume's path within the filesystem, parsed from `findmnt -o SOURCE`
-/// (e.g. `/dev/disk/by-uuid/…[/@postgresql]` → `@postgresql`). `None` when the
-/// data dir lives on the top-level subvolume (no `[…]` suffix).
-fn subvol_rel_path(source: &str) -> Option<String> {
-	let start = source.find('[')?;
-	let end = source.rfind(']')?;
-	let sub = source.get(start + 1..end)?.trim_start_matches('/');
-	(!sub.is_empty()).then(|| sub.to_owned())
-}
-
 /// Take the snapshot and mount it; returns the kopia source path and the
 /// teardown state. Caller must always pass the result to [`teardown`].
 pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(PathBuf, Mounts)> {
@@ -76,11 +66,15 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 		"/dev/disk/by-uuid/{}",
 		sys::findmnt_field("UUID", &resolved.data_dir).await?
 	);
-	// The subvolume's path within the fs (from findmnt SOURCE), so we can snapshot
-	// it through our own read-write top-level mount rather than its live mount: the
-	// daemon's ProtectSystem=strict makes the live mount read-only, and btrfs
-	// refuses to snapshot a source on a read-only mount.
-	let subvol = subvol_rel_path(&sys::findmnt_field("SOURCE", &resolved.data_dir).await?);
+	// The subvolume's path within the fs (findmnt's FSROOT, e.g. `/@postgres`), so
+	// we can snapshot it through our own read-write top-level mount rather than its
+	// live mount: the daemon's ProtectSystem=strict makes the live mount read-only,
+	// and btrfs refuses to snapshot a source on a read-only mount. `/` (or empty)
+	// means the data dir is on the top-level subvolume.
+	let subvol = sys::findmnt_json_field("FSROOT", &resolved.data_dir)
+		.await?
+		.trim_start_matches('/')
+		.to_owned();
 	let map = sys::postgres_to_kopia_idmap().await?;
 
 	let kopia_mount = stable_kopia_mount(backup_type);
@@ -105,11 +99,12 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 	.await?;
 
 	// Snapshot the subvolume via the read-write top-level mount (see `subvol`),
-	// not its read-only live mount. The top-level subvolume itself when there's
-	// no nested subvol.
-	let snapshot_source = match &subvol {
-		Some(sub) => toplevel_mount.join(sub),
-		None => toplevel_mount.clone(),
+	// not its read-only live mount; the top-level subvolume itself when the data
+	// dir isn't on a nested subvol.
+	let snapshot_source = if subvol.is_empty() {
+		toplevel_mount.clone()
+	} else {
+		toplevel_mount.join(&subvol)
 	};
 	info!(snapshot = %snapshot_path.display(), "creating read-only btrfs snapshot");
 	sys::run_ok(
@@ -196,21 +191,6 @@ async fn reap_stale(fsdev: &str, kopia_mount: &Path) {
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	#[test]
-	fn subvol_rel_path_parses_findmnt_source() {
-		assert_eq!(
-			subvol_rel_path("/dev/disk/by-uuid/abc[/@postgresql]").as_deref(),
-			Some("@postgresql")
-		);
-		assert_eq!(
-			subvol_rel_path("/dev/mapper/vg-lv[/@/var/lib/postgresql]").as_deref(),
-			Some("@/var/lib/postgresql")
-		);
-		// No subvol bracket (top-level subvolume) → None.
-		assert_eq!(subvol_rel_path("/dev/sda2"), None);
-		assert_eq!(subvol_rel_path("/dev/sda2[/]"), None);
-	}
 
 	#[test]
 	fn snapshot_name_carries_reaper_infix() {

--- a/crates/bestool/src/actions/canopy/backup/postgresql/sys.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/sys.rs
@@ -63,6 +63,27 @@ pub(super) async fn findmnt_field(field: &str, data_dir: &Path) -> Result<String
 	capture("findmnt", &["-no", field, "--target", path(data_dir)]).await
 }
 
+/// A single `findmnt` field for `data_dir`, read from `--json` rather than the
+/// raw `-no` form — structured, so e.g. the btrfs subvolume (`FSROOT`) doesn't
+/// have to be teased out of the bracketed `SOURCE` string.
+pub(super) async fn findmnt_json_field(field: &str, data_dir: &Path) -> Result<String> {
+	let out = capture("findmnt", &["--json", "-o", field, "--target", path(data_dir)]).await?;
+	parse_findmnt_field(&out, &field.to_ascii_lowercase())
+		.ok_or_else(|| miette!("findmnt --json had no {field} for {}", data_dir.display()))
+}
+
+/// Pull a column from the first filesystem of `findmnt --json` output.
+fn parse_findmnt_field(json: &str, key: &str) -> Option<String> {
+	let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
+	parsed
+		.get("filesystems")?
+		.as_array()?
+		.first()?
+		.get(key)?
+		.as_str()
+		.map(str::to_owned)
+}
+
 /// A user's numeric uid / gid (via `id`).
 pub(super) async fn uid_of(user: &str) -> Result<u32> {
 	parse_id(&capture("id", &["-u", user]).await?, user)
@@ -171,5 +192,17 @@ mod tests {
 	#[test]
 	fn relative_data_path_rejects_outside() {
 		assert!(relative_data_path(Path::new("/srv/pg"), Path::new("/var/lib/postgresql")).is_err());
+	}
+
+	#[test]
+	fn parse_findmnt_field_reads_first_filesystem() {
+		let json = r#"{"filesystems":[{"target":"/var/lib/postgresql","source":"/dev/sda2[/@postgres]","fsroot":"/@postgres"}]}"#;
+		assert_eq!(parse_findmnt_field(json, "fsroot").as_deref(), Some("/@postgres"));
+		assert_eq!(
+			parse_findmnt_field(json, "source").as_deref(),
+			Some("/dev/sda2[/@postgres]")
+		);
+		assert_eq!(parse_findmnt_field(json, "missing"), None);
+		assert_eq!(parse_findmnt_field("not json", "fsroot"), None);
 	}
 }


### PR DESCRIPTION
🤖 Confirmed on-host: `findmnt /var/lib/postgresql` shows the cluster's live mount as **`ro`** in the daemon's namespace (from `ProtectSystem=strict`), and btrfs refuses to snapshot a source on a read-only mount:

```
ERROR: cannot snapshot '/var/lib/postgresql': Operation not permitted
```

We already mount the filesystem's top-level subvolume (`subvolid=5`) read-write to hold the snapshot. So snapshot the subvolume **through that read-write mount** instead of its read-only live path: resolve the subvolume's path within the fs from `findmnt -o SOURCE` (the `[/@postgresql]` suffix) and snapshot `<toplevel>/<subvol>` — falling back to the top-level subvolume itself when the data dir isn't on a nested subvol.

The snapshot content is identical (same subvolume); only the *path we name as the source* changes, to one on a writable mount.

Unit test covers the `findmnt SOURCE` parsing. The snapshot/mount path itself needs a btrfs host to confirm (no btrfs/sandbox here), but this directly addresses the read-only-source EPERM you diagnosed.
