### PR TITLE
fix(tamanu): skip the doctor TUI when the terminal lacks ANSI support

### DIFF
--- a/.workhorse/specs/tamanu/doctor.md
+++ b/.workhorse/specs/tamanu/doctor.md
@@ -48,7 +48,8 @@ The same grouping and ordering apply during the live sweep and in the final rend
 
 ## Live execution in an interactive terminal
 
-When stdout is attached to a terminal and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep.
+When stdout is attached to a terminal that honours ANSI escape sequences and JSON output is not requested, the command takes over the terminal in an alternate-screen TUI for the duration of the sweep.
+A terminal that cannot render ANSI escapes (for instance an older console that does not support them) is treated as non-interactive, and styled colour output is likewise suppressed there.
 Every selected check appears as a row in the list from the start of the sweep, in a pending state.
 A pending check shows a neutral indicator, a running check shows an animated spinner, and a completed check shows its outcome tag alongside the check name and one-line summary.
 As each check completes, its row moves to its grouped-and-ordered position; a check that completes as skipped is removed from the live list entirely.
@@ -82,7 +83,7 @@ When no check warns, breaks, or fails and `--all` is not set, the displayed list
 
 ## Non-interactive output
 
-When stdout is not attached to a terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner.
+When stdout is not attached to an ANSI-capable terminal and JSON output is not requested, the command produces line-by-line output without an alternate-screen TUI or animated spinner.
 Non-interactive output follows the same grouping, ordering, source note, result line, and replay filter rules.
 
 ## JSON output

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -81,7 +81,13 @@ const DAEMON_BASE: &str = "http://127.0.0.1:8271";
 
 pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	let tamanu = ctx.require::<TamanuArgs>();
-	let use_colours = tamanu.use_colours;
+
+	// When ANSI escapes are not honoured (e.g. an older Windows console where
+	// virtual terminal processing cannot be enabled), the live TUI cannot render
+	// and styled output would print as garbage, so fall back to plain
+	// non-interactive output.
+	let ansi = ansi_supported();
+	let use_colours = tamanu.use_colours && ansi;
 
 	let install = resolve_sweep_tamanu(try_find_tamanu(tamanu).await?)?;
 	if install.is_none() {
@@ -89,7 +95,7 @@ pub async fn run(args: DoctorArgs, ctx: Context) -> Result<()> {
 	}
 	let http_client = crate::http::client();
 
-	let live_tty = !args.json && std::io::stdout().is_terminal();
+	let live_tty = !args.json && ansi && std::io::stdout().is_terminal();
 
 	let (sweep, source, interrupted) = if args.no_daemon {
 		let outcome = run_local_sweep(install.clone(), http_client.clone(), &args, live_tty).await?;
@@ -399,6 +405,22 @@ fn results_from_wire(payload: &Value) -> Vec<(Check, bool)> {
 			))
 		})
 		.collect()
+}
+
+/// Whether the terminal honours ANSI escape sequences, which the live TUI and
+/// styled output both rely on. On Windows this attempts to enable virtual
+/// terminal processing; if that fails on an older console, crossterm falls back
+/// to a winapi screen-buffer path that our buffered drawing cannot target, so
+/// we treat ANSI as unavailable rather than render a black screen.
+fn ansi_supported() -> bool {
+	#[cfg(windows)]
+	{
+		crossterm::ansi_support::supports_ansi()
+	}
+	#[cfg(not(windows))]
+	{
+		true
+	}
 }
 
 /// Set up the progress channel and (when running in a TTY) the live TUI task.


### PR DESCRIPTION
🤖 Fixes the `tamanu doctor` live TUI rendering as a black screen on Windows consoles that don't support ANSI escape sequences (seen on Windows Server 2019).

## Cause

When virtual terminal processing can't be enabled, crossterm falls back to a winapi path for the alternate screen: `EnterAlternateScreen` creates a new active console screen buffer, and crossterm's cursor/clear/colour commands target it. But our buffered text is written through Rust's `io::stdout()`, which is bound to the original `STD_OUTPUT_HANDLE` and never follows the active-buffer switch — so the text lands in the now-inactive original buffer. The result is a black alternate screen while drawing, and on exit the original buffer (holding the leftover frame) becomes active again and the replay overwrites it.

## Fix

Gate the live TUI and styled colour output on whether ANSI escapes are actually honoured (on Windows, whether virtual terminal processing can be enabled). When they aren't, fall back to the plain non-interactive output: the sweep runs without the TUI and prints the short result replay directly.

The spec is updated to describe the ANSI-capability requirement for the TUI and the non-interactive fallback.
