### PR TITLE
feat(doctor): send each check's summary and reason to canopy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,6 @@
 - When changing Windows-specific code, run `cargo check` with a Windows GNU target (unless currently running on Windows).
 - Releases are automated via release-plz: pushing to `main` opens a `repo: release` PR which auto-merges and publishes to crates.io. No manual release step is needed.
 - It's very important for alertd that postgres (or anything else we're checking) IS NOT REQUIRED for the alertd daemon to start, because otherwise we CANNOT ALERT ON THE DATABASE BEING DOWN.
+- The alertd daemon is run using the exact unit file in services/bestool-alertd.service.
 - When writing or changing specs in `.workhorse/specs/`, follow the spec rules in [.workhorse/rules.md](.workhorse/rules.md).
 <!-- end rules -->

--- a/crates/alertd/src/doctor/check.rs
+++ b/crates/alertd/src/doctor/check.rs
@@ -44,6 +44,17 @@ impl CheckStatus {
 	pub fn is_skip(&self) -> bool {
 		matches!(self, CheckStatus::Skip(_))
 	}
+
+	/// The explanatory reason carried by every non-pass status, if any.
+	pub fn reason(&self) -> Option<&str> {
+		match self {
+			CheckStatus::Pass => None,
+			CheckStatus::Skip(r)
+			| CheckStatus::Warning(r)
+			| CheckStatus::Fail(r)
+			| CheckStatus::Broken(r) => Some(r),
+		}
+	}
 }
 
 /// Result of one healthcheck.
@@ -154,6 +165,13 @@ impl Check {
 		obj.insert("result".into(), self.status.wire_result().into());
 		for (k, v) in &self.details {
 			obj.insert(k.clone(), v.clone());
+		}
+		// Carry the human summary and (for non-pass) the reason so an operator can
+		// see *why* a check warned/failed from canopy, without shelling into the
+		// box. Inserted after the details so the reserved keys always win.
+		obj.insert("summary".into(), self.summary.clone().into());
+		if let Some(reason) = self.status.reason() {
+			obj.insert("reason".into(), reason.into());
 		}
 		Value::Object(obj)
 	}
@@ -329,18 +347,27 @@ mod tests {
 		assert_eq!(v["check"], "db_connect");
 		assert_eq!(v["result"], "passed");
 		assert_eq!(v["latency_ms"], 3);
+		assert_eq!(v["summary"], "ok");
+		// A pass carries no reason.
+		assert!(v.get("reason").is_none());
 	}
 
 	#[test]
 	fn check_to_wire_statuses() {
 		let warn = Check::warning("disk_free", "20% used", "below threshold");
-		assert_eq!(warn.to_wire()["result"], "warning");
+		let v = warn.to_wire();
+		assert_eq!(v["result"], "warning");
+		// The reason and summary travel to canopy so the *why* is visible off-box.
+		assert_eq!(v["summary"], "20% used");
+		assert_eq!(v["reason"], "below threshold");
 		let fail = Check::fail("disk_free", "1% free", "out of space");
 		assert_eq!(fail.to_wire()["result"], "failed");
+		assert_eq!(fail.to_wire()["reason"], "out of space");
 		let broken = Check::broken("x", "query broken", "no such column");
 		assert_eq!(broken.to_wire()["result"], "broken");
 		let skip = Check::skip("x", "n/a", "central-only");
 		assert_eq!(skip.to_wire()["result"], "skipped");
+		assert_eq!(skip.to_wire()["reason"], "central-only");
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 The canopy-bound per-check payload (`Check::to_wire`) carried only `result` plus the flattened `details`, and deliberately dropped the `summary` and `reason`. So a warning/failure was impossible to interpret without shelling into the box — e.g. `version_drift` sent only:

```json
{ "check": "version_drift", "result": "warning", "supervisor": "systemd" }
```

…with no hint that the real reason was `podman ps failed: … newuidmap …`.

Include the `summary` and (for any non-pass status) the `reason` in `to_wire()`, so the *why* travels to canopy with every check:

```json
{ "check": "version_drift", "result": "warning", "supervisor": "systemd",
  "summary": "could not read running container versions",
  "reason": "`podman ps` failed, so version drift can't be checked: …" }
```

`details` already flatten arbitrary keys into the entry, so canopy's health-entry schema already accepts extra properties — these two are safe to add. Applies to all checks, not just version_drift.
