### PR TITLE
build(deb): depend on backup helper tools (bindfs, btrfs-progs, sudo; recommend lvm2)

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -177,6 +177,8 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
+          Depends: bindfs, btrfs-progs, sudo
+          Recommends: lvm2
           Maintainer: BES Developers <support@bes.au>
           Description: BES Deployment tooling
           Homepage: https://github.com/beyondessential/bestool


### PR DESCRIPTION
🤖 The bestool deb declared no dependencies, so the backup helper tools were expected to be present out of band — and one (bindfs) wasn't, which silently dropped the `simple` backup onto a heavier, failure-prone copy path.

Declare what the backup backends shell out to:

- **Depends: bindfs** — the `simple` backup's preferred kopia-readable view.
- **Depends: btrfs-progs** — btrfs snapshots, and the doctor disk-stats check (`btrfs device stats`).
- **Depends: sudo** — the postgres backup runs pg tools as the postgres user (`sudo -u postgres` for CHECKPOINT and `pg_basebackup` peer auth).
- **Recommends: lvm2** — the thin-LVM snapshot path; not every host uses LVM, so it's a recommend rather than a hard requirement.

Everything else bestool runs is either Essential (coreutils, util-linux), part of systemd (present where the daemon runs), Windows-only, pulled in transitively (fuse via bindfs), or a bestool-managed external tool (kopia, node/pm2, podman, tailscale) that isn't an apt dependency.
