### PR TITLE
feat(kopia): account S3 bytes through the re-signing proxy

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -433,7 +433,26 @@ async fn backup_after_start(
 		.await;
 	emit(&progress, BackupEvent::Phase("report"));
 
-	// Report whatever happened, then surface the original error (if any).
+	// The proxy saw every S3 request this run made (success or failure), so its
+	// tallies are a rough measure of the network/S3 traffic this run accounts for.
+	let traffic = proxy.traffic();
+	info!(
+		backup_type,
+		run_id,
+		sent_raw = traffic.sent_raw,
+		sent_payload = traffic.sent_payload,
+		received_raw = traffic.received_raw,
+		received_payload = traffic.received_payload,
+		"s3 traffic for this run"
+	);
+
+	// Report whatever happened, then surface the original error (if any). The
+	// traffic counts go on both outcomes: bytes flow whether or not it succeeds.
+	let to_i64 = |n: u64| i64::try_from(n).unwrap_or(i64::MAX);
+	let s3_sent_raw_bytes = Some(to_i64(traffic.sent_raw));
+	let s3_sent_payload_bytes = Some(to_i64(traffic.sent_payload));
+	let s3_received_raw_bytes = Some(to_i64(traffic.received_raw));
+	let s3_received_payload_bytes = Some(to_i64(traffic.received_payload));
 	let report = match &outcome {
 		Ok(snapshot) => BackupReport {
 			run_id,
@@ -443,6 +462,10 @@ async fn backup_after_start(
 			error: None,
 			bytes_uploaded: snapshot.bytes_uploaded,
 			snapshot_id: snapshot.id.as_deref(),
+			s3_sent_raw_bytes,
+			s3_sent_payload_bytes,
+			s3_received_raw_bytes,
+			s3_received_payload_bytes,
 		},
 		Err(err) => BackupReport {
 			run_id,
@@ -452,6 +475,10 @@ async fn backup_after_start(
 			error: Some(&trim_error(err)),
 			bytes_uploaded: None,
 			snapshot_id: None,
+			s3_sent_raw_bytes,
+			s3_sent_payload_bytes,
+			s3_received_raw_bytes,
+			s3_received_payload_bytes,
 		},
 	};
 	client

--- a/crates/bestool/src/canopy_contract.rs
+++ b/crates/bestool/src/canopy_contract.rs
@@ -443,6 +443,13 @@ async fn backup_report_request_matches_spec() {
 		error: None,
 		bytes_uploaded: Some(12345),
 		snapshot_id: Some("abc123"),
+		// Intentionally populated: this gates the PR. bestool already sends these
+		// (canopy ignores unknown fields), but the contract check stays red until
+		// canopy's OpenAPI spec defines the s3 traffic fields — then it goes green.
+		s3_sent_raw_bytes: Some(2_000_000),
+		s3_sent_payload_bytes: Some(1_950_000),
+		s3_received_raw_bytes: Some(4096),
+		s3_received_payload_bytes: Some(0),
 	})
 	.unwrap();
 	assert_valid(spec, &request_schema("/backup-report", "post"), &instance);

--- a/crates/canopy/src/backup.rs
+++ b/crates/canopy/src/backup.rs
@@ -115,6 +115,18 @@ pub struct BackupReport<'a> {
 	pub bytes_uploaded: Option<i64>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub snapshot_id: Option<&'a str>,
+	/// S3 traffic the run accounted for, measured by the re-signing proxy. `*_raw`
+	/// is the full HTTP message (headers + on-the-wire body incl. SigV4 chunk
+	/// framing); `*_payload` is the decoded object data. A rough per-deployment
+	/// network/S3 measure; distinct from `bytes_uploaded` (kopia's own figure).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub s3_sent_raw_bytes: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub s3_sent_payload_bytes: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub s3_received_raw_bytes: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub s3_received_payload_bytes: Option<i64>,
 }
 
 #[cfg(test)]
@@ -243,6 +255,10 @@ mod tests {
 			error: None,
 			bytes_uploaded: None,
 			snapshot_id: None,
+			s3_sent_raw_bytes: None,
+			s3_sent_payload_bytes: None,
+			s3_received_raw_bytes: None,
+			s3_received_payload_bytes: None,
 		};
 		assert_eq!(
 			serde_json::to_value(&report).unwrap(),
@@ -265,6 +281,10 @@ mod tests {
 			error: Some("kopia exploded"),
 			bytes_uploaded: Some(42),
 			snapshot_id: Some("snap"),
+			s3_sent_raw_bytes: Some(2048),
+			s3_sent_payload_bytes: Some(1024),
+			s3_received_raw_bytes: Some(64),
+			s3_received_payload_bytes: Some(0),
 		};
 		assert_eq!(
 			serde_json::to_value(&report).unwrap(),
@@ -276,6 +296,10 @@ mod tests {
 				"error": "kopia exploded",
 				"bytes_uploaded": 42,
 				"snapshot_id": "snap",
+				"s3_sent_raw_bytes": 2048,
+				"s3_sent_payload_bytes": 1024,
+				"s3_received_raw_bytes": 64,
+				"s3_received_payload_bytes": 0,
 			})
 		);
 	}

--- a/crates/kopia/src/proxy.rs
+++ b/crates/kopia/src/proxy.rs
@@ -10,7 +10,15 @@
 //!
 //! See the S3P spec for the design.
 
-use std::{future::Future, net::SocketAddr, pin::Pin, sync::Arc};
+use std::{
+	future::Future,
+	net::SocketAddr,
+	pin::Pin,
+	sync::{
+		Arc,
+		atomic::{AtomicU64, Ordering},
+	},
+};
 
 use tokio::{net::TcpListener, task::JoinHandle};
 
@@ -20,6 +28,56 @@ pub mod stream;
 
 /// Boxed error used across the proxy's async paths.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Cumulative byte accounting for a proxy's lifetime, shared with the server
+/// task. Since the proxy sees every request, this gives a rough measure of the
+/// S3 traffic a run is accountable for.
+///
+/// `*_raw` counts the full HTTP message — request/status line, headers, and the
+/// body as it goes on the wire, including the SigV4 chunk framing kopia adds to
+/// streaming uploads. `*_payload` counts only the object data (the decoded
+/// body). The difference is protocol overhead.
+#[derive(Default)]
+pub(crate) struct Traffic {
+	sent_raw: AtomicU64,
+	sent_payload: AtomicU64,
+	received_raw: AtomicU64,
+	received_payload: AtomicU64,
+}
+
+impl Traffic {
+	pub(crate) fn add_sent(&self, raw: u64, payload: u64) {
+		self.sent_raw.fetch_add(raw, Ordering::Relaxed);
+		self.sent_payload.fetch_add(payload, Ordering::Relaxed);
+	}
+
+	pub(crate) fn add_received(&self, raw: u64, payload: u64) {
+		self.received_raw.fetch_add(raw, Ordering::Relaxed);
+		self.received_payload.fetch_add(payload, Ordering::Relaxed);
+	}
+
+	fn snapshot(&self) -> TrafficStats {
+		TrafficStats {
+			sent_raw: self.sent_raw.load(Ordering::Relaxed),
+			sent_payload: self.sent_payload.load(Ordering::Relaxed),
+			received_raw: self.received_raw.load(Ordering::Relaxed),
+			received_payload: self.received_payload.load(Ordering::Relaxed),
+		}
+	}
+}
+
+/// A point-in-time read of a proxy's [`Traffic`]. All counts are bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TrafficStats {
+	/// Full request bytes sent upstream (line + headers + framed body).
+	pub sent_raw: u64,
+	/// Object-data bytes uploaded (decoded, excluding chunk framing).
+	pub sent_payload: u64,
+	/// Full response bytes received from upstream (line + headers + body).
+	pub received_raw: u64,
+	/// Object-data bytes downloaded (response bodies).
+	pub received_payload: u64,
+}
 
 /// A live set of S3 credentials.
 #[derive(Clone)]
@@ -71,6 +129,7 @@ pub struct S3ProxyConfig {
 pub struct RunningProxy {
 	addr: SocketAddr,
 	task: JoinHandle<()>,
+	traffic: Arc<Traffic>,
 }
 
 impl RunningProxy {
@@ -82,6 +141,11 @@ impl RunningProxy {
 	/// `host:port` form for kopia's `--endpoint` (TLS is disabled on this leg).
 	pub fn endpoint(&self) -> String {
 		self.addr.to_string()
+	}
+
+	/// Bytes sent to and received from upstream S3 over this proxy's lifetime.
+	pub fn traffic(&self) -> TrafficStats {
+		self.traffic.snapshot()
 	}
 
 	/// Stop serving.
@@ -109,7 +173,12 @@ pub async fn spawn(
 
 	let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
 	let addr = listener.local_addr()?;
-	let task = tokio::spawn(server::run(listener, config, provider));
+	let traffic = Arc::new(Traffic::default());
+	let task = tokio::spawn(server::run(listener, config, provider, traffic.clone()));
 	tracing::info!(%addr, "s3 re-signing proxy bound");
-	Ok(RunningProxy { addr, task })
+	Ok(RunningProxy {
+		addr,
+		task,
+		traffic,
+	})
 }

--- a/crates/kopia/src/proxy/server.rs
+++ b/crates/kopia/src/proxy/server.rs
@@ -12,7 +12,7 @@ use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::{
 	Request, Response, StatusCode,
 	body::{Body, Frame, Incoming, SizeHint},
-	header::{HeaderName, HeaderValue},
+	header::{HeaderMap, HeaderName, HeaderValue},
 };
 use hyper_util::{
 	client::legacy::{Client, connect::HttpConnector},
@@ -20,7 +20,7 @@ use hyper_util::{
 };
 use tokio::net::TcpListener;
 
-use super::{BoxError, CredentialProvider, S3ProxyConfig, sigv4, stream::ChunkResigner};
+use super::{BoxError, CredentialProvider, S3ProxyConfig, Traffic, sigv4, stream::ChunkResigner};
 
 type ReqBody = BoxBody<Bytes, BoxError>;
 type ResBody = BoxBody<Bytes, BoxError>;
@@ -46,12 +46,14 @@ struct State {
 	config: S3ProxyConfig,
 	provider: Arc<dyn CredentialProvider>,
 	client: HttpsClient,
+	traffic: Arc<Traffic>,
 }
 
 pub(super) async fn run(
 	listener: TcpListener,
 	config: S3ProxyConfig,
 	provider: Arc<dyn CredentialProvider>,
+	traffic: Arc<Traffic>,
 ) {
 	let https = hyper_rustls::HttpsConnectorBuilder::new()
 		.with_webpki_roots()
@@ -63,6 +65,7 @@ pub(super) async fn run(
 		config,
 		provider,
 		client,
+		traffic,
 	});
 
 	loop {
@@ -182,6 +185,20 @@ async fn proxy(state: &State, req: Request<Incoming>) -> Result<Response<ResBody
 		creds.access_key
 	);
 
+	// Account the request: `content-length` is the body as it goes on the wire
+	// (the chunk-framed length for a streaming upload); the payload is the decoded
+	// object data — `x-amz-decoded-content-length` when streaming, else the body.
+	let body_len = header_u64(&headers, "content-length");
+	let payload_len = if streaming {
+		header_u64(&headers, "x-amz-decoded-content-length")
+	} else {
+		body_len
+	};
+	let request_overhead = request_overhead(method.as_str(), &path, &query, &fwd, &authorization);
+	state
+		.traffic
+		.add_sent(request_overhead + body_len, payload_len);
+
 	let upstream_body: ReqBody = if streaming {
 		let exact_len: u64 = headers
 			.get("content-length")
@@ -234,6 +251,10 @@ async fn proxy(state: &State, req: Request<Incoming>) -> Result<Response<ResBody
 		tracing::debug!(%status, %path, "upstream returned non-2xx");
 	}
 	let (parts, body) = resp.into_parts();
+	// Account the response line + headers now; the body is counted as it streams.
+	state
+		.traffic
+		.add_received(response_overhead(status, &parts.headers), 0);
 	let mut out = Response::builder().status(status);
 	for (name, value) in parts.headers.iter() {
 		if DROP_RESPONSE_HEADERS.contains(&name.as_str()) {
@@ -241,7 +262,11 @@ async fn proxy(state: &State, req: Request<Incoming>) -> Result<Response<ResBody
 		}
 		out = out.header(name, value);
 	}
-	let body: ResBody = body.map_err(|e| -> BoxError { Box::new(e) }).boxed();
+	let body: ResBody = CountingBody {
+		inner: body.map_err(|e| -> BoxError { Box::new(e) }).boxed(),
+		traffic: state.traffic.clone(),
+	}
+	.boxed();
 	out.body(body).map_err(|e| -> BoxError { Box::new(e) })
 }
 
@@ -302,5 +327,113 @@ impl Body for ResignBody {
 
 	fn size_hint(&self) -> SizeHint {
 		SizeHint::with_exact(self.exact_len)
+	}
+}
+
+/// Wraps the upstream response body, tallying every byte received into the
+/// proxy's [`Traffic`]. A response body is object data with no extra framing, so
+/// it counts as both raw and payload.
+struct CountingBody {
+	inner: ResBody,
+	traffic: Arc<Traffic>,
+}
+
+impl Body for CountingBody {
+	type Data = Bytes;
+	type Error = BoxError;
+
+	fn poll_frame(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+	) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+		let this = self.get_mut();
+		match Pin::new(&mut this.inner).poll_frame(cx) {
+			Poll::Ready(Some(Ok(frame))) => {
+				if let Some(data) = frame.data_ref() {
+					let n = data.len() as u64;
+					this.traffic.add_received(n, n);
+				}
+				Poll::Ready(Some(Ok(frame)))
+			}
+			other => other,
+		}
+	}
+
+	fn size_hint(&self) -> SizeHint {
+		self.inner.size_hint()
+	}
+}
+
+/// A request/response header's value parsed as a `u64`, or 0 if absent/unparsable.
+fn header_u64(headers: &HeaderMap, name: &str) -> u64 {
+	headers
+		.get(name)
+		.and_then(|v| v.to_str().ok())
+		.and_then(|s| s.parse().ok())
+		.unwrap_or(0)
+}
+
+/// Rough wire size of the request line + forwarded headers + authorization
+/// (`name: value\r\n` per header, trailing blank line). An estimate: it doesn't
+/// model HTTP/2 or TLS, which is fine for the per-deployment traffic accounting
+/// this feeds.
+fn request_overhead(
+	method: &str,
+	path: &str,
+	query: &str,
+	fwd: &[(String, String)],
+	authorization: &str,
+) -> u64 {
+	let query_len = if query.is_empty() { 0 } else { 1 + query.len() };
+	let line = method.len() + 1 + path.len() + query_len + " HTTP/1.1\r\n".len();
+	let headers: usize = fwd.iter().map(|(n, v)| n.len() + 2 + v.len() + 2).sum();
+	let auth = "authorization".len() + 2 + authorization.len() + 2;
+	(line + headers + auth + 2) as u64
+}
+
+/// Rough wire size of the response status line + headers.
+fn response_overhead(status: StatusCode, headers: &HeaderMap) -> u64 {
+	let reason = status.canonical_reason().map_or(0, str::len);
+	let line = "HTTP/1.1 ".len() + 3 + 1 + reason + 2;
+	let headers: usize = headers
+		.iter()
+		.map(|(n, v)| n.as_str().len() + 2 + v.as_bytes().len() + 2)
+		.sum();
+	(line + headers + 2) as u64
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn header_u64_parses_or_zeroes() {
+		let mut headers = HeaderMap::new();
+		headers.insert("content-length", HeaderValue::from_static("1234"));
+		assert_eq!(header_u64(&headers, "content-length"), 1234);
+		assert_eq!(header_u64(&headers, "x-amz-decoded-content-length"), 0);
+	}
+
+	#[test]
+	fn request_overhead_sums_line_headers_and_auth() {
+		// "GET /p HTTP/1.1\r\n" (17) + "host: h\r\n" (9) + "authorization: a\r\n"
+		// (18) + trailing "\r\n" (2) = 46.
+		let fwd = vec![("host".to_string(), "h".to_string())];
+		assert_eq!(request_overhead("GET", "/p", "", &fwd, "a"), 46);
+	}
+
+	#[test]
+	fn request_overhead_includes_query() {
+		let fwd = vec![];
+		// "GET /p?x=1 HTTP/1.1\r\n" (21) + "authorization: a\r\n" (18) + "\r\n" (2).
+		assert_eq!(request_overhead("GET", "/p", "x=1", &fwd, "a"), 41);
+	}
+
+	#[test]
+	fn response_overhead_sums_status_line_and_headers() {
+		let mut headers = HeaderMap::new();
+		headers.insert("content-type", HeaderValue::from_static("text/plain"));
+		// "HTTP/1.1 200 OK\r\n" (17) + "content-type: text/plain\r\n" (26) + "\r\n" (2).
+		assert_eq!(response_overhead(StatusCode::OK, &headers), 45);
 	}
 }


### PR DESCRIPTION
🤖 Since the re-signing proxy already sees every request kopia makes, tally the bytes through it: a rough measure of the S3 / network traffic a backup (or restore) run is accountable for.

Each request adds to a shared `Traffic` (atomics), split two ways:
- **raw** — the full HTTP message: request/status line, headers, and the body as it goes on the wire, *including* the SigV4 chunk framing kopia adds to streaming uploads.
- **payload** — only the object data (the decoded body): `x-amz-decoded-content-length` for streaming uploads, the body otherwise; response bodies for downloads.

`raw − payload` is protocol overhead (headers + chunk signatures). Header/line sizes are estimated from the headers we forward (it doesn't model TLS framing — fine for the per-deployment accounting this feeds).

Surfaced three ways:
- `RunningProxy::traffic() -> TrafficStats`.
- logged per backup run (`s3 traffic for this run`).
- reported to canopy on the backup report as `s3_{sent,received}_{raw,payload}_bytes` (on both success and failure, since bytes flow either way). They're optional/omitted-when-absent, and canopy ignores fields it doesn't know yet, so bestool can send them ahead of canopy storing them.

**Gating:** the live canopy-contract check is intentionally **red** — the contract test's report instance carries the new fields, so it fails spec validation until canopy's OpenAPI defines `s3_*_bytes`. Once canopy ships that, it goes green and this can merge.
