### PR TITLE
fix(self-update): correct embedded release public key to match signing key

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -231,6 +231,29 @@ jobs:
             "$src_dir/$name.tar.zst"
           rm -f signing.key
 
+      # Guard against the signing key drifting from the public key baked into
+      # the binary: verify the just-signed artifact against the exact key the
+      # self-update path trusts (RELEASE_PUBLIC_KEY in download.rs). If they
+      # don't match, no shipped bestool could self-update to this release, so
+      # fail here rather than publish an un-updatable build.
+      - name: Verify signature with the embedded self-update key
+        shell: bash
+        run: |
+          src_dir="target/${{ matrix.target }}/dist"
+          name="bestool"
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            name="bestool.exe"
+          fi
+          embedded=$(grep -oE 'RW[A-Za-z0-9+/=]{40,}' crates/bestool/src/download.rs | head -n1)
+          if [[ -z "$embedded" ]]; then
+            echo "could not extract RELEASE_PUBLIC_KEY from crates/bestool/src/download.rs" >&2
+            exit 1
+          fi
+          echo "verifying against embedded key: $embedded"
+          rsign verify "$src_dir/$name.tar.zst" \
+            -P "$embedded" \
+            -x "$src_dir/$name.tar.zst.minisig"
+
       - uses: actions/upload-artifact@v7
         with:
           name: bestool-${{ matrix.target }}-${{ github.sha }}

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -223,5 +223,5 @@ bin-dir = "{ bin }{ binary-ext }"
 
 [package.metadata.binstall.signing]
 algorithm = "minisign"
-pubkey = "RWS1KOzOdZegWyADv/mT0GoLELjY7esgGwjtDVPqt6yaf/Wk1u1ZUCIf"
+pubkey = "RWT+oj++Y0app3N4K+PLSYTKhtXimltIHxhoFgyWjxR/ZElCG0lDBDl5"
 file = "{ url }.minisig"

--- a/crates/bestool/src/download.rs
+++ b/crates/bestool/src/download.rs
@@ -228,7 +228,7 @@ pub async fn check_for_update() -> Result<()> {
 /// build rather than one fetched at update time.
 #[cfg(feature = "self-update")]
 pub(crate) const RELEASE_PUBLIC_KEY: &str =
-	"RWS1KOzOdZegWyADv/mT0GoLELjY7esgGwjtDVPqt6yaf/Wk1u1ZUCIf";
+	"RWT+oj++Y0app3N4K+PLSYTKhtXimltIHxhoFgyWjxR/ZElCG0lDBDl5";
 
 /// Fetch and decode the detached signature published next to `artifact_url`
 /// (at the artifact URL with a `.minisig` suffix).
@@ -398,6 +398,20 @@ mod signature_tests {
 	#[test]
 	fn embedded_release_key_is_a_valid_minisign_key() {
 		assert!(minisign_verify::PublicKey::from_base64(RELEASE_PUBLIC_KEY).is_ok());
+	}
+
+	#[test]
+	fn embedded_release_key_matches_binstall_metadata() {
+		// self-update (RELEASE_PUBLIC_KEY) and binstall (the
+		// [package.metadata.binstall.signing] pubkey) verify against the same
+		// released artifacts, so they must be the same key. Keeping both copies
+		// in step is otherwise a silent, release-only failure.
+		let manifest = include_str!("../Cargo.toml");
+		let expected = format!("pubkey = \"{RELEASE_PUBLIC_KEY}\"");
+		assert!(
+			manifest.contains(&expected),
+			"RELEASE_PUBLIC_KEY must match the binstall signing pubkey in Cargo.toml"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Self-update rejected every signed release with `release signature did not verify: The signature was created with a different key than the one provided`.

## Root cause

The public key baked into the binary — both `RELEASE_PUBLIC_KEY` in `download.rs` (used by self-update) and the binstall `pubkey` in `Cargo.toml` — was an unrelated keypair from the one that actually signs releases in CI:

| | key ID |
|---|---|
| Embedded in the binary | `5BA09775CEEC28B5` |
| CI signing key (`SIGNING_KEY` secret) | `A7A94663BE3FA2FE` |

Verified end-to-end: the published 1.37.3 artifact verifies against the real signing key and is rejected by the old embedded key with exactly the key-ID error above.

## Changes

- Point both embedded copies at the real public key (id `A7A94663BE3FA2FE`).
- Release workflow: after signing, verify each artifact against the key embedded in `download.rs` before any upload, so a future key mismatch fails the release instead of publishing an un-updatable build.
- Unit test tying `RELEASE_PUBLIC_KEY` to the binstall `pubkey` so the two in-binary copies can't drift.

## Rollout caveat

Already-deployed binaries embed the wrong key, so they can't self-update or binstall to the fixed version (both verify against the bad embedded key). Windows hosts need a corrected binary pushed via a non-verifying path (apt `.deb`, or manual/ansible) before self-update heals going forward.
