### PR TITLE
fix(canopy): report snapshot size from the root directory summary

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -820,10 +820,22 @@ fn parse_snapshot_output(stdout: &str) -> SnapshotResult {
 		.get("id")
 		.and_then(|v| v.as_str())
 		.map(|s| s.to_owned());
+	// `snapshot create --json` strips the whole `stats` object (kopia only emits it
+	// under `--json-verbose`), so the size lives in the root directory summary
+	// (`rootEntry.summ.size`), which is always present. It equals `stats.totalSize`
+	// for a complete snapshot (both sum every file once); fall back to it for the
+	// verbose form.
 	let bytes_uploaded = value
-		.get("stats")
-		.and_then(|s| s.get("totalSize"))
-		.and_then(|v| v.as_i64());
+		.get("rootEntry")
+		.and_then(|r| r.get("summ"))
+		.and_then(|s| s.get("size"))
+		.and_then(serde_json::Value::as_i64)
+		.or_else(|| {
+			value
+				.get("stats")
+				.and_then(|s| s.get("totalSize"))
+				.and_then(serde_json::Value::as_i64)
+		});
 	SnapshotResult { id, bytes_uploaded }
 }
 
@@ -1042,6 +1054,20 @@ mod tests {
 			parse_snapshot_output(out),
 			SnapshotResult {
 				id: Some("abc123".to_owned()),
+				bytes_uploaded: Some(987654),
+			}
+		);
+	}
+
+	#[test]
+	fn parse_snapshot_output_prefers_root_summary_size() {
+		// The real `--json` output has no `stats` (kopia strips it); the size comes
+		// from the root summary. When both are present, the root summary wins.
+		let out = r#"{"id":"x","stats":{"totalSize":10},"rootEntry":{"summ":{"size":987654}}}"#;
+		assert_eq!(
+			parse_snapshot_output(out),
+			SnapshotResult {
+				id: Some("x".to_owned()),
 				bytes_uploaded: Some(987654),
 			}
 		);


### PR DESCRIPTION
🤖 `bytes_uploaded` has been null in canopy for every backup run, success or fail (`select count(*) from backup_runs where bytes_uploaded is not null` → 0), while `snapshot_id` is always populated on success.

Root cause: `parse_snapshot_output` reads the size from `stats.totalSize`, but kopia's `snapshot create --json` **strips the whole `stats` object** unless `--json-verbose` is passed — its `cleanupSnapshotManifestForJSON` shadows the field with an empty `stats,omitempty` string (the kopia comment literally says *"trick to remove 'stats' completely"*). So `stats.totalSize` is never in the output; `id` survives because it's top-level.

The size is still present at `rootEntry.summ.size` (the root `DirectorySummary`), which kopia does not strip. Read from there, falling back to `stats.totalSize` for the verbose form.

The report plumbing was already correct end-to-end (bestool `BackupReport.bytes_uploaded` → canopy `ReportArgs.bytes_uploaded` → `backup_runs.bytes_uploaded`); only the extraction was wrong. A failed run still reports no size (no completed snapshot), so canopy keeps its proxy-stats fallback there.
