### PR TITLE
feat(alertd): self-update the bestool binary on Windows

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -79,7 +79,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.81.8
         with:
-          tool: cargo-zigbuild,cargo-auditable
+          tool: cargo-zigbuild,cargo-auditable,rsign2
 
       # zigbuild isn't compatible with auditable
       # https://github.com/rust-secure-code/cargo-auditable/issues/179
@@ -210,6 +210,27 @@ jobs:
           fi
           tar -C "$src_dir" -cf - "$name" | zstd -19 -f -o "$src_dir/$name.tar.zst"
 
+      # Sign the compressed artifact (what binstall downloads and what
+      # self-update verifies). The detached signature is published alongside it
+      # as <artifact>.minisig. Assumes SIGNING_KEY is an unencrypted minisign
+      # secret key (the -W automation path); a password-protected key would need
+      # its password supplied here instead.
+      - name: Sign release artifact
+        shell: bash
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        run: |
+          src_dir="target/${{ matrix.target }}/dist"
+          name="bestool"
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            name="bestool.exe"
+          fi
+          printf '%s\n' "$SIGNING_KEY" > signing.key
+          rsign sign -W -s signing.key \
+            -x "$src_dir/$name.tar.zst.minisig" \
+            "$src_dir/$name.tar.zst"
+          rm -f signing.key
+
       - uses: actions/upload-artifact@v7
         with:
           name: bestool-${{ matrix.target }}-${{ github.sha }}
@@ -240,6 +261,7 @@ jobs:
           fi
           aws s3 cp "$src" "$dest" --no-progress
           aws s3 cp "$src.tar.zst" "$dest" --no-progress
+          aws s3 cp "$src.tar.zst.minisig" "$dest" --no-progress
 
           for deb in bestool-*.deb; do
             [[ -f "$deb" ]] || continue
@@ -258,6 +280,7 @@ jobs:
           fi
           aws s3 cp "$src" "$dest" --no-progress
           aws s3 cp "$src.tar.zst" "$dest" --no-progress
+          aws s3 cp "$src.tar.zst.minisig" "$dest" --no-progress
 
           aws cloudfront create-invalidation --distribution-id=EDAG0UBS1MN74 --paths '/bestool/latest/*'
 

--- a/.workhorse/specs/bestool/self-update.md
+++ b/.workhorse/specs/bestool/self-update.md
@@ -1,0 +1,50 @@
+---
+id: UPD
+---
+
+# Self-update
+
+`bestool self-update` replaces the running bestool binary in place with the latest published release.
+On Windows the alert daemon also keeps the binary current on its own, so a host running the service stays up to date without anyone invoking the command.
+
+## Published artifacts
+
+Each release publishes, per target, a downloadable release artifact carrying the bestool binary, alongside a single file naming the latest released version.
+A detached signature sits next to each artifact, at the artifact's URL with a `.minisig` suffix.
+
+## Signature verification
+
+Every released artifact is signed with a private key held only by the release pipeline.
+bestool embeds the corresponding public key as a trust anchor.
+Before installing — whether the update is invoked manually or performed by the daemon — bestool fetches the detached signature for the downloaded artifact and verifies the artifact against the embedded public key, and only then unpacks and swaps in the binary it contains.
+An artifact whose signature is missing or does not verify is never installed; the update fails instead.
+
+The same public key is recorded in the binstall metadata, and the signature covers the same artifact binstall downloads, so `cargo binstall` verifies it on its installs too.
+
+## Manual update
+
+`bestool self-update` resolves the latest published version, and unless a specific version or a forced reinstall is requested, does nothing when already on that version.
+Otherwise it downloads the target artifact, verifies its signature, and replaces the running binary.
+
+On a package-managed install (the Linux deb) the command refuses to act unless forced, directing the operator to the package manager.
+
+## Delegation to the running daemon
+
+On Windows, when the alert service is running, `bestool self-update` asks the daemon to perform the update rather than swapping the binary itself.
+The daemon owns the download, verification, binary replacement, and service restart in one place.
+When the service is not running, the command updates the binary directly.
+
+The daemon exposes this through an endpoint that reports whether an update is warranted — and to which version — then carries out the download, install, and restart.
+Because the restart drops the connection, the reply is the decision, not a live progress stream.
+The command reaches the daemon over whichever loopback address answers, since the daemon binds only the first it can.
+
+## Automatic update by the daemon
+
+The Windows alert daemon checks once a day whether a newer version has been published, at a time staggered across hosts so a fleet neither fetches nor restarts in lockstep.
+When a strictly newer version is available it downloads and verifies it, replaces its own binary, and restarts the service so the new binary takes effect.
+
+The daemon does not repeatedly attempt a version that has already failed to install.
+Checking and updating never block or stop the daemon's other duties: a failed update is logged and retried on a later check, and the daemon keeps running the current binary in the meantime.
+
+This behaviour is Windows-only.
+On Linux the binary is kept current by the package manager, and the hardened service deployment cannot write its own binary in any case.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,8 @@ dependencies = [
  "merkle_hash",
  "miette",
  "mimalloc",
+ "minisign",
+ "minisign-verify",
  "node-semver",
  "notify",
  "owo-colors 4.3.0",
@@ -604,6 +606,7 @@ dependencies = [
  "reqwest",
  "rpi-st7789v2-driver",
  "rppal",
+ "self-replace",
  "semver",
  "serde",
  "serde_json",
@@ -620,7 +623,6 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "trycmd",
- "upgrade",
  "uuid",
  "walkdir",
  "windows-acl",
@@ -1773,6 +1775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,9 +2815,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4168,6 +4178,24 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aefd422a7a8b5efced01cd7cdf3771e62ebecbc90e3d27695002d3af6af94586"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.4.3",
+ "rpassword",
+ "scrypt",
+]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -7904,15 +7932,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "upgrade"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed24be121473bfdd8484f96101885c503df710aabba32e885568c68dc976e12"
-dependencies = [
- "self-replace",
-]
 
 [[package]]
 name = "url"

--- a/crates/alertd/src/context.rs
+++ b/crates/alertd/src/context.rs
@@ -15,4 +15,7 @@ pub struct InternalContext {
 	/// Bumped on each reload request (SIGHUP/SIGUSR1); tasks watch it to refresh
 	/// their state without a restart.
 	pub reload: watch::Receiver<u64>,
+	/// Handle to ask the daemon to restart itself. `None` in detached test
+	/// contexts. Used by the self-update task after it replaces the binary.
+	pub restart: Option<crate::daemon::RestartTrigger>,
 }

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -52,6 +52,24 @@ impl DaemonControl {
 	}
 }
 
+/// A handle a background task can use to ask the daemon to restart itself.
+///
+/// Held by [`TaskContext`](crate::tasks::TaskContext) so a task that has
+/// replaced the running binary (self-update) can have the daemon exit for the
+/// service manager to relaunch the new binary, via the same path as the
+/// `/restart` control.
+#[derive(Clone, Debug)]
+pub struct RestartTrigger {
+	events: mpsc::Sender<DaemonEvent>,
+}
+
+impl RestartTrigger {
+	/// Ask the daemon to exit so the service manager restarts it.
+	pub async fn request_restart(&self) {
+		let _ = self.events.send(DaemonEvent::Restart).await;
+	}
+}
+
 pub async fn run(daemon_config: DaemonConfig) -> Result<()> {
 	let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 	run_with_shutdown(daemon_config, shutdown_rx).await
@@ -115,14 +133,17 @@ pub async fn run_with_shutdown(
 	let (reload_tx, reload_rx) = tokio::sync::watch::channel(0u64);
 	let reload_tx = Arc::new(reload_tx);
 
+	let (event_tx, mut event_rx) = mpsc::channel(100);
+
 	let ctx = Arc::new(InternalContext {
 		pg_pool: pool,
 		http_client: crate::http_client(),
 		canopy_client,
 		reload: reload_rx,
+		restart: Some(RestartTrigger {
+			events: event_tx.clone(),
+		}),
 	});
-
-	let (event_tx, mut event_rx) = mpsc::channel(100);
 
 	// Control handle for the HTTP server's `/reload` and `/restart` endpoints.
 	let control = DaemonControl {

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -16,6 +16,7 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		http_client: reqwest::Client::new(),
 		canopy_client: None,
 		reload: tokio::sync::watch::channel(0).1,
+		restart: None,
 	});
 
 	Arc::new(ServerState {

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -17,7 +17,7 @@ pub mod windows_service;
 
 pub use backup::{BackupRegistry, BackupRunner, BackupTask, RunningBackup};
 pub use context::InternalContext;
-pub use daemon::{run, run_with_shutdown};
+pub use daemon::{RestartTrigger, run, run_with_shutdown};
 pub use tasks::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
 
 /// The version of the alertd library

--- a/crates/alertd/src/tasks.rs
+++ b/crates/alertd/src/tasks.rs
@@ -19,6 +19,9 @@ pub struct TaskContext {
 	/// Bumped on each reload request (SIGHUP/SIGUSR1); a task can
 	/// `reload.changed().await` to refresh its state without a restart.
 	pub reload: tokio::sync::watch::Receiver<u64>,
+	/// Handle to ask the daemon to restart itself, for a task that has replaced
+	/// the running binary. `None` in detached test contexts.
+	pub restart: Option<crate::daemon::RestartTrigger>,
 	/// Query parameters of the request, for HTTP endpoint handlers. Empty on the
 	/// periodic `run` tick.
 	pub query: BTreeMap<String, String>,
@@ -31,6 +34,7 @@ impl TaskContext {
 			http_client: ctx.http_client.clone(),
 			canopy_client: ctx.canopy_client.clone(),
 			reload: ctx.reload.clone(),
+			restart: ctx.restart.clone(),
 			query: BTreeMap::new(),
 		}
 	}

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -55,6 +55,7 @@ lloggs = "1.1.0"
 merkle_hash = { version = "3.8.0", optional = true }
 miette = { workspace = true, features = ["fancy"] }
 mimalloc = "0.1.50"
+minisign-verify = { version = "0.2.5", optional = true }
 node-semver = { version = "2.2.0", optional = true }
 notify = { version = "8.2.0", optional = true }
 owo-colors = { version = "4.2.3", optional = true }
@@ -66,6 +67,7 @@ regex = { version = "1.11.2", optional = true }
 reqwest = { workspace = true }
 rpi-st7789v2-driver = { version = "0.3.14", path = "../rpi-st7789v2-driver", features = ["miette"], optional = true }
 rppal = { version = "0.22.1", optional = true }
+self-replace = { version = "1.5.0", optional = true }
 semver = { version = "1.0.28", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
@@ -80,7 +82,6 @@ tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-uuid-1
 tokio-util = { workspace = true, optional = true }
 toml = { version = "1", optional = true }
 tracing = { workspace = true }
-upgrade = { version = "2.0.1", optional = true }
 uuid = { version = "1.23.2", features = ["v4"] }
 walkdir = { version = "2.5.0", optional = true }
 zip = { version = "8.6.0", optional = true, default-features = false, features = ["time"] }
@@ -112,7 +113,7 @@ crypto = ["dep:algae-cli", "dep:blake3", "dep:merkle_hash"]
 file = ["dep:blake3", "dep:indicatif", "dep:tokio-util"]
 kopia = ["dep:bestool-kopia", "bestool-kopia/cli", "dep:comfy-table"]
 rdp = ["dep:duct", "dep:privilege", "dep:quick-xml", "dep:tauri-winrt-notification", "dep:windows-service"]
-self-update = ["download", "dep:semver", "dep:upgrade", "dep:windows-env"]
+self-update = ["download", "dep:minisign-verify", "dep:self-replace", "dep:semver", "dep:windows-env"]
 ssh = ["dep:dirs", "dep:duct", "dep:fs4", "dep:ssh-key", "dep:privilege", "dep:windows-acl"]
 
 ## Tamanu subcommands
@@ -212,8 +213,15 @@ notify = ["dep:notify"]
 [dev-dependencies]
 age = { version = "0.11.3", features = ["async"] }
 jsonschema = { version = "0.46.5", default-features = false }
+minisign = "0.9.1"
 trycmd = "1.2.0"
 
 [package.metadata.binstall]
-pkg-url = "https://tools.ops.tamanu.io/bestool/{ version }/{ target }/{ name }{ binary-ext }"
-pkg-fmt = "bin"
+pkg-url = "https://tools.ops.tamanu.io/bestool/{ version }/{ target }/{ name }{ binary-ext }.tar.zst"
+pkg-fmt = "tzstd"
+bin-dir = "{ bin }{ binary-ext }"
+
+[package.metadata.binstall.signing]
+algorithm = "minisign"
+pubkey = "RWS1KOzOdZegWyADv/mT0GoLELjY7esgGwjtDVPqt6yaf/Wk1u1ZUCIf"
+file = "{ url }.minisig"

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -222,6 +222,13 @@ fn with_daemon_tasks(
 		(config, doctor)
 	};
 
+	// On Windows the daemon keeps bestool current itself; on Linux the package
+	// manager owns updates.
+	#[cfg(all(windows, feature = "self-update"))]
+	let config = config.with_task(Arc::new(
+		crate::actions::self_update::task::SelfUpdateTask::new(),
+	));
+
 	config.with_task(Arc::new(doctor))
 }
 

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -2,14 +2,20 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-use binstalk_downloader::download::{Download, PkgFmt};
+use binstalk_downloader::download::{DataVerifier as _, Download, PkgFmt};
 use detect_targets::{TARGET, get_desired_targets};
 use miette::{IntoDiagnostic, Result, miette};
-use tracing::{debug, info};
+use tracing::info;
 
-use crate::download::{DownloadSource, client, fetch_latest_version};
+use crate::download::{
+	DownloadSource, ReleaseVerifier, client, fetch_latest_version, fetch_release_signature,
+	remote_is_newer,
+};
 
 use super::Context;
+
+#[cfg(all(windows, feature = "alertd"))]
+pub(crate) mod task;
 
 #[cfg(unix)]
 fn check_exe_writable() -> Result<()> {
@@ -87,6 +93,13 @@ pub struct SelfUpdateArgs {
 }
 
 pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
+	// On Windows, when the alert daemon is running, let it own the binary swap
+	// and its own restart rather than racing it from this separate process.
+	#[cfg(all(windows, feature = "alertd"))]
+	if is_alertd_service_running().await {
+		return delegate_to_daemon(&args).await;
+	}
+
 	#[cfg(unix)]
 	{
 		check_exe_writable()?;
@@ -102,29 +115,78 @@ pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
 		add_to_path,
 	} = args;
 
-	if version == "latest" && !force {
-		match fetch_latest_version().await {
-			Ok(latest) => {
-				let current = env!("CARGO_PKG_VERSION");
-				if latest == current {
-					info!(
-						version = current,
-						"Already on the latest version. Use --force to reinstall."
-					);
-					return Ok(());
-				}
-				info!(current = current, latest = %latest, "Update available, proceeding");
-			}
-			Err(err) => {
-				debug!("Failed to check latest version, continuing with download: {err}");
-			}
+	#[cfg(windows)]
+	if add_to_path && let Err(err) = add_self_to_path() {
+		tracing::error!("{err:?}");
+	}
+
+	match perform_update(&version, target, temp_dir, force).await? {
+		UpdateOutcome::AlreadyCurrent { version } => {
+			info!(
+				version = %version,
+				"already on the latest version; use --force to reinstall"
+			);
+		}
+		UpdateOutcome::Updated { from, to } => {
+			info!(from = %from, to = %to, "updated bestool");
 		}
 	}
+
+	Ok(())
+}
+
+/// What [`perform_update`] did.
+#[derive(Debug, Clone)]
+pub(crate) enum UpdateOutcome {
+	/// The running build is already current; nothing was downloaded.
+	AlreadyCurrent { version: String },
+	/// The running binary was replaced; `to` is now installed.
+	Updated { from: String, to: String },
+}
+
+/// Resolve, download, verify, and install a bestool release, replacing the
+/// running binary in place.
+///
+/// `version` is `"latest"` or a specific version. With `"latest"` and `force`
+/// unset, returns [`UpdateOutcome::AlreadyCurrent`] without downloading when the
+/// running build is already at or ahead of the published release. A specific
+/// version is always installed.
+///
+/// The downloaded archive is verified against the embedded release public key
+/// before the binary it contains is swapped in; an artifact with a missing or
+/// invalid signature is never installed. Replacing the binary does not restart
+/// anything — the caller decides what happens next (a CLI invocation exits; the
+/// daemon requests its own restart).
+pub(crate) async fn perform_update(
+	version: &str,
+	target: Option<String>,
+	temp_dir: Option<PathBuf>,
+	force: bool,
+) -> Result<UpdateOutcome> {
+	let current = env!("CARGO_PKG_VERSION");
+
+	let resolved = if version == "latest" {
+		let latest = fetch_latest_version().await?;
+		if !force && !remote_is_newer(current, &latest) {
+			return Ok(UpdateOutcome::AlreadyCurrent {
+				version: current.to_string(),
+			});
+		}
+		latest
+	} else {
+		version.to_string()
+	};
+
+	info!(from = current, to = %resolved, "updating bestool");
 
 	let client = client().await?;
 
 	let detected_targets = get_desired_targets(target.map(|t| vec![t]));
 	let detected_targets = detected_targets.get().await;
+	let target = detected_targets
+		.first()
+		.cloned()
+		.unwrap_or_else(|| TARGET.into());
 
 	let dir = temp_dir.unwrap_or_else(std::env::temp_dir);
 	let filename = format!(
@@ -135,51 +197,78 @@ pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
 	let _ = tokio::fs::remove_file(&dest).await;
 
 	let host = DownloadSource::Tools.host();
-	let target = detected_targets
-		.first()
-		.cloned()
-		.unwrap_or_else(|| TARGET.into());
-	let bin_path = format!("/bestool/{version}/{target}/{filename}");
-	let bin_url = host.join(&bin_path).into_diagnostic()?;
-	let tzst_url = host
-		.join(&format!("{bin_path}.tar.zst"))
+	let archive_path = format!("/bestool/{resolved}/{target}/{filename}.tar.zst");
+	let archive_url = host.join(&archive_path).into_diagnostic()?;
+
+	info!(url = %archive_url, "downloading and verifying release");
+	let signature = fetch_release_signature(&client, &archive_url).await?;
+	let mut verifier = ReleaseVerifier::new(signature);
+	Download::new_with_data_verifier(client, archive_url, &mut verifier)
+		.and_extract(PkgFmt::Tzstd, &dir)
+		.await
 		.into_diagnostic()?;
 
-	let tzst_available = client
-		.remote_gettable(tzst_url.clone())
+	if !verifier.validate() {
+		return Err(miette!(
+			"release signature verification failed; refusing to install {resolved}"
+		));
+	}
+
+	info!(?dest, "signature verified, replacing binary");
+	self_replace::self_replace(&dest).into_diagnostic()?;
+	let _ = tokio::fs::remove_file(&dest).await;
+
+	Ok(UpdateOutcome::Updated {
+		from: current.to_string(),
+		to: resolved,
+	})
+}
+
+/// Ask the running alert daemon to perform the update (and restart itself),
+/// rather than swapping the binary from this separate process.
+///
+/// Surfaces the daemon's decision (updating, or already current) to the
+/// operator who ran the command.
+#[cfg(all(windows, feature = "alertd"))]
+async fn delegate_to_daemon(args: &SelfUpdateArgs) -> Result<()> {
+	use serde_json::Value;
+
+	// Reuse the daemon client that probes every default address (v6 and v4
+	// loopback) and returns the base URL that answered: the daemon binds only
+	// the first address it can, so a hardcoded family can miss it.
+	let (client, base_url) =
+		bestool_alertd::commands::try_connect_daemon(&bestool_alertd::commands::default_server_addrs())
+			.await?;
+
+	let mut url = reqwest::Url::parse(&format!("{base_url}/tasks/self-update/update"))
+		.into_diagnostic()?;
+	url.query_pairs_mut()
+		.append_pair("version", &args.version)
+		.append_pair("force", if args.force { "true" } else { "false" });
+
+	info!("alert daemon is running; delegating update to it");
+	let response = client
+		.get(url)
+		.send()
 		.await
-		.unwrap_or(false);
+		.map_err(|err| miette!("could not reach the alert daemon: {err}"))?;
 
-	if tzst_available {
-		info!(url = %tzst_url, "downloading compressed");
-		Download::new(client, tzst_url)
-			.and_extract(PkgFmt::Tzstd, &dir)
-			.await
-			.into_diagnostic()?;
+	let body: Value = response
+		.json()
+		.await
+		.map_err(|err| miette!("unexpected response from the alert daemon: {err}"))?;
+
+	if body.get("updating").and_then(Value::as_bool) == Some(true) {
+		let from = body.get("from").and_then(Value::as_str).unwrap_or("?");
+		let to = body.get("to").and_then(Value::as_str).unwrap_or("?");
+		info!(from, to, "alert daemon is updating and will restart");
+	} else if let Some(message) = body.get("error").and_then(Value::as_str) {
+		return Err(miette!("alert daemon could not update: {message}"));
 	} else {
-		info!(url = %bin_url, "downloading");
-		Download::new(client, bin_url)
-			.and_extract(PkgFmt::Bin, &dest)
-			.await
-			.into_diagnostic()?;
+		let current = body.get("current").and_then(Value::as_str).unwrap_or("?");
+		info!(version = current, "alert daemon is already on the latest version");
 	}
 
-	#[cfg(windows)]
-	if add_to_path && let Err(err) = add_self_to_path() {
-		tracing::error!("{err:?}");
-	}
-
-	info!(?dest, "downloaded, self-upgrading");
-	upgrade::run_upgrade(&dest, true, vec!["--version"])
-		.map_err(|err| miette!("upgrade: {err:?}"))?;
-	
-	#[cfg(windows)]
-	if is_alertd_service_running().await {
-		if let Err(err) = schedule_service_restart() {
-			tracing::warn!("failed to schedule service restart: {err:?}");
-		}
-	}
-	
 	Ok(())
 }
 
@@ -198,43 +287,13 @@ fn add_self_to_path() -> Result<()> {
 	Ok(())
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "alertd"))]
 async fn is_alertd_service_running() -> bool {
-	// Try to query the alertd HTTP API status endpoint
-	match crate::http::client()
-		.get("http://127.0.0.1:8271/status")
-		.send()
+	// Probes every default address (v6 and v4 loopback): the daemon binds only
+	// the first address it can, so checking a single family can miss it.
+	bestool_alertd::commands::try_connect_daemon(&bestool_alertd::commands::default_server_addrs())
 		.await
-	{
-		Ok(response) => response.status().is_success(),
-		Err(_) => false,
-	}
-}
-
-#[cfg(windows)]
-fn schedule_service_restart() -> Result<()> {
-	use std::process::Command;
-	
-	// Schedule a service restart using a PowerShell command that waits 60 seconds
-	// then restarts the service
-	let ps_command = "Start-Sleep -Seconds 60; Restart-Service -Name bestool-alertd -Force";
-	
-	let output = Command::new("powershell")
-		.args(&[
-			"-NoProfile",
-			"-Command",
-			&format!("Start-Process powershell -ArgumentList '-NoProfile', '-Command', '{}' -WindowStyle Hidden", ps_command),
-		])
-		.output()
-		.into_diagnostic()?;
-	
-	if !output.status.success() {
-		let stderr = String::from_utf8_lossy(&output.stderr);
-		return Err(miette!("failed to schedule service restart: {}", stderr));
-	}
-	
-	info!("scheduled service restart for 1 minute later");
-	Ok(())
+		.is_ok()
 }
 
 #[cfg(all(test, unix))]

--- a/crates/bestool/src/actions/self_update/task.rs
+++ b/crates/bestool/src/actions/self_update/task.rs
@@ -1,0 +1,201 @@
+//! Windows-only background task that keeps bestool up to date.
+//!
+//! The daemon checks daily — staggered across the fleet — for a newer published
+//! release; when one is available it downloads and verifies it, replaces the
+//! binary, and restarts itself so the new binary takes effect. On Linux the
+//! package manager owns updates, so this task is Windows-only.
+//!
+//! It also exposes `/tasks/self-update/update`, which `bestool self-update`
+//! calls to hand an on-demand update to the running daemon instead of swapping
+//! the binary from a separate process.
+
+use std::{
+	collections::hash_map::DefaultHasher,
+	hash::{Hash as _, Hasher as _},
+	sync::{Arc, Mutex},
+	time::Duration,
+};
+
+use futures::future::BoxFuture;
+use miette::Result;
+use serde_json::json;
+use tracing::{debug, info, warn};
+
+use bestool_alertd::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
+
+use super::{UpdateOutcome, perform_update};
+use crate::download::{fetch_latest_version, remote_is_newer};
+
+/// How often to check for a new release once the initial stagger has elapsed.
+const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Window over which the first check is spread across hosts, so a fleet doesn't
+/// fetch and restart in lockstep. The offset within it is derived from the
+/// hostname, so a given host's schedule is stable across restarts.
+const STAGGER_WINDOW: Duration = Duration::from_secs(60 * 60);
+
+pub(crate) struct SelfUpdateTask {
+	/// A version that failed to install, so the same failure isn't reattempted
+	/// on every check. A newer version compares unequal and is still tried.
+	/// Shared with the on-demand endpoint handler.
+	failed_version: Arc<Mutex<Option<String>>>,
+}
+
+impl SelfUpdateTask {
+	pub(crate) fn new() -> Self {
+		Self {
+			failed_version: Arc::new(Mutex::new(None)),
+		}
+	}
+
+	async fn check_and_update(&self, ctx: &TaskContext) {
+		let current = env!("CARGO_PKG_VERSION");
+		let latest = match fetch_latest_version().await {
+			Ok(latest) => latest,
+			Err(err) => {
+				warn!("self-update: could not check latest version: {err}");
+				return;
+			}
+		};
+
+		if !remote_is_newer(current, &latest) {
+			debug!(current, %latest, "self-update: already current");
+			return;
+		}
+
+		if self.failed_version.lock().unwrap().as_deref() == Some(latest.as_str()) {
+			warn!(%latest, "self-update: skipping version that previously failed to install");
+			return;
+		}
+
+		info!(current, %latest, "self-update: newer version available, installing");
+		match perform_update(&latest, None, None, false).await {
+			Ok(UpdateOutcome::Updated { from, to }) => {
+				info!(%from, %to, "self-update installed; requesting daemon restart");
+				request_restart(ctx).await;
+			}
+			Ok(UpdateOutcome::AlreadyCurrent { .. }) => {}
+			Err(err) => {
+				warn!(%latest, "self-update failed; not retrying this version: {err}");
+				*self.failed_version.lock().unwrap() = Some(latest);
+			}
+		}
+	}
+}
+
+/// Initial delay before the first check, derived from the hostname so the
+/// fleet's checks spread across [`STAGGER_WINDOW`] rather than aligning.
+fn stagger_offset() -> Duration {
+	let host = std::env::var("COMPUTERNAME").unwrap_or_default();
+	let mut hasher = DefaultHasher::new();
+	host.hash(&mut hasher);
+	Duration::from_secs(hasher.finish() % STAGGER_WINDOW.as_secs())
+}
+
+async fn request_restart(ctx: &TaskContext) {
+	if let Some(restart) = &ctx.restart {
+		restart.request_restart().await;
+	} else {
+		warn!("self-update: no restart handle; the new binary takes effect on next restart");
+	}
+}
+
+impl BackgroundTask for SelfUpdateTask {
+	fn name(&self) -> &'static str {
+		"self-update"
+	}
+
+	fn interval(&self) -> Duration {
+		// run() is resident (it loops internally), so this only gates the
+		// daemon's single first tick.
+		CHECK_INTERVAL
+	}
+
+	fn run<'a>(&'a self, ctx: &'a TaskContext) -> BoxFuture<'a, Result<()>> {
+		Box::pin(async move {
+			let offset = stagger_offset();
+			info!(?offset, "self-update: first check staggered");
+			tokio::time::sleep(offset).await;
+
+			let mut tick = tokio::time::interval(CHECK_INTERVAL);
+			loop {
+				tick.tick().await;
+				self.check_and_update(ctx).await;
+			}
+		})
+	}
+
+	fn http_endpoints(&self) -> Vec<TaskEndpoint> {
+		let failed_version = self.failed_version.clone();
+		vec![TaskEndpoint {
+			name: "update",
+			handler: Arc::new(move |ctx: TaskContext| {
+				Box::pin(on_demand_update(ctx, failed_version.clone()))
+			}),
+		}]
+	}
+}
+
+/// Handle `/tasks/self-update/update`: decide whether an update is warranted and
+/// respond immediately, kicking off the download, install, and restart in the
+/// background so the response reaches the caller before the daemon exits.
+async fn on_demand_update(
+	ctx: TaskContext,
+	failed_version: Arc<Mutex<Option<String>>>,
+) -> TaskEndpointResponse {
+	let current = env!("CARGO_PKG_VERSION");
+	let requested = ctx
+		.query
+		.get("version")
+		.map(String::as_str)
+		.unwrap_or("latest");
+	let force = ctx.query.get("force").map(|v| v == "true").unwrap_or(false);
+
+	let resolved = if requested == "latest" {
+		match fetch_latest_version().await {
+			Ok(latest) => {
+				if !force && !remote_is_newer(current, &latest) {
+					return TaskEndpointResponse::Json(json!({
+						"updating": false,
+						"current": current,
+						"latest": latest,
+					}));
+				}
+				latest
+			}
+			Err(err) => {
+				return TaskEndpointResponse::Error {
+					status: 502,
+					message: format!("could not check latest version: {err}"),
+				};
+			}
+		}
+	} else {
+		requested.to_string()
+	};
+
+	let restart = ctx.restart.clone();
+	let to = resolved.clone();
+	tokio::spawn(async move {
+		match perform_update(&resolved, None, None, true).await {
+			Ok(_) => {
+				info!(version = %resolved, "on-demand self-update installed; restarting");
+				// Brief grace so the HTTP response flushes before the daemon exits.
+				tokio::time::sleep(Duration::from_secs(1)).await;
+				if let Some(restart) = restart {
+					restart.request_restart().await;
+				}
+			}
+			Err(err) => {
+				warn!(version = %resolved, "on-demand self-update failed: {err}");
+				*failed_version.lock().unwrap() = Some(resolved);
+			}
+		}
+	});
+
+	TaskEndpointResponse::Json(json!({
+		"updating": true,
+		"from": current,
+		"to": to,
+	}))
+}

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -222,6 +222,106 @@ pub async fn check_for_update() -> Result<()> {
 	Ok(())
 }
 
+/// Trust anchor for released binaries: the minisign public key whose private
+/// counterpart is held only by the release pipeline. It ships in the binary so
+/// an update can be verified against a key that travelled with the running
+/// build rather than one fetched at update time.
+#[cfg(feature = "self-update")]
+pub(crate) const RELEASE_PUBLIC_KEY: &str =
+	"RWS1KOzOdZegWyADv/mT0GoLELjY7esgGwjtDVPqt6yaf/Wk1u1ZUCIf";
+
+/// Fetch and decode the detached signature published next to `artifact_url`
+/// (at the artifact URL with a `.minisig` suffix).
+#[cfg(feature = "self-update")]
+pub(crate) async fn fetch_release_signature(
+	client: &Client,
+	artifact_url: &Url,
+) -> Result<minisign_verify::Signature> {
+	use miette::miette;
+
+	let sig_url = Url::parse(&format!("{artifact_url}.minisig")).into_diagnostic()?;
+	debug!(%sig_url, "fetching release signature");
+
+	let response = client
+		.get(sig_url)
+		.send(true)
+		.await
+		.map_err(|err| miette!("could not fetch release signature: {err}"))?;
+	let sig_bytes = response.bytes().await.into_diagnostic()?;
+	let sig_text = std::str::from_utf8(&sig_bytes)
+		.map_err(|err| miette!("release signature is not UTF-8: {err}"))?;
+	minisign_verify::Signature::decode(sig_text)
+		.map_err(|err| miette!("malformed release signature: {err}"))
+}
+
+/// Streams a downloaded artifact through minisign verification against
+/// [`RELEASE_PUBLIC_KEY`].
+///
+/// Plug it into the downloader with [`Download::new_with_data_verifier`], then
+/// call [`DataVerifier::validate`] once the download finishes: it returns
+/// `false` unless the bytes that streamed through carry a valid release
+/// signature. The artifact verified is the exact one downloaded, so an
+/// unverified artifact is rejected before its contents are trusted.
+///
+/// [`Download::new_with_data_verifier`]: binstalk_downloader::download::Download::new_with_data_verifier
+#[cfg(feature = "self-update")]
+pub(crate) struct ReleaseVerifier {
+	signature: minisign_verify::Signature,
+	data: Vec<u8>,
+}
+
+#[cfg(feature = "self-update")]
+impl ReleaseVerifier {
+	pub(crate) fn new(signature: minisign_verify::Signature) -> Self {
+		Self {
+			signature,
+			data: Vec::new(),
+		}
+	}
+}
+
+#[cfg(feature = "self-update")]
+impl binstalk_downloader::download::DataVerifier for ReleaseVerifier {
+	fn update(&mut self, data: &binstalk_downloader::bytes::Bytes) {
+		self.data.extend_from_slice(data);
+	}
+
+	fn validate(&mut self) -> bool {
+		if verify_signed(RELEASE_PUBLIC_KEY, &self.signature, &self.data) {
+			info!("release signature verified");
+			true
+		} else {
+			false
+		}
+	}
+}
+
+/// Check `data` against `signature` under the base64 minisign public key
+/// `public_key_b64`. Rejects the legacy (non-prehashed) minisign format. Logs
+/// and returns `false` on any failure rather than erroring, for the
+/// `DataVerifier::validate` contract.
+#[cfg(feature = "self-update")]
+fn verify_signed(
+	public_key_b64: &str,
+	signature: &minisign_verify::Signature,
+	data: &[u8],
+) -> bool {
+	let public_key = match minisign_verify::PublicKey::from_base64(public_key_b64) {
+		Ok(key) => key,
+		Err(err) => {
+			tracing::error!("invalid release public key: {err}");
+			return false;
+		}
+	};
+	match public_key.verify(data, signature, false) {
+		Ok(()) => true,
+		Err(err) => {
+			tracing::error!("release signature did not verify: {err}");
+			false
+		}
+	}
+}
+
 /// Whether the remote version is strictly higher than the current version.
 ///
 /// Avoids notifying when a dev or pre-release build (e.g. installed from a
@@ -275,5 +375,56 @@ mod tests {
 	fn unparseable_falls_back_to_inequality() {
 		assert!(remote_is_newer("not-semver", "1.0.0"));
 		assert!(!remote_is_newer("not-semver", "not-semver"));
+	}
+}
+
+#[cfg(all(test, feature = "self-update"))]
+mod signature_tests {
+	use std::io::Cursor;
+
+	use minisign_verify::Signature;
+
+	use super::{RELEASE_PUBLIC_KEY, verify_signed};
+
+	/// Sign `data` with a fresh keypair, returning (public-key base64, signature
+	/// text). `minisign::sign` produces a prehashed signature by default — the
+	/// only format the verifier accepts.
+	fn sign(data: &[u8]) -> (String, String) {
+		let keypair = minisign::KeyPair::generate_unencrypted_keypair().unwrap();
+		let signature = minisign::sign(None, &keypair.sk, Cursor::new(data), None, None).unwrap();
+		(keypair.pk.to_base64(), signature.into_string())
+	}
+
+	#[test]
+	fn embedded_release_key_is_a_valid_minisign_key() {
+		assert!(minisign_verify::PublicKey::from_base64(RELEASE_PUBLIC_KEY).is_ok());
+	}
+
+	#[test]
+	fn accepts_a_valid_signature() {
+		let data = b"the bestool release archive bytes";
+		let (pubkey, sig) = sign(data);
+		let signature = Signature::decode(&sig).unwrap();
+		assert!(verify_signed(&pubkey, &signature, data));
+	}
+
+	#[test]
+	fn rejects_tampered_data() {
+		let (pubkey, sig) = sign(b"the bestool release archive bytes");
+		let signature = Signature::decode(&sig).unwrap();
+		assert!(!verify_signed(
+			&pubkey,
+			&signature,
+			b"tampered archive bytes"
+		));
+	}
+
+	#[test]
+	fn rejects_a_signature_from_a_different_key() {
+		let data = b"the bestool release archive bytes";
+		let (_pubkey, sig) = sign(data);
+		let signature = Signature::decode(&sig).unwrap();
+		let (other_pubkey, _) = sign(data);
+		assert!(!verify_signed(&other_pubkey, &signature, data));
 	}
 }


### PR DESCRIPTION
🤖 The Windows alert daemon now keeps bestool up to date on its own, so a host running the service stays current without anyone calling `self-update` or remembering to restart it. On Linux the deb/apt path still owns updates, so this is Windows-only (compile-gated).

## What it does

- **Daemon self-update (Windows):** a background task checks once a day — staggered across the fleet by a hostname-derived offset, so hosts don't fetch and restart in lockstep — for a newer published release. When one exists it downloads, verifies, replaces its own binary, and requests its own restart through the existing exit-nonzero path. It only moves forward, and won't reattempt a version that already failed to install.
- **`bestool self-update` delegates to the daemon:** on Windows, when the service is running, the command hands the update to the daemon so the binary swap and restart have a single owner, rather than racing it from a separate process. It reaches the daemon over whichever loopback address answers (the daemon binds only the first of `[::1]:8271` / `127.0.0.1:8271` it can), reusing `try_connect_daemon` — this also fixes a latent v4/v6 mismatch in the old service-detection check.
- **Signature verification (all platforms):** release artifacts are signed with minisign, and bestool verifies the downloaded artifact against an embedded public key before installing — for both self-update and `cargo binstall`. Verification is mandatory; an artifact with a missing or invalid signature is never installed. Only the modern (prehashed) minisign format is accepted.
- **binstall uses the compressed artifact:** the binstall metadata now points at the `.tar.zst` with matching `signing` config, so binstall and the daemon share one signed artifact.

## Release pipeline

The release workflow signs each `.tar.zst` with `rsign2` (a pure-Rust minisign, installed via the install-action binstall fallback) using the existing `SIGNING_KEY` secret, and publishes the `.minisig` alongside.

## Notes

- Spec: `.workhorse/specs/bestool/self-update.md` (id `UPD`).
- Dropped the `upgrade` crate in favour of `self-replace` directly: the daemon must own its restart, not have the swap spawn a detached process.
- Added a `RestartTrigger` to the daemon's task context so a task can drive the same restart the `/restart` control uses.
