### PR TITLE
feat(canopy): connection_url for postgres client commands

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -64,10 +64,20 @@ pub struct PostgresqlConfig {
 	/// Override the resolved major version.
 	#[serde(default)]
 	pub version: Option<String>,
-	/// Override the port used to connect for `CHECKPOINT`.
+	/// libpq connection URI / conninfo for the client commands (`CHECKPOINT`,
+	/// `pg_basebackup`, restore verification). Takes precedence over `socket` /
+	/// `port` and carries the role and credentials — needed where peer auth isn't
+	/// available (e.g. Windows, which has no `sudo -u postgres`). May embed a
+	/// password (then visible in the process's argv); a passwordless URI plus a
+	/// pgpass file / `PGPASSWORD` avoids that.
+	#[serde(default)]
+	pub connection_url: Option<String>,
+	/// Override the port used to connect for `CHECKPOINT` (ignored when
+	/// `connection_url` is set).
 	#[serde(default)]
 	pub port: Option<u16>,
-	/// Override the unix socket directory used to connect.
+	/// Override the unix socket directory used to connect (ignored when
+	/// `connection_url` is set).
 	#[serde(default)]
 	pub socket: Option<PathBuf>,
 	/// Force a snapshot strategy instead of auto-detecting (for testing).

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -137,8 +137,7 @@ async fn basebackup_prepared(
 	backup_type: &str,
 	config: &PostgresqlConfig,
 ) -> Result<Prepared> {
-	let (path, root) =
-		basebackup::prepare(resolved, backup_type, config.socket.as_deref(), config.port).await?;
+	let (path, root) = basebackup::prepare(resolved, backup_type, config).await?;
 	Ok(Prepared {
 		path,
 		// Tagged as basebackup even on fallback — it reflects what actually ran.
@@ -214,10 +213,9 @@ async fn pg_resetwal(data_dir: &Path) -> Result<()> {
 
 async fn verify(config: &PostgresqlConfig, data_dir: &Path) {
 	let mut cmd = pg_command(&postgres_bin("psql", data_dir));
-	cmd.args(["-X", "-q", "-tAc", "SELECT 1"]);
-	if let Some(port) = config.port {
-		cmd.arg("-p").arg(port.to_string());
-	}
+	// -w as in `checkpoint`: never block on a terminal password prompt.
+	cmd.args(["-X", "-q", "-w", "-tAc", "SELECT 1"]);
+	apply_connection(&mut cmd, config);
 	cmd.stdin(std::process::Stdio::null());
 	match cmd.status().await {
 		Ok(s) if s.success() => info!("restored cluster accepts connections"),
@@ -288,6 +286,23 @@ pub(super) fn pg_command(bin: &str) -> tokio::process::Command {
 	}
 }
 
+/// Apply connection params to a libpq client command (`psql`, `pg_basebackup`).
+/// A configured `connection_url` (libpq URI / conninfo) carries the role, host
+/// and credentials and takes over; otherwise fall back to the `socket` / `port`
+/// flags and libpq's defaults for the rest.
+pub(super) fn apply_connection(cmd: &mut tokio::process::Command, config: &PostgresqlConfig) {
+	if let Some(url) = &config.connection_url {
+		cmd.arg("-d").arg(url);
+		return;
+	}
+	if let Some(socket) = &config.socket {
+		cmd.arg("-h").arg(socket);
+	}
+	if let Some(port) = config.port {
+		cmd.arg("-p").arg(port.to_string());
+	}
+}
+
 /// Run a prepared command, erroring on non-zero exit.
 async fn run_checked(mut cmd: tokio::process::Command, what: &str) -> Result<()> {
 	let status = cmd
@@ -310,12 +325,7 @@ async fn checkpoint(config: &PostgresqlConfig, data_dir: &Path) {
 	// connection that needs a password (e.g. as the OS user on Windows) blocks the
 	// service forever. With -w it fails fast instead, and CHECKPOINT is best-effort.
 	cmd.args(["-X", "-q", "-w"]);
-	if let Some(socket) = &config.socket {
-		cmd.arg("-h").arg(socket);
-	}
-	if let Some(port) = config.port {
-		cmd.arg("-p").arg(port.to_string());
-	}
+	apply_connection(&mut cmd, config);
 	cmd.args(["-c", "CHECKPOINT;"]);
 	cmd.stdin(std::process::Stdio::null());
 
@@ -354,6 +364,42 @@ mod tests {
 				"{required} must never be ignored"
 			);
 		}
+	}
+
+	fn pg_config(connection_url: Option<&str>, socket: Option<&str>, port: Option<u16>) -> PostgresqlConfig {
+		PostgresqlConfig {
+			cluster: "main".into(),
+			data_dir: None,
+			version: None,
+			connection_url: connection_url.map(str::to_owned),
+			port,
+			socket: socket.map(PathBuf::from),
+			strategy: None,
+		}
+	}
+
+	#[test]
+	fn apply_connection_prefers_the_url() {
+		let mut cmd = tokio::process::Command::new("psql");
+		apply_connection(&mut cmd, &pg_config(Some("postgresql://u:p@h/db"), Some("/run/pg"), Some(5433)));
+		let args: Vec<_> = cmd
+			.as_std()
+			.get_args()
+			.map(|a| a.to_string_lossy().into_owned())
+			.collect();
+		assert_eq!(args, vec!["-d", "postgresql://u:p@h/db"]);
+	}
+
+	#[test]
+	fn apply_connection_falls_back_to_socket_and_port() {
+		let mut cmd = tokio::process::Command::new("psql");
+		apply_connection(&mut cmd, &pg_config(None, Some("/run/pg"), Some(5433)));
+		let args: Vec<_> = cmd
+			.as_std()
+			.get_args()
+			.map(|a| a.to_string_lossy().into_owned())
+			.collect();
+		assert_eq!(args, vec!["-h", "/run/pg", "-p", "5433"]);
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
@@ -17,7 +17,7 @@ use std::{
 use miette::{Context as _, IntoDiagnostic as _, Result, bail};
 use tracing::info;
 
-use super::resolve::ResolvedCluster;
+use super::{super::method::PostgresqlConfig, resolve::ResolvedCluster};
 
 /// Where this run's base backup is streamed to (and what kopia snapshots). Nests
 /// `<version>/<cluster>` under the stable source dir so the kopia source path
@@ -30,31 +30,23 @@ fn destination(backup_type: &str, resolved: &ResolvedCluster) -> PathBuf {
 }
 
 /// `pg_basebackup` args for a plain (uncompressed) base backup with streamed WAL.
-fn basebackup_args(dest: &Path, socket: Option<&Path>, port: Option<u16>) -> Vec<String> {
-	let mut args = vec![
+/// Connection params (`connection_url` or socket/port) are applied separately by
+/// [`super::apply_connection`]. `--no-password` keeps it from ever prompting.
+fn basebackup_args(dest: &Path) -> Vec<String> {
+	vec![
 		"-D".to_owned(),
 		dest.to_string_lossy().into_owned(),
 		"--wal-method=stream".to_owned(),
 		"--checkpoint=fast".to_owned(),
 		"--no-password".to_owned(),
-	];
-	if let Some(socket) = socket {
-		args.push("-h".to_owned());
-		args.push(socket.to_string_lossy().into_owned());
-	}
-	if let Some(port) = port {
-		args.push("-p".to_owned());
-		args.push(port.to_string());
-	}
-	args
+	]
 }
 
 /// Stream a base backup and return (kopia source path, the dir to clean up).
 pub async fn prepare(
 	resolved: &ResolvedCluster,
 	backup_type: &str,
-	socket: Option<&Path>,
-	port: Option<u16>,
+	config: &PostgresqlConfig,
 ) -> Result<(PathBuf, PathBuf)> {
 	let root = super::stable_source_dir(backup_type);
 	let dest = destination(backup_type, resolved);
@@ -77,7 +69,8 @@ pub async fn prepare(
 
 	info!(dest = %dest.display(), "streaming pg_basebackup");
 	let mut cmd = super::pg_command(&super::postgres_bin("pg_basebackup", &resolved.data_dir));
-	cmd.args(basebackup_args(&dest, socket, port));
+	cmd.args(basebackup_args(&dest));
+	super::apply_connection(&mut cmd, config);
 	cmd.stdin(Stdio::null());
 	let status = cmd
 		.status()
@@ -185,7 +178,9 @@ mod tests {
 
 	#[test]
 	fn basebackup_args_stream_wal_and_fast_checkpoint() {
-		let args = basebackup_args(Path::new("/staging/16/main"), None, None);
+		// Connection params are applied separately (see `apply_connection`); these
+		// are just the fixed base-backup flags.
+		let args = basebackup_args(Path::new("/staging/16/main"));
 		assert_eq!(
 			args,
 			vec![
@@ -196,16 +191,5 @@ mod tests {
 				"--no-password",
 			]
 		);
-	}
-
-	#[test]
-	fn basebackup_args_include_socket_and_port() {
-		let args = basebackup_args(
-			Path::new("/staging/16/main"),
-			Some(Path::new("/var/run/postgresql")),
-			Some(5433),
-		);
-		assert!(args.windows(2).any(|w| w == ["-h", "/var/run/postgresql"]));
-		assert!(args.windows(2).any(|w| w == ["-p", "5433"]));
 	}
 }

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -187,6 +187,7 @@ mod tests {
 			cluster: cluster.to_owned(),
 			data_dir,
 			version: version.map(str::to_owned),
+			connection_url: None,
 			port: None,
 			socket: None,
 			strategy: None,


### PR DESCRIPTION
🤖 Follow-up to #587 (which only stops the *hang*). This makes the postgres backup actually authenticate on Windows.

On Linux bestool sidesteps auth with `sudo -u postgres` (peer auth as the superuser). Windows has no equivalent, and local auth is password (md5/scram), so the client commands (`CHECKPOINT`, `pg_basebackup`, restore-verify) had no credentials and fell back to a terminal password prompt.

Add an optional **`connection_url`** (libpq URI / conninfo) to `[postgresql]`:

```toml
[postgresql]
cluster = "main"
connection_url = "postgresql://backup:secret@localhost:5432/postgres"
```

When set it carries the role, host and credentials, and is applied to every libpq client command via a shared `apply_connection` helper, taking precedence over `socket`/`port`. A passwordless URI plus a pgpass file / `PGPASSWORD` avoids putting the secret in argv. Use a role with `pg_checkpoint` (PG15+) or superuser for the CHECKPOINT.

Also adds `-w` to the restore-verify psql — the one client command still missing the no-prompt guard from #587.

Verified compiling + tests for `x86_64-pc-windows-gnu`. Stacked on #587.
