### PR TITLE
fix(canopy): make backup-source traversable for the kopia user

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/btrfs.rs
@@ -104,6 +104,9 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 	mounts.snapshot_path = snapshot_path.clone();
 
 	sys::mkdir(&kopia_mount).await?;
+	if let Some(parent) = kopia_mount.parent() {
+		sys::make_traversable(parent).await?;
+	}
 	sys::run_ok(
 		"mount",
 		&[

--- a/crates/bestool/src/actions/canopy/backup/postgresql/lvm.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/lvm.rs
@@ -93,6 +93,9 @@ pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(P
 	.await?;
 
 	sys::mkdir(&kopia_mount).await?;
+	if let Some(parent) = kopia_mount.parent() {
+		sys::make_traversable(parent).await?;
+	}
 	sys::run_ok(
 		"mount",
 		&[

--- a/crates/bestool/src/actions/canopy/backup/postgresql/sys.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/sys.rs
@@ -86,6 +86,25 @@ pub(super) async fn mkdir(dir: &Path) -> Result<()> {
 		.wrap_err_with(|| format!("creating {}", dir.display()))
 }
 
+/// Make `dir` world-traversable (mode 0o755) so the unprivileged kopia user can
+/// descend through it to the mounted source. The daemon runs with a restrictive
+/// umask, which would otherwise leave a freshly-created `backup-source` dir
+/// group-only and deny the kopia user. The dir is a bare mountpoint parent — the
+/// mounted snapshot keeps its own (idmapped) permissions.
+pub(super) async fn make_traversable(dir: &Path) -> Result<()> {
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt as _;
+		tokio::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755))
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("making {} traversable", dir.display()))?;
+	}
+	#[cfg(not(unix))]
+	let _ = dir;
+	Ok(())
+}
+
 pub(super) async fn umount(dir: &Path) {
 	if is_mountpoint(dir).await {
 		let _ = run_ok("umount", &[path(dir)]).await;

--- a/crates/bestool/src/actions/canopy/backup/simple.rs
+++ b/crates/bestool/src/actions/canopy/backup/simple.rs
@@ -105,6 +105,16 @@ async fn prepare_linux(source: &Path, backup_type: &str) -> Result<(PathBuf, Cle
 		.into_diagnostic()
 		.wrap_err_with(|| format!("creating simple backup view dir {}", view.display()))?;
 
+	// The daemon's restrictive umask would leave `backup-source` group-only;
+	// widen it so the unprivileged kopia user can traverse it to reach the view.
+	if let Some(parent) = view.parent() {
+		use std::os::unix::fs::PermissionsExt as _;
+		tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755))
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("making {} traversable", parent.display()))?;
+	}
+
 	// Preferred: a read-only bindfs view presenting the tree as kopia-owned.
 	match Command::new("bindfs")
 		.arg("-r")


### PR DESCRIPTION
🤖 After CAP_FOWNER (#571) let the btrfs snapshot succeed, kopia then failed with `permission denied` on `lstat` of the cluster dir inside the prepared mount.

On-host `namei` traced it to one component: the shared `backup-source` dir was mode `0770 root:root`. The daemon runs with `UMask=0007` (deliberate — `/etc/bestool` is a setgid group-shared dir), so `create_dir_all` left `backup-source` group-only. kopia, dropped to an unprivileged user, is neither root nor in the root group, so it couldn't traverse into `backup-source` to reach the mount.

The idmap and snapshot were both fine — the mount root and its contents showed up correctly as kopia-owned. The only wall was that one parent dir.

Fix: explicitly widen `backup-source` to `0755` after creating the per-type mountpoint, in the btrfs, thin-LVM, and `simple` source-prep paths. It's a bare mountpoint parent holding no secrets; the mounted snapshot keeps its own idmapped permissions. `UMask=0007` is left intact so `/etc/bestool` writes stay group-only.
