### PR TITLE
fix(doctor): elevate root-only checks (btrfs, podman) via sudo when not root

### DIFF
--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -87,6 +87,38 @@ pub struct CheckContext {
 	pub has_install: bool,
 }
 
+/// Whether the doctor is running as root (euid 0), read from `/proc/self/status`.
+async fn is_root() -> bool {
+	// euid is the second field of the `Uid:` line.
+	tokio::fs::read_to_string("/proc/self/status")
+		.await
+		.ok()
+		.and_then(|status| {
+			status
+				.lines()
+				.find_map(|line| line.strip_prefix("Uid:"))
+				.and_then(|rest| rest.split_whitespace().nth(1).map(str::to_owned))
+		})
+		.and_then(|euid| euid.parse::<u32>().ok())
+		.is_some_and(|euid| euid == 0)
+}
+
+/// Build a command that runs `program` as root: directly when we already are,
+/// else via `sudo`. Some checks read root-only interfaces — btrfs ioctls
+/// (`device stats`), and the like — that see nothing as a normal user. The
+/// alertd daemon runs the sweep as root (direct); an interactive `bestool tamanu
+/// doctor` elevates rather than reporting blind. (Assumes passwordless sudo
+/// where used; otherwise sudo's own failure surfaces in the check.)
+pub(crate) async fn privileged(program: &str) -> tokio::process::Command {
+	if is_root().await {
+		tokio::process::Command::new(program)
+	} else {
+		let mut cmd = tokio::process::Command::new("sudo");
+		cmd.arg(program);
+		cmd
+	}
+}
+
 /// `tokio_postgres::Error`'s top-level Display is the unhelpful `"db error"`.
 /// The actual SQL message lives in the optional `DbError` underneath; this
 /// helper surfaces it where present and falls back to the source chain.

--- a/crates/alertd/src/doctor/checks/btrfs.rs
+++ b/crates/alertd/src/doctor/checks/btrfs.rs
@@ -23,7 +23,6 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
 use serde_json::{Value, json};
-use tokio::process::Command;
 
 use super::SweepContext;
 use crate::doctor::check::Check;
@@ -145,7 +144,9 @@ enum CmdErr {
 }
 
 async fn btrfs_cmd(args: &[&str]) -> Result<String, CmdErr> {
-	match Command::new("btrfs").args(args).output().await {
+	// device stats / subvolume list need CAP_SYS_ADMIN; elevate when not root so
+	// an interactive run still collects, matching the root daemon sweep.
+	match super::privileged("btrfs").await.args(args).output().await {
 		Ok(o) if o.status.success() => Ok(String::from_utf8_lossy(&o.stdout).into_owned()),
 		Ok(o) => Err(CmdErr::Failed(format!(
 			"`btrfs {}` exited {}: {}",

--- a/crates/tamanu/src/versions.rs
+++ b/crates/tamanu/src/versions.rs
@@ -136,7 +136,18 @@ pub fn parse_image_tag(image: &str) -> Option<&str> {
 #[cfg(target_os = "linux")]
 #[instrument(level = "debug")]
 pub async fn running_versions_linux() -> Result<HashMap<String, String>, String> {
-	let result = tokio::process::Command::new("podman")
+	// The deployment runs rootful podman, so the containers are only visible to
+	// root. When we're not root (an interactive `tamanu status` / `doctor`),
+	// elevate via sudo rather than letting podman run rootless and see nothing or
+	// error; the alertd daemon already runs as root and invokes it directly.
+	let mut command = if is_root().await {
+		tokio::process::Command::new("podman")
+	} else {
+		let mut c = tokio::process::Command::new("sudo");
+		c.arg("podman");
+		c
+	};
+	let result = command
 		.args([
 			"ps",
 			"--format",
@@ -183,6 +194,25 @@ pub async fn running_versions_linux() -> Result<HashMap<String, String>, String>
 #[cfg(not(target_os = "linux"))]
 pub async fn running_versions_linux() -> Result<HashMap<String, String>, String> {
 	Ok(HashMap::new())
+}
+
+/// Whether this process is running as root (euid 0), read from
+/// `/proc/self/status`. Used to decide whether reading the rootful podman needs
+/// elevating via sudo.
+#[cfg(target_os = "linux")]
+async fn is_root() -> bool {
+	// euid is the second field of the `Uid:` line.
+	tokio::fs::read_to_string("/proc/self/status")
+		.await
+		.ok()
+		.and_then(|status| {
+			status
+				.lines()
+				.find_map(|line| line.strip_prefix("Uid:"))
+				.and_then(|rest| rest.split_whitespace().nth(1).map(str::to_owned))
+		})
+		.and_then(|euid| euid.parse::<u32>().ok())
+		.is_some_and(|euid| euid == 0)
 }
 
 /// Parse a version string leniently, tolerating a leading `v` (image tags and


### PR DESCRIPTION
🤖 Running `bestool tamanu doctor` as an unprivileged user produces two false warnings:

```
WARN  btrfs          /: `btrfs device stats /` exited 1: ... Operation not permitted
WARN  version_drift  `podman ps` failed ... newuidmap ... (rootless)
```

Both are privilege artifacts, not faults — and the data *is* obtainable, just needs root:
- **btrfs** `device stats` / `subvolume list` need `CAP_SYS_ADMIN`.
- **version_drift** — the deployment uses **rootful** podman, so the containers are only visible to root; as a normal user `podman ps` runs rootless and errors.

So rather than skip (go blind), **elevate**: when not running as root (euid != 0, read from `/proc/self/status`), run those commands via `sudo`. The alertd daemon runs the sweep as root and invokes them directly — this only changes the interactive non-root case, which now collects the same data instead of warning. Assumes passwordless sudo where used; otherwise sudo's own failure surfaces in the check.

podman elevation lives in the shared `running_versions_linux`, so `tamanu status` gets the same fix.

Note: this addresses the **interactive** case. The separate report that the *root daemon* itself gets EPERM on `btrfs device stats` is a sandbox/caps issue in the deployed unit, still being diagnosed — elevation doesn't apply there (already root).
