### PR TITLE
fix(tamanu): resolve pm2 CLI via Windows-aware finder for lifecycle commands

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -409,7 +409,7 @@ pub async fn stop_targets(supervisor: Supervisor, targets: &[String]) -> Result<
 	match supervisor {
 		Supervisor::Systemd => systemd::stop(targets).await,
 		Supervisor::Pm2 => {
-			let status = Command::new("pm2")
+			let status = pm2::command()
 				.arg("stop")
 				.args(targets)
 				.status()
@@ -436,7 +436,7 @@ pub async fn start_targets(supervisor: Supervisor, targets: &[String]) -> Result
 	match supervisor {
 		Supervisor::Systemd => systemd::start(targets).await,
 		Supervisor::Pm2 => {
-			let status = Command::new("pm2")
+			let status = pm2::command()
 				.arg("start")
 				.args(targets)
 				.status()
@@ -464,7 +464,7 @@ pub fn pm2_restart_targets(targets: &[String]) -> Result<()> {
 	if targets.is_empty() {
 		return Ok(());
 	}
-	let stop = Command::new("pm2")
+	let stop = pm2::command()
 		.arg("stop")
 		.args(targets)
 		.status()
@@ -473,7 +473,7 @@ pub fn pm2_restart_targets(targets: &[String]) -> Result<()> {
 		bail!("pm2 stop failed: exit {stop}");
 	}
 	std::thread::sleep(Duration::from_secs(1));
-	let start = Command::new("pm2")
+	let start = pm2::command()
 		.arg("start")
 		.args(targets)
 		.status()
@@ -497,7 +497,7 @@ pub fn delete_pm2(names: &[String]) -> Result<()> {
 	if names.is_empty() {
 		return Ok(());
 	}
-	let status = Command::new("pm2")
+	let status = pm2::command()
 		.arg("delete")
 		.args(names)
 		.status()
@@ -757,7 +757,7 @@ pub fn container_ip_for_unit(unit: &str) -> Result<Option<std::net::IpAddr>> {
 /// `PORT` env var. Returns None if pm2 doesn't expose one — e.g.
 /// workers that don't open a socket.
 pub fn pm2_port_for(pm_id: i64) -> Result<Option<u16>> {
-	let output = Command::new("pm2").arg("jlist").output().into_diagnostic()?;
+	let output = pm2::command().arg("jlist").output().into_diagnostic()?;
 	if !output.status.success() {
 		bail!(
 			"pm2 jlist failed: {}",

--- a/crates/bestool/src/actions/tamanu/start.rs
+++ b/crates/bestool/src/actions/tamanu/start.rs
@@ -9,6 +9,7 @@ use miette::{Result, WrapErr, bail};
 use tracing::{debug, info, warn};
 
 use bestool_tamanu::{
+	pm2,
 	services::{self, ExpectedState, Expectation, Supervisor},
 	systemd,
 };
@@ -262,7 +263,7 @@ fn spawn_log_follower(supervisor: Supervisor, targets: &[String]) -> Option<LogF
 					deduped.push(t);
 				}
 			}
-			let mut cmd = Command::new("pm2");
+			let mut cmd = Command::new(pm2::program());
 			cmd.args(["logs", "--lines", "0"]);
 			cmd.args(deduped);
 			cmd

--- a/crates/bestool/src/actions/tamanu/sync.rs
+++ b/crates/bestool/src/actions/tamanu/sync.rs
@@ -309,7 +309,7 @@ fn spawn_log_child(
 			c
 		}
 		Supervisor::Pm2 => {
-			let mut c = Command::new("pm2");
+			let mut c = Command::new(bestool_tamanu::pm2::program());
 			c.arg("logs")
 				.arg(service)
 				.arg("--lines")

--- a/crates/tamanu/src/pm2.rs
+++ b/crates/tamanu/src/pm2.rs
@@ -95,20 +95,13 @@ pub fn find_command() -> Option<PathBuf> {
 	candidate_install_paths().into_iter().find(|c| probe(c))
 }
 
-/// Resolve the pm2 CLI executable path via [`find_command`] (which handles
-/// Windows PATHEXT — `Command::new("pm2")` doesn't expand it, so a bare `pm2`
-/// is "program not found" on Windows even when `pm2.cmd` is on PATH — and
-/// common npm-global install dirs). Falls back to a bare `pm2` when discovery
-/// finds nothing: on Linux that's the PATH-resolved binary.
-///
-/// Use this for both `std::process::Command` and `tokio::process::Command`:
-/// `Command::new(pm2::program())`.
+/// Resolve the pm2 CLI path. On Windows `Command::new("pm2")` doesn't apply
+/// PATHEXT, so a bare `pm2` is "program not found" even when `pm2.cmd` is on
+/// PATH; `find_command` handles that. Falls back to bare `pm2` (Linux PATH).
 pub fn program() -> PathBuf {
 	find_command().unwrap_or_else(|| PathBuf::from("pm2"))
 }
 
-/// Build a [`std::process::Command`] for the pm2 CLI with the executable
-/// resolved by [`program`].
 pub fn command() -> Command {
 	Command::new(program())
 }
@@ -504,10 +497,7 @@ mod tests {
 
 	#[test]
 	fn program_falls_back_to_bare_pm2_when_undiscovered() {
-		// On a host with no pm2 install and no override, `program()` must still
-		// hand back a runnable name rather than panicking — the bare `pm2` PATH
-		// lookup. (On Windows this is what `find_command` exists to replace, but
-		// the fallback path itself must hold.)
+		// No pm2 installed + no override: program() must still return a runnable name.
 		if find_command().is_none() {
 			assert_eq!(program(), PathBuf::from("pm2"));
 		}

--- a/crates/tamanu/src/pm2.rs
+++ b/crates/tamanu/src/pm2.rs
@@ -95,6 +95,24 @@ pub fn find_command() -> Option<PathBuf> {
 	candidate_install_paths().into_iter().find(|c| probe(c))
 }
 
+/// Resolve the pm2 CLI executable path via [`find_command`] (which handles
+/// Windows PATHEXT — `Command::new("pm2")` doesn't expand it, so a bare `pm2`
+/// is "program not found" on Windows even when `pm2.cmd` is on PATH — and
+/// common npm-global install dirs). Falls back to a bare `pm2` when discovery
+/// finds nothing: on Linux that's the PATH-resolved binary.
+///
+/// Use this for both `std::process::Command` and `tokio::process::Command`:
+/// `Command::new(pm2::program())`.
+pub fn program() -> PathBuf {
+	find_command().unwrap_or_else(|| PathBuf::from("pm2"))
+}
+
+/// Build a [`std::process::Command`] for the pm2 CLI with the executable
+/// resolved by [`program`].
+pub fn command() -> Command {
+	Command::new(program())
+}
+
 fn probe(path: &Path) -> bool {
 	Command::new(path)
 		.arg("--version")
@@ -482,6 +500,17 @@ mod tests {
 		let procs = list_via_dump_at(tmp.path()).unwrap();
 		assert_eq!(procs.len(), 1);
 		assert!(!procs[0].running);
+	}
+
+	#[test]
+	fn program_falls_back_to_bare_pm2_when_undiscovered() {
+		// On a host with no pm2 install and no override, `program()` must still
+		// hand back a runnable name rather than panicking — the bare `pm2` PATH
+		// lookup. (On Windows this is what `find_command` exists to replace, but
+		// the fallback path itself must hold.)
+		if find_command().is_none() {
+			assert_eq!(program(), PathBuf::from("pm2"));
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
## Problem

On Windows, `bestool tamanu restart` fails:

```
INFO ... bulk-restarting non-rolling services targets=["tamanu-tasks", "tamanu-fhir-resolve", "tamanu-fhir-refresh"]
Error:   x program not found
```

The lifecycle commands (`restart`, `start`, `stop`, log followers) spawned pm2 with a bare `Command::new("pm2")`. `Command::new` on Windows doesn't apply `PATHEXT`, so `pm2` (really `pm2.cmd`) resolves to nothing — "program not found".

`pm2.rs` already has a Windows-aware `find_command()` (tries `pm2.cmd`/`pm2.bat` and common npm-global install dirs), but only its own `jlist` discovery used it.

## Fix

Add `pm2::program()` / `pm2::command()` wrapping `find_command()` (falling back to a bare `pm2` on Linux), and route every pm2 spawn in `lifecycle.rs`, `start.rs`, and `sync.rs` through it.

## Notes

`cargo` wasn't available in my environment, so clippy/fmt/tests were not run locally — please rely on CI.