### PR TITLE
feat(alertd): add fhir_config check for FHIR/worker toggle consistency

### DIFF
--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -23,6 +23,7 @@ pub mod db_connect;
 pub mod db_version;
 pub mod disk_free;
 pub mod external_users;
+pub mod fhir_config;
 pub mod fhir_job_errors;
 pub mod fhir_jobs;
 pub mod fhir_service_requests_unresolved;
@@ -281,6 +282,8 @@ pub fn all() -> Vec<CheckEntry> {
 		entry!("version_drift", version_drift),
 		entry!("external_users", external_users, host),
 		entry!("sync_sessions", sync_sessions),
+		// Config-derived: the FHIR API and worker toggles must agree.
+		entry!("fhir_config", fhir_config),
 		entry!("fhir_jobs", fhir_jobs),
 		entry!("kopia_backup", kopia_backup, host),
 		entry!(

--- a/crates/alertd/src/doctor/checks/fhir_config.rs
+++ b/crates/alertd/src/doctor/checks/fhir_config.rs
@@ -1,0 +1,77 @@
+//! FHIR integration / worker consistency.
+//!
+//! Tamanu's FHIR support has two independent toggles: `integrations.fhir.enabled`
+//! gates whether materialisation jobs are queued, and
+//! `integrations.fhir.worker.enabled` runs the worker that consumes that queue.
+//! They're meant to move together.
+//!
+//! With the API enabled but the worker off, jobs are queued with nothing to
+//! consume them and the queue grows unbounded — a real fault, so we fail. The
+//! inverse (worker on, API off) means the worker has no jobs to do but still
+//! holds DB connections and server memory; wasteful but not harmful, so it only
+//! warns. Both on or both off is consistent and passes.
+
+use super::CheckContext;
+use crate::doctor::check::Check;
+
+const NAME: &str = "fhir_config";
+
+pub async fn run(ctx: CheckContext) -> Check {
+	if !ctx.has_install {
+		return Check::skip(
+			NAME,
+			"no Tamanu config on this host",
+			"the FHIR toggles live in the install's config, and this context was built from a database URL alone",
+		);
+	}
+	evaluate(ctx.config.fhir_enabled(), ctx.config.fhir_worker_enabled())
+}
+
+fn evaluate(fhir_enabled: bool, worker_enabled: bool) -> Check {
+	let check = match (fhir_enabled, worker_enabled) {
+		(true, false) => Check::fail(
+			NAME,
+			"FHIR enabled but its worker is off",
+			"integrations.fhir.enabled is true while integrations.fhir.worker.enabled is false: materialisation jobs are queued with no worker to consume them, so the queue grows unbounded",
+		),
+		(false, true) => Check::warning(
+			NAME,
+			"FHIR worker on but FHIR is off",
+			"integrations.fhir.worker.enabled is true while integrations.fhir.enabled is false: the worker has no jobs to do but still holds DB connections and server memory",
+		),
+		(true, true) => Check::pass(NAME, "FHIR and its worker both enabled"),
+		(false, false) => Check::pass(NAME, "FHIR and its worker both disabled"),
+	};
+	check
+		.with_detail("fhir_enabled", fhir_enabled)
+		.with_detail("worker_enabled", worker_enabled)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::doctor::check::CheckStatus;
+
+	#[test]
+	fn fhir_on_worker_off_fails() {
+		assert!(matches!(evaluate(true, false).status, CheckStatus::Fail(_)));
+	}
+
+	#[test]
+	fn fhir_off_worker_on_warns() {
+		assert!(matches!(
+			evaluate(false, true).status,
+			CheckStatus::Warning(_)
+		));
+	}
+
+	#[test]
+	fn both_on_passes() {
+		assert!(matches!(evaluate(true, true).status, CheckStatus::Pass));
+	}
+
+	#[test]
+	fn both_off_passes() {
+		assert!(matches!(evaluate(false, false).status, CheckStatus::Pass));
+	}
+}

--- a/crates/tamanu/src/config/structure.rs
+++ b/crates/tamanu/src/config/structure.rs
@@ -77,6 +77,10 @@ impl TamanuConfig {
 			.or(self.country_time_zone.as_deref())
 	}
 
+	pub fn fhir_enabled(&self) -> bool {
+		self.integrations.fhir.enabled
+	}
+
 	pub fn fhir_worker_enabled(&self) -> bool {
 		self.integrations.fhir.worker.enabled
 	}
@@ -210,6 +214,7 @@ impl SyncApiConnection {
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Fhir {
+	pub enabled: bool,
 	pub worker: FhirWorker,
 }
 
@@ -376,6 +381,25 @@ mod tests {
 	#[test]
 	fn fhir_worker_disabled_when_integrations_missing() {
 		assert!(!parse(base()).fhir_worker_enabled());
+	}
+
+	#[test]
+	fn fhir_enabled_reads_integrations_path() {
+		let mut json = base();
+		json["integrations"] = serde_json::json!({ "fhir": { "enabled": true } });
+		assert!(parse(json).fhir_enabled());
+	}
+
+	#[test]
+	fn fhir_disabled_when_integrations_says_false() {
+		let mut json = base();
+		json["integrations"] = serde_json::json!({ "fhir": { "enabled": false } });
+		assert!(!parse(json).fhir_enabled());
+	}
+
+	#[test]
+	fn fhir_disabled_when_integrations_missing() {
+		assert!(!parse(base()).fhir_enabled());
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Tamanu's FHIR support has two independent toggles that are meant to move together: `integrations.fhir.enabled` gates whether materialisation jobs are queued, and `integrations.fhir.worker.enabled` runs the worker that consumes that queue. A new doctor check, `fhir_config`, flags when they disagree:

- **fail** — API enabled, worker off: materialisation jobs are queued with no worker to consume them, so the queue grows unbounded.
- **warning** — worker on, API off: the worker has no jobs to do but still holds DB connections and server memory.
- **pass** — both on, or both off.
- **skip** — no Tamanu install on this host (context built from a database URL alone, so there's no config to read).

The `integrations.fhir.enabled` field wasn't modelled in the config struct yet, so this adds it (with a serde default of `false`, matching the worker toggle) plus a `fhir_enabled()` accessor alongside the existing `fhir_worker_enabled()`.
