### PR TITLE
build(deb): depend on kopia

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -177,7 +177,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
-          Depends: bindfs, btrfs-progs, sudo
+          Depends: bindfs, btrfs-progs, kopia, sudo
           Recommends: lvm2
           Maintainer: BES Developers <support@bes.au>
           Description: BES Deployment tooling


### PR DESCRIPTION
🤖 Follow-up to #577. kopia is the engine the canopy backups drive, and the BES apt repo now ships a kopia package that also provisions the `kopia` user/group/home that bestool runs backups as (`LINUX_KOPIA_USER` / `/var/lib/kopia`).

With kopia in the same repo the dependency is satisfiable, so depend on it: a fresh `bestool` install is then backup-capable out of the box, with the kopia user provisioned by the kopia package (bestool doesn't create it).

(Earlier I'd kept kopia out of the deps because it wasn't in the base repos and the upstream package doesn't create a user — both now moot.)
