### PR TITLE
fix(canopy): never let the pre-snapshot CHECKPOINT prompt for a password

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -305,7 +305,11 @@ async fn run_checked(mut cmd: tokio::process::Command, what: &str) -> Result<()>
 /// Best-effort `CHECKPOINT` as the postgres superuser over the local socket.
 async fn checkpoint(config: &PostgresqlConfig, data_dir: &Path) {
 	let mut cmd = pg_command(&postgres_bin("psql", data_dir));
-	cmd.args(["-X", "-q"]);
+	// -w: never prompt for a password. libpq reads a password prompt straight from
+	// the terminal, not stdin, so null stdin alone doesn't stop it — without -w a
+	// connection that needs a password (e.g. as the OS user on Windows) blocks the
+	// service forever. With -w it fails fast instead, and CHECKPOINT is best-effort.
+	cmd.args(["-X", "-q", "-w"]);
 	if let Some(socket) = &config.socket {
 		cmd.arg("-h").arg(socket);
 	}


### PR DESCRIPTION
🤖 On Windows the canopy postgres backup hung forever in `prepare`, right after:

```
INFO ...postgresql: preparing postgresql backup cluster=main version=18 strategy=Vss ...
Password for user Administrator:
```

The pre-snapshot `CHECKPOINT` shells out to `psql`, which on Windows connects as the OS user (`Administrator`); with no password configured, libpq prompts for one. The prompt is read **from the terminal, not stdin**, so the `stdin(null)` already in place didn't stop it — and in the alertd service (no console) it blocks the whole backup run indefinitely.

Pass `psql -w` (`--no-password`) so it fails fast instead of prompting. `CHECKPOINT` is already best-effort — the VSS/snapshot is crash-consistent regardless; a skipped checkpoint just means recovery may replay a little more WAL — so it logs a warning and the backup proceeds. (`pg_basebackup` already passes `--no-password`.)

Verified compiling for `x86_64-pc-windows-gnu`.
