### PR TITLE
refactor(canopy): use generated schema types; fix OpenAPI fetch

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,6 +30,19 @@ jobs:
           rustup default stable
       - id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@v1.0.4
+      - name: Refresh canopy OpenAPI snapshot for packaging
+        # Ship a current schema in the published bestool-canopy crate, so its
+        # offline / docs.rs consumers (which can't fetch live) don't get a stale
+        # committed snapshot. Written but not committed; publish_allow_dirty in
+        # release-plz.toml lets it be packaged. Keep the URL in step with
+        # SPEC_URL in crates/canopy/build.rs. Non-fatal: on a fetch blip the
+        # committed snapshot is published instead.
+        run: |
+          if curl -fsS --max-time 30 https://meta.tamanu.app/api/openapi.json -o /tmp/canopy-openapi.json; then
+            mv /tmp/canopy-openapi.json crates/canopy/openapi.snapshot.json
+          else
+            echo "::warning::canopy OpenAPI refresh failed; publishing the committed snapshot"
+          fi
       - uses: MarcoIeni/release-plz-action@v0.5.130
         with:
           command: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,6 @@ dependencies = [
  "tokio",
  "tracing",
  "typify",
- "ureq",
  "uuid",
 ]
 
@@ -5848,6 +5847,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -8050,34 +8050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64 0.22.1",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8089,12 +8061,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -24,8 +24,9 @@ use std::{
 };
 
 use bestool_canopy::{
-	BackupReport, CanopyClient, DEFAULT_CANOPY_URL, Outcome, Purpose, TargetOutcome,
+	CanopyClient, DEFAULT_CANOPY_URL, TargetOutcome,
 	registration::Registration,
+	schema::{BackupPurpose, ReportArgs, RunOutcome},
 };
 use bestool_kopia::{
 	RunAs, S3KopiaEnv, args_policy_set_ignores, args_repository_connect_s3, args_snapshot_create,
@@ -279,7 +280,7 @@ pub(super) async fn spawn_proxy(
 	client: Arc<CanopyClient>,
 	base_url: Url,
 	backup_type: String,
-	purpose: Purpose,
+	purpose: BackupPurpose,
 	region: &str,
 ) -> Result<RunningProxy> {
 	let provider = Arc::new(CanopyCredentialProvider::new(
@@ -335,7 +336,7 @@ async fn upstream_host_for(region: &str) -> String {
 pub(super) async fn connect_repo(
 	kopia: &Path,
 	s3env: &S3KopiaEnv<'_>,
-	target: &bestool_canopy::BackupTarget,
+	target: &bestool_canopy::schema::BackupTarget,
 	endpoint: &str,
 	server_id: &str,
 	run_as: RunAs,
@@ -442,7 +443,7 @@ async fn backup_after_start(
 		client.clone(),
 		base_url.clone(),
 		backup_type.to_owned(),
-		Purpose::Backup,
+		BackupPurpose::Backup,
 		&target.region,
 	)
 	.await?;
@@ -483,26 +484,30 @@ async fn backup_after_start(
 	let s3_sent_payload_bytes = Some(to_i64(traffic.sent_payload));
 	let s3_received_raw_bytes = Some(to_i64(traffic.received_raw));
 	let s3_received_payload_bytes = Some(to_i64(traffic.received_payload));
+	let run_uuid: Uuid = run_id
+		.parse()
+		.into_diagnostic()
+		.wrap_err("backup run_id is not a valid uuid")?;
 	let report = match &outcome {
-		Ok(snapshot) => BackupReport {
-			run_id,
-			r#type: backup_type,
-			purpose: Purpose::Backup,
-			outcome: Outcome::Success,
+		Ok(snapshot) => ReportArgs {
+			run_id: run_uuid,
+			type_: backup_type.to_owned(),
+			purpose: BackupPurpose::Backup,
+			outcome: RunOutcome::Success,
 			error: None,
 			bytes_uploaded: snapshot.bytes_uploaded,
-			snapshot_id: snapshot.id.as_deref(),
+			snapshot_id: snapshot.id.clone(),
 			s3_sent_raw_bytes,
 			s3_sent_payload_bytes,
 			s3_received_raw_bytes,
 			s3_received_payload_bytes,
 		},
-		Err(err) => BackupReport {
-			run_id,
-			r#type: backup_type,
-			purpose: Purpose::Backup,
-			outcome: Outcome::Failure,
-			error: Some(&trim_error(err)),
+		Err(err) => ReportArgs {
+			run_id: run_uuid,
+			type_: backup_type.to_owned(),
+			purpose: BackupPurpose::Backup,
+			outcome: RunOutcome::Failure,
+			error: Some(trim_error(err)),
 			bytes_uploaded: None,
 			snapshot_id: None,
 			s3_sent_raw_bytes,
@@ -545,7 +550,7 @@ async fn backup_after_start(
 /// always runs cleanup + post even when the snapshot fails.
 async fn run_kopia_backup(
 	def: &BackupDef,
-	target: &bestool_canopy::BackupTarget,
+	target: &bestool_canopy::schema::BackupTarget,
 	conn: &RepoConn,
 	server_id: &str,
 	device_id: Option<&str>,
@@ -587,7 +592,7 @@ async fn run_kopia_backup(
 
 /// Connect to the repo and create the snapshot.
 async fn snapshot(
-	target: &bestool_canopy::BackupTarget,
+	target: &bestool_canopy::schema::BackupTarget,
 	conn: &RepoConn,
 	source_path: &Path,
 	server_id: &str,

--- a/crates/bestool/src/actions/canopy/backup/provider.rs
+++ b/crates/bestool/src/actions/canopy/backup/provider.rs
@@ -8,7 +8,10 @@
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
-use bestool_canopy::{BackupCredentials, CanopyClient, Purpose};
+use bestool_canopy::{
+	CanopyClient,
+	schema::{BackupPurpose, CredentialProcessOutput},
+};
 use bestool_kopia::proxy::{BoxError, CredentialProvider, Credentials};
 use futures::future::BoxFuture;
 use jiff::{Timestamp, ToSpan};
@@ -21,12 +24,12 @@ const REFRESH_MARGIN_MINUTES: i64 = 2;
 /// Fetches a fresh set of creds from Canopy. Boxed so the provider is testable
 /// without a live `CanopyClient`.
 type Refresher =
-	Arc<dyn Fn() -> BoxFuture<'static, Result<BackupCredentials, String>> + Send + Sync>;
+	Arc<dyn Fn() -> BoxFuture<'static, Result<CredentialProcessOutput, String>> + Send + Sync>;
 
 /// A [`CredentialProvider`] that draws backup credentials from Canopy.
 pub struct CanopyCredentialProvider {
 	refresh: Refresher,
-	cached: Mutex<Option<BackupCredentials>>,
+	cached: Mutex<Option<CredentialProcessOutput>>,
 }
 
 impl CanopyCredentialProvider {
@@ -36,7 +39,7 @@ impl CanopyCredentialProvider {
 		client: Arc<CanopyClient>,
 		base_url: Url,
 		backup_type: String,
-		purpose: Purpose,
+		purpose: BackupPurpose,
 	) -> Self {
 		let refresh: Refresher = Arc::new(move || {
 			let client = client.clone();
@@ -61,7 +64,7 @@ impl CanopyCredentialProvider {
 }
 
 /// Whether cached creds are absent or within the refresh margin of expiry.
-fn needs_refresh(cached: &Option<BackupCredentials>, now: Timestamp) -> bool {
+fn needs_refresh(cached: &Option<CredentialProcessOutput>, now: Timestamp) -> bool {
 	match cached {
 		None => true,
 		Some(creds) => creds.expiration <= now + REFRESH_MARGIN_MINUTES.minutes(),
@@ -96,7 +99,7 @@ mod tests {
 
 	use super::*;
 
-	fn creds_expiring(expiration: &str) -> BackupCredentials {
+	fn creds_expiring(expiration: &str) -> CredentialProcessOutput {
 		serde_json::from_value(json!({
 			"Version": 1,
 			"AccessKeyId": "AKIA",

--- a/crates/bestool/src/actions/canopy/register.rs
+++ b/crates/bestool/src/actions/canopy/register.rs
@@ -8,6 +8,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bestool_canopy::{
 	TAILSCALE_URL, device_identity,
 	registration::{self, Registration},
+	schema::{BeginArgs, BeginResponse, CompleteArgs, CompleteResponse},
 	tailscale_client,
 };
 use bestool_tamanu::server_info::generate_device_key_pem;
@@ -19,7 +20,7 @@ use p256::{
 	elliptic_curve::pkcs8::{DecodePrivateKey as _, EncodePublicKey as _},
 };
 use reqwest::Url;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -66,34 +67,6 @@ struct EnrollTicket {
 	token: String,
 }
 
-#[derive(Serialize)]
-pub(crate) struct BeginRequest<'a> {
-	pub(crate) server_id: &'a str,
-	pub(crate) token: &'a str,
-	/// DER SubjectPublicKeyInfo (base64), sent only over the tailscale path
-	/// where there's no client cert for canopy to read it from.
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub(crate) spki: Option<&'a str>,
-}
-
-#[derive(Deserialize)]
-pub(crate) struct BeginResponse {
-	pub(crate) nonce: String,
-	#[serde(default)]
-	pub(crate) channel_binding_required: bool,
-}
-
-#[derive(Serialize)]
-pub(crate) struct CompleteRequest<'a> {
-	pub(crate) server_id: &'a str,
-	pub(crate) nonce: &'a str,
-	pub(crate) signature: &'a str,
-	/// DER SubjectPublicKeyInfo (base64), sent only over the tailscale path
-	/// where there's no client cert for canopy to read it from.
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub(crate) spki: Option<&'a str>,
-}
-
 /// Which network path the enrollment handshake takes.
 ///
 /// Mirrors the rest of bestool's canopy traffic: prefer the tailnet when it's
@@ -131,12 +104,6 @@ impl Transport {
 				.wrap_err_with(|| format!("building register/{step} URL")),
 		}
 	}
-}
-
-#[derive(Deserialize)]
-pub(crate) struct CompleteResponse {
-	pub(crate) server_id: String,
-	pub(crate) device_id: String,
 }
 
 /// RFC-7807-style problem body. Canopy's register errors are intentionally
@@ -248,14 +215,7 @@ pub async fn run(args: RegisterArgs, _ctx: Context) -> Result<()> {
 	let spki_b64 = STANDARD.encode(&spki_der);
 
 	// Step 1: begin — fetch the challenge nonce. The token isn't consumed here.
-	let begin = begin(
-		&transport,
-		&api_url,
-		&ticket.server_id,
-		&ticket.token,
-		&spki_b64,
-	)
-	.await?;
+	let begin = begin(&transport, &api_url, server_id, &ticket.token, &spki_b64).await?;
 	if begin.channel_binding_required {
 		bail!(
 			"this Canopy server requires TLS channel binding, which this version of bestool does not support yet"
@@ -274,7 +234,7 @@ pub async fn run(args: RegisterArgs, _ctx: Context) -> Result<()> {
 	let complete = complete(
 		&transport,
 		&api_url,
-		&ticket.server_id,
+		server_id,
 		&begin.nonce,
 		&signature_b64,
 		&spki_b64,
@@ -283,9 +243,9 @@ pub async fn run(args: RegisterArgs, _ctx: Context) -> Result<()> {
 
 	// Persist the result so the agent knows it's bound and where to report.
 	let registration = Registration {
-		server_id: Some(complete.server_id.clone()),
+		server_id: Some(complete.server_id.to_string()),
 		device_key: Some(device_key_pem),
-		device_id: Some(complete.device_id.clone()),
+		device_id: Some(complete.device_id.to_string()),
 		api_url: Some(api_url.to_string()),
 		..Registration::default()
 	};
@@ -352,7 +312,7 @@ fn build_transcript(nonce: &[u8], server_id: &Uuid, spki_der: &[u8]) -> Vec<u8> 
 async fn begin(
 	transport: &Transport,
 	api_url: &Url,
-	server_id: &str,
+	server_id: Uuid,
 	token: &str,
 	spki: &str,
 ) -> Result<BeginResponse> {
@@ -360,10 +320,12 @@ async fn begin(
 	let resp = transport
 		.client()
 		.post(url)
-		.json(&BeginRequest {
+		.json(&BeginArgs {
 			server_id,
-			token,
-			spki: transport.carries_spki_in_body().then_some(spki),
+			token: token.to_owned(),
+			spki: transport
+				.carries_spki_in_body()
+				.then(|| spki.to_owned()),
 		})
 		.send()
 		.await
@@ -375,7 +337,7 @@ async fn begin(
 async fn complete(
 	transport: &Transport,
 	api_url: &Url,
-	server_id: &str,
+	server_id: Uuid,
 	nonce: &str,
 	signature: &str,
 	spki: &str,
@@ -384,11 +346,13 @@ async fn complete(
 	let resp = transport
 		.client()
 		.post(url)
-		.json(&CompleteRequest {
+		.json(&CompleteArgs {
 			server_id,
-			nonce,
-			signature,
-			spki: transport.carries_spki_in_body().then_some(spki),
+			nonce: nonce.to_owned(),
+			signature: signature.to_owned(),
+			spki: transport
+				.carries_spki_in_body()
+				.then(|| spki.to_owned()),
 		})
 		.send()
 		.await

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -11,7 +11,7 @@ use std::{
 	path::PathBuf,
 };
 
-use bestool_canopy::{Purpose, TargetOutcome};
+use bestool_canopy::{TargetOutcome, schema::BackupPurpose};
 use bestool_kopia::{
 	RunAs, S3KopiaEnv, Snapshot, args_snapshot_list, args_snapshot_restore,
 	build_kopia_command_with_s3, find_kopia_binary,
@@ -101,7 +101,7 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		client.clone(),
 		base_url.clone(),
 		args.backup_type.clone(),
-		Purpose::Restore,
+		BackupPurpose::Restore,
 		&target.region,
 	)
 	.await?;

--- a/crates/bestool/src/canopy_contract.rs
+++ b/crates/bestool/src/canopy_contract.rs
@@ -14,17 +14,15 @@
 
 use std::collections::BTreeMap;
 
-use bestool_canopy::{
-	BackupCredentials, BackupCredentialsRequest, BackupReport, BackupTarget, CapabilitiesRequest,
-	NewEvent, Outcome, Purpose, Severity,
+use bestool_canopy::schema::{
+	BackupPurpose, BackupTarget, BeginArgs, BeginResponse, CapabilitiesArgs, CompleteArgs,
+	CompleteResponse, CredentialProcessOutput, CredentialsArgs, NewEvent, ReportArgs, RunOutcome,
+	Severity,
 };
 use serde_json::{Value, json};
 use tokio::sync::OnceCell;
 
-use crate::actions::{
-	canopy::register::{BeginRequest, BeginResponse, CompleteRequest, CompleteResponse},
-	tamanu::{artifacts::Artifact, psql::Snippet},
-};
+use crate::actions::tamanu::{artifacts::Artifact, psql::Snippet};
 
 const SPEC_URL: &str = "https://meta.tamanu.app/api/openapi.json";
 
@@ -123,10 +121,10 @@ async fn events_request_matches_spec() {
 	assert_operation_exists(spec, "/events", "post");
 
 	let event = NewEvent {
-		source: "bestool-contract-test",
-		r#ref: "host/alert:target",
-		message: "message",
-		description: Some("description"),
+		source: "bestool-contract-test".to_owned(),
+		ref_: "host/alert:target".to_owned(),
+		message: "message".to_owned(),
+		description: Some("description".to_owned()),
 		severity: Some(Severity::Warning),
 		occurred_at: Some("2026-01-01T00:00:00Z".parse().unwrap()),
 		active: Some(true),
@@ -232,10 +230,10 @@ async fn register_begin_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/servers/register/begin", "post");
 
-	let request = BeginRequest {
-		server_id: "00000000-0000-0000-0000-000000000000",
-		token: "enrollment-token",
-		spki: Some("c3BraQ=="),
+	let request = BeginArgs {
+		server_id: "00000000-0000-0000-0000-000000000000".parse().unwrap(),
+		token: "enrollment-token".to_owned(),
+		spki: Some("c3BraQ==".to_owned()),
 	};
 	let instance = serde_json::to_value(&request).unwrap();
 	assert_valid(
@@ -261,10 +259,10 @@ async fn register_complete_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/servers/register/complete", "post");
 
-	let request = CompleteRequest {
-		server_id: "00000000-0000-0000-0000-000000000000",
-		nonce: "bm9uY2U=",
-		signature: "c2lnbmF0dXJl",
+	let request = CompleteArgs {
+		server_id: "00000000-0000-0000-0000-000000000000".parse().unwrap(),
+		nonce: "bm9uY2U=".to_owned(),
+		signature: "c2lnbmF0dXJl".to_owned(),
 		spki: None,
 	};
 	let instance = serde_json::to_value(&request).unwrap();
@@ -284,8 +282,14 @@ async fn register_complete_matches_spec() {
 		&sample,
 	);
 	let decoded: CompleteResponse = serde_json::from_value(sample).unwrap();
-	assert_eq!(decoded.server_id, "00000000-0000-0000-0000-000000000000");
-	assert_eq!(decoded.device_id, "11111111-1111-1111-1111-111111111111");
+	assert_eq!(
+		decoded.server_id.to_string(),
+		"00000000-0000-0000-0000-000000000000"
+	);
+	assert_eq!(
+		decoded.device_id.to_string(),
+		"11111111-1111-1111-1111-111111111111"
+	);
 }
 
 #[tokio::test]
@@ -357,7 +361,7 @@ async fn backup_capabilities_request_matches_spec() {
 	assert_operation_exists(spec, "/backup-capabilities", "post");
 
 	let types = vec!["tamanu-postgres".to_owned()];
-	let instance = serde_json::to_value(CapabilitiesRequest { types: &types }).unwrap();
+	let instance = serde_json::to_value(CapabilitiesArgs { types }).unwrap();
 	assert_valid(
 		spec,
 		&request_schema("/backup-capabilities", "post"),
@@ -371,9 +375,9 @@ async fn backup_credentials_request_and_response_match_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/backup-credentials", "post");
 
-	let instance = serde_json::to_value(BackupCredentialsRequest {
-		r#type: "tamanu-postgres",
-		purpose: Purpose::Backup,
+	let instance = serde_json::to_value(CredentialsArgs {
+		type_: "tamanu-postgres".to_owned(),
+		purpose: Some(BackupPurpose::Backup),
 	})
 	.unwrap();
 	assert_valid(
@@ -405,7 +409,7 @@ async fn backup_credentials_request_and_response_match_spec() {
 		&response_schema("/backup-credentials", "post"),
 		&sample,
 	);
-	let decoded: BackupCredentials = serde_json::from_value(sample).unwrap();
+	let decoded: CredentialProcessOutput = serde_json::from_value(sample).unwrap();
 	assert_eq!(decoded.version, 1);
 	assert_eq!(&*decoded.session_token, "token");
 }
@@ -435,14 +439,14 @@ async fn backup_report_request_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/backup-report", "post");
 
-	let instance = serde_json::to_value(BackupReport {
-		run_id: "00000000-0000-0000-0000-000000000000",
-		r#type: "tamanu-postgres",
-		purpose: Purpose::Backup,
-		outcome: Outcome::Success,
+	let instance = serde_json::to_value(ReportArgs {
+		run_id: "00000000-0000-0000-0000-000000000000".parse().unwrap(),
+		type_: "tamanu-postgres".to_owned(),
+		purpose: BackupPurpose::Backup,
+		outcome: RunOutcome::Success,
 		error: None,
 		bytes_uploaded: Some(12345),
-		snapshot_id: Some("abc123"),
+		snapshot_id: Some("abc123".to_owned()),
 		// Intentionally populated: this gates the PR. bestool already sends these
 		// (canopy ignores unknown fields), but the contract check stays red until
 		// canopy's OpenAPI spec defines the s3 traffic fields — then it goes green.

--- a/crates/canopy/Cargo.toml
+++ b/crates/canopy/Cargo.toml
@@ -37,9 +37,9 @@ tempfile = "3.21.0"
 
 [build-dependencies]
 prettyplease = "0.2.37"
+reqwest = { workspace = true, features = ["blocking"] }
 schemars = "0.8.22"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 syn = "2.0.118"
 typify = "0.7.0"
-ureq = { version = "3.1.2", default-features = false, features = ["rustls"] }

--- a/crates/canopy/build.rs
+++ b/crates/canopy/build.rs
@@ -52,18 +52,68 @@ fn main() {
 		.expect("generating types from canopy schemas");
 
 	let file = syn::parse2(type_space.to_stream()).expect("parsing generated canopy schema tokens");
-	let generated = prettyplease::unparse(&file).replace(
-		"::chrono::DateTime<::chrono::offset::Utc>",
-		"::jiff::Timestamp",
-	);
-	assert!(
-		!generated.contains("chrono"),
-		"generated canopy schema still references chrono after rewrite to jiff"
-	);
+	let generated = rewrite_types(&prettyplease::unparse(&file));
 
 	let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR is set for build scripts");
 	fs::write(Path::new(&out_dir).join("canopy_schema.rs"), generated)
 		.expect("writing generated canopy schema");
+}
+
+/// Post-process the generated wire types.
+///
+/// typify emits every field as a plain type from the JSON Schema, which loses
+/// two properties bestool relies on: timestamps should be `jiff::Timestamp`
+/// (canopy models them as `date-time` strings, or bare strings for the
+/// credential expiry), and credential secrets must not be printable. This
+/// rewrites those fields in the generated source: `date-time` fields and the
+/// credential expiry become `jiff::Timestamp`, and each secret field is wrapped
+/// in [`crate::Redacted`] so it stays out of `Debug` output and logs.
+///
+/// The rewrites are string substitutions keyed on the exact field lines typify
+/// produces. The asserts below fail the build if a substitution stops matching
+/// — a schema or codegen change that silently dropped redaction would otherwise
+/// compile clean.
+fn rewrite_types(generated: &str) -> String {
+	let generated = generated
+		.replace(
+			"::chrono::DateTime<::chrono::offset::Utc>",
+			"::jiff::Timestamp",
+		)
+		.replace(
+			"pub expiration: ::std::string::String,",
+			"pub expiration: ::jiff::Timestamp,",
+		)
+		.replace(
+			"pub secret_access_key: ::std::string::String,",
+			"pub secret_access_key: crate::Redacted<::std::string::String>,",
+		)
+		.replace(
+			"pub session_token: ::std::string::String,",
+			"pub session_token: crate::Redacted<::std::string::String>,",
+		)
+		.replace(
+			"pub repo_password: ::std::string::String,",
+			"pub repo_password: crate::Redacted<::std::string::String>,",
+		);
+
+	assert!(
+		!generated.contains("chrono"),
+		"generated canopy schema still references chrono after rewrite to jiff"
+	);
+	for needle in [
+		"pub expiration: ::jiff::Timestamp,",
+		"pub secret_access_key: crate::Redacted<::std::string::String>,",
+		"pub session_token: crate::Redacted<::std::string::String>,",
+		"pub repo_password: crate::Redacted<::std::string::String>,",
+	] {
+		assert!(
+			generated.contains(needle),
+			"canopy schema rewrite did not apply; expected `{needle}` in the generated source \
+			 (did canopy's OpenAPI field names change?)"
+		);
+	}
+
+	generated
 }
 
 fn fetch_live() -> Result<String, ureq::Error> {

--- a/crates/canopy/build.rs
+++ b/crates/canopy/build.rs
@@ -1,12 +1,18 @@
 //! Generates the `schema` module from canopy's OpenAPI document.
 //!
-//! The document is fetched live from the running canopy deployment, falling
-//! back to the committed snapshot when the network is unavailable (offline or
-//! sealed CI builds). Its `components.schemas` are wrapped into a JSON-Schema
-//! root document and handed to typify, which emits the wire types. The result
-//! is written to `OUT_DIR` and `include!`d by the crate — nothing generated is
-//! committed, so canopy adding a field changes no committed source and never
-//! triggers a republish.
+//! The document is fetched live from the running canopy deployment so the wire
+//! types track canopy as it evolves, with nothing generated committed — canopy
+//! adding a field changes no committed source and never triggers a republish.
+//! Its `components.schemas` are wrapped into a JSON-Schema root document and
+//! handed to typify, which emits the wire types; the result is written to
+//! `OUT_DIR` and `include!`d by the crate.
+//!
+//! A failed fetch is a **hard error** by default, rather than a silent fall back
+//! to a possibly-stale snapshot: `cargo:warning` is hidden for dependencies, so
+//! silently falling back would let a downstream build ship stale types with no
+//! signal. The committed snapshot is used only where a live fetch is impossible
+//! by design — docs.rs builds (which set `DOCS_RS`) and builds that explicitly
+//! opt in with `CANOPY_OPENAPI_OFFLINE`.
 
 use std::{env, fs, path::Path, time::Duration};
 
@@ -14,20 +20,37 @@ use schemars::schema::RootSchema;
 use serde_json::Value;
 use typify::{TypeSpace, TypeSpaceSettings};
 
+// Kept in step with the snapshot-refresh step in .github/workflows/release-plz.yml.
 const SPEC_URL: &str = "https://meta.tamanu.app/api/openapi.json";
 const SNAPSHOT: &str = "openapi.snapshot.json";
 const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// docs.rs sets this in its (network-less) build environment.
+const DOCS_RS_ENV: &str = "DOCS_RS";
+/// Explicit opt-in to the committed snapshot for offline / sealed builds.
+const OFFLINE_ENV: &str = "CANOPY_OPENAPI_OFFLINE";
+
 fn main() {
 	println!("cargo:rerun-if-changed=build.rs");
 	println!("cargo:rerun-if-changed={SNAPSHOT}");
+	println!("cargo:rerun-if-env-changed={DOCS_RS_ENV}");
+	println!("cargo:rerun-if-env-changed={OFFLINE_ENV}");
 
-	let spec_text = fetch_live().unwrap_or_else(|err| {
-		println!(
-			"cargo:warning=canopy OpenAPI live fetch failed ({err}); using committed snapshot"
-		);
-		fs::read_to_string(SNAPSHOT).expect("reading canopy OpenAPI snapshot")
-	});
+	let spec_text = match fetch_live() {
+		Ok(text) => text,
+		Err(err) if snapshot_allowed() => {
+			println!(
+				"cargo:warning=canopy OpenAPI live fetch failed ({err}); using committed snapshot"
+			);
+			fs::read_to_string(SNAPSHOT).expect("reading canopy OpenAPI snapshot")
+		}
+		Err(err) => panic!(
+			"canopy OpenAPI live fetch from {SPEC_URL} failed: {err}\n\
+			 The generated schema tracks canopy live, so this build cannot proceed with a \
+			 possibly-stale snapshot. Fix connectivity to canopy, or set {OFFLINE_ENV}=1 to \
+			 build against the committed {SNAPSHOT} instead."
+		),
+	};
 
 	let spec: Value = serde_json::from_str(&spec_text).expect("parsing canopy OpenAPI document");
 	let schemas = spec
@@ -116,10 +139,18 @@ fn rewrite_types(generated: &str) -> String {
 	generated
 }
 
-fn fetch_live() -> Result<String, ureq::Error> {
-	let config = ureq::Agent::config_builder()
-		.timeout_global(Some(FETCH_TIMEOUT))
-		.build();
-	let agent: ureq::Agent = config.into();
-	agent.get(SPEC_URL).call()?.body_mut().read_to_string()
+/// Whether a failed live fetch may fall back to the committed snapshot: only on
+/// docs.rs or when an offline build is explicitly requested.
+fn snapshot_allowed() -> bool {
+	env::var_os(DOCS_RS_ENV).is_some() || env::var_os(OFFLINE_ENV).is_some()
+}
+
+fn fetch_live() -> Result<String, reqwest::Error> {
+	reqwest::blocking::Client::builder()
+		.timeout(FETCH_TIMEOUT)
+		.build()?
+		.get(SPEC_URL)
+		.send()?
+		.error_for_status()?
+		.text()
 }

--- a/crates/canopy/src/backup.rs
+++ b/crates/canopy/src/backup.rs
@@ -1,62 +1,19 @@
-//! Wire types for Canopy's backup-credentials endpoints.
+//! Backup-specific types that aren't part of canopy's wire contract.
 //!
-//! These mirror the canopy public-server contract (`CapabilitiesArgs`,
-//! `CredentialsArgs`, `ReportArgs`, `CredentialProcessOutput`, `BackupTarget`).
-//! The device fetches short-lived S3 creds and the repo target from Canopy on
-//! each run, then serves the creds to kopia's minio-go provider in the
-//! [`ContainerCreds`] shape (note `Token`, not `SessionToken`).
+//! The request and response bodies for the backup endpoints are generated from
+//! canopy's OpenAPI document — see the [`schema`](crate::schema) module. This
+//! module holds the two shapes that don't map onto a schema type: the container
+//! credentials kopia's minio-go provider polls for, and the local result of a
+//! [`GET /backup-target`](crate::CanopyClient::backup_target) that folds the
+//! dormant device state into an enum.
 
 use jiff::Timestamp;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-use crate::Redacted;
-
-/// Why a credential was issued / a run executed.
-///
-/// A real capability gate on the issued S3 creds: `backup` grants
-/// write-without-delete, `restore` grants read-only.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Purpose {
-	#[default]
-	Backup,
-	Restore,
-}
-
-/// Outcome of a reported backup/restore run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Outcome {
-	Success,
-	Failure,
-}
-
-/// Body for `POST /backup-capabilities`: the backup types this server can run.
-#[derive(Debug, Clone, Serialize)]
-pub struct CapabilitiesRequest<'a> {
-	pub types: &'a [String],
-}
-
-/// Body for `POST /backup-credentials`.
-#[derive(Debug, Clone, Serialize)]
-pub struct BackupCredentialsRequest<'a> {
-	pub r#type: &'a str,
-	pub purpose: Purpose,
-}
-
-/// `credential_process`-shaped creds returned by `POST /backup-credentials`.
-///
-/// Field names are fixed by the AWS SDK (PascalCase). The driver translates
-/// these into the [`ContainerCreds`] shape kopia's minio-go provider polls for.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct BackupCredentials {
-	pub version: u32,
-	pub access_key_id: String,
-	pub secret_access_key: Redacted<String>,
-	pub session_token: Redacted<String>,
-	pub expiration: Timestamp,
-}
+use crate::{
+	Redacted,
+	schema::{BackupTarget, CredentialProcessOutput},
+};
 
 /// Creds in the ECS container-credentials shape kopia's minio-go provider polls
 /// for: note **`Token`** (not `SessionToken`), and `Expiration` as RFC3339 `Z`.
@@ -69,8 +26,8 @@ pub struct ContainerCreds {
 	pub expiration: Timestamp,
 }
 
-impl From<&BackupCredentials> for ContainerCreds {
-	fn from(c: &BackupCredentials) -> Self {
+impl From<&CredentialProcessOutput> for ContainerCreds {
+	fn from(c: &CredentialProcessOutput) -> Self {
 		Self {
 			access_key_id: c.access_key_id.clone(),
 			secret_access_key: c.secret_access_key.clone(),
@@ -80,53 +37,13 @@ impl From<&BackupCredentials> for ContainerCreds {
 	}
 }
 
-/// The S3 repo target returned by `GET /backup-target`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct BackupTarget {
-	/// Always `"s3"`.
-	pub storage: String,
-	pub bucket: String,
-	/// Normally empty (the repo lives at the bucket root).
-	#[serde(default)]
-	pub prefix: String,
-	pub region: String,
-	pub repo_password: Redacted<String>,
-}
-
-/// Result of `GET /backup-target`: a live target, or the benign dormant state
-/// (the device is not yet authorised for backups — `412`/`409`).
+/// Result of [`GET /backup-target`](crate::CanopyClient::backup_target): a live
+/// target, or the benign dormant state (the device is not yet authorised for
+/// backups — `412`/`409`).
 #[derive(Debug, Clone)]
 pub enum TargetOutcome {
 	Ready(BackupTarget),
 	Dormant,
-}
-
-/// Body for `POST /backup-report`.
-#[derive(Debug, Clone, Serialize)]
-pub struct BackupReport<'a> {
-	/// The run-uuid bestool minted at run start (becomes `backup_runs.id`).
-	pub run_id: &'a str,
-	pub r#type: &'a str,
-	pub purpose: Purpose,
-	pub outcome: Outcome,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub error: Option<&'a str>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub bytes_uploaded: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub snapshot_id: Option<&'a str>,
-	/// S3 traffic the run accounted for, measured by the re-signing proxy. `*_raw`
-	/// is the full HTTP message (headers + on-the-wire body incl. SigV4 chunk
-	/// framing); `*_payload` is the decoded object data. A rough per-deployment
-	/// network/S3 measure; distinct from `bytes_uploaded` (kopia's own figure).
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_sent_raw_bytes: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_sent_payload_bytes: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_received_raw_bytes: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_received_payload_bytes: Option<i64>,
 }
 
 #[cfg(test)]
@@ -136,83 +53,15 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn purpose_serialises_lowercase() {
-		assert_eq!(
-			serde_json::to_value(Purpose::Backup).unwrap(),
-			json!("backup")
-		);
-		assert_eq!(
-			serde_json::to_value(Purpose::Restore).unwrap(),
-			json!("restore")
-		);
-	}
-
-	#[test]
-	fn purpose_defaults_to_backup() {
-		assert_eq!(Purpose::default(), Purpose::Backup);
-	}
-
-	#[test]
-	fn outcome_serialises_lowercase() {
-		assert_eq!(
-			serde_json::to_value(Outcome::Success).unwrap(),
-			json!("success")
-		);
-		assert_eq!(
-			serde_json::to_value(Outcome::Failure).unwrap(),
-			json!("failure")
-		);
-	}
-
-	#[test]
-	fn credentials_request_carries_type_and_purpose() {
-		let req = BackupCredentialsRequest {
-			r#type: "tamanu-postgres",
-			purpose: Purpose::Backup,
-		};
-		assert_eq!(
-			serde_json::to_value(&req).unwrap(),
-			json!({"type": "tamanu-postgres", "purpose": "backup"})
-		);
-	}
-
-	#[test]
-	fn capabilities_request_lists_types() {
-		let types = vec!["tamanu-postgres".to_owned(), "files".to_owned()];
-		let req = CapabilitiesRequest { types: &types };
-		assert_eq!(
-			serde_json::to_value(&req).unwrap(),
-			json!({"types": ["tamanu-postgres", "files"]})
-		);
-	}
-
-	#[test]
-	fn backup_credentials_deserialise_from_credential_process_shape() {
-		let body = json!({
-			"Version": 1,
-			"AccessKeyId": "AKIA",
-			"SecretAccessKey": "secret",
-			"SessionToken": "token",
-			"Expiration": "2026-05-21T13:00:00Z",
-		});
-		let creds: BackupCredentials = serde_json::from_value(body).unwrap();
-		assert_eq!(creds.version, 1);
-		assert_eq!(creds.access_key_id, "AKIA");
-		assert_eq!(&*creds.secret_access_key, "secret");
-		assert_eq!(&*creds.session_token, "token");
-		assert_eq!(creds.expiration.to_string(), "2026-05-21T13:00:00Z");
-	}
-
-	#[test]
 	fn container_creds_translate_session_token_to_token() {
-		let body = json!({
+		let creds: CredentialProcessOutput = serde_json::from_value(json!({
 			"Version": 1,
 			"AccessKeyId": "AKIA",
 			"SecretAccessKey": "secret",
 			"SessionToken": "session-token",
 			"Expiration": "2026-05-21T13:00:00Z",
-		});
-		let creds: BackupCredentials = serde_json::from_value(body).unwrap();
+		}))
+		.unwrap();
 		let container = ContainerCreds::from(&creds);
 		let out = serde_json::to_value(&container).unwrap();
 		assert_eq!(
@@ -226,82 +75,6 @@ mod tests {
 		);
 		// No SessionToken key leaks through.
 		assert!(out.get("SessionToken").is_none());
-	}
-
-	#[test]
-	fn backup_target_deserialises() {
-		let body = json!({
-			"storage": "s3",
-			"bucket": "my-bucket",
-			"prefix": "",
-			"region": "ap-southeast-2",
-			"repo_password": "hunter2",
-		});
-		let target: BackupTarget = serde_json::from_value(body).unwrap();
-		assert_eq!(target.storage, "s3");
-		assert_eq!(target.bucket, "my-bucket");
-		assert_eq!(target.prefix, "");
-		assert_eq!(target.region, "ap-southeast-2");
-		assert_eq!(&*target.repo_password, "hunter2");
-	}
-
-	#[test]
-	fn backup_report_omits_optional_fields() {
-		let report = BackupReport {
-			run_id: "11111111-1111-1111-1111-111111111111",
-			r#type: "tamanu-postgres",
-			purpose: Purpose::Backup,
-			outcome: Outcome::Success,
-			error: None,
-			bytes_uploaded: None,
-			snapshot_id: None,
-			s3_sent_raw_bytes: None,
-			s3_sent_payload_bytes: None,
-			s3_received_raw_bytes: None,
-			s3_received_payload_bytes: None,
-		};
-		assert_eq!(
-			serde_json::to_value(&report).unwrap(),
-			json!({
-				"run_id": "11111111-1111-1111-1111-111111111111",
-				"type": "tamanu-postgres",
-				"purpose": "backup",
-				"outcome": "success",
-			})
-		);
-	}
-
-	#[test]
-	fn backup_report_includes_failure_fields() {
-		let report = BackupReport {
-			run_id: "run",
-			r#type: "tamanu-postgres",
-			purpose: Purpose::Backup,
-			outcome: Outcome::Failure,
-			error: Some("kopia exploded"),
-			bytes_uploaded: Some(42),
-			snapshot_id: Some("snap"),
-			s3_sent_raw_bytes: Some(2048),
-			s3_sent_payload_bytes: Some(1024),
-			s3_received_raw_bytes: Some(64),
-			s3_received_payload_bytes: Some(0),
-		};
-		assert_eq!(
-			serde_json::to_value(&report).unwrap(),
-			json!({
-				"run_id": "run",
-				"type": "tamanu-postgres",
-				"purpose": "backup",
-				"outcome": "failure",
-				"error": "kopia exploded",
-				"bytes_uploaded": 42,
-				"snapshot_id": "snap",
-				"s3_sent_raw_bytes": 2048,
-				"s3_sent_payload_bytes": 1024,
-				"s3_received_raw_bytes": 64,
-				"s3_received_payload_bytes": 0,
-			})
-		);
 	}
 
 	#[test]

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -12,11 +12,9 @@ use hickory_resolver::{
 	config::{ConnectionConfig, NameServerConfig, ResolverConfig},
 	net::runtime::TokioRuntimeProvider,
 };
-use jiff::Timestamp;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
 use reqwest::Url;
-use serde::{Deserialize, Serialize};
 use time::{Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::RwLock;
 use tracing::debug;
@@ -24,13 +22,11 @@ use uuid::Uuid;
 
 use crate::{
 	Redacted,
-	backup::{
-		BackupCredentials, BackupCredentialsRequest, BackupReport, BackupTarget,
-		CapabilitiesRequest, Purpose, TargetOutcome,
-	},
-	restore::{
-		RestoreCapabilitiesRequest, RestoreCredentials, RestoreCredentialsRequest,
-		RestoreVerification, WorklistEntry,
+	backup::TargetOutcome,
+	restore::{RestoreCapabilitiesRequest, RestoreCredentialsRequest},
+	schema::{
+		BackupPurpose, BackupTarget, CapabilitiesArgs, CredentialProcessOutput, CredentialsArgs,
+		NewEvent, ReportArgs, RestoreCredentials, VerificationArgs, WorklistEntry,
 	},
 };
 
@@ -107,38 +103,6 @@ pub fn client_builder(version: &str) -> reqwest::ClientBuilder {
 /// public mTLS.
 pub async fn tailscale_client(make_builder: &ClientBuilderFactory) -> Option<reqwest::Client> {
 	probe_tailscale(make_builder).await
-}
-
-/// Severities accepted by the canopy `/events` API.
-///
-/// Canopy narrowed its vocabulary from RFC 5424 to this five-level set; the
-/// retired syslog severities (`emergency`, `alert`, `notice`) are rejected by
-/// the strict enum validation on `POST /events`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Severity {
-	Critical,
-	Error,
-	Warning,
-	Info,
-	Debug,
-}
-
-/// Payload for posting to `POST /events` on a canopy server.
-#[derive(Debug, Clone, Serialize)]
-pub struct NewEvent<'a> {
-	pub source: &'a str,
-	#[serde(rename = "ref")]
-	pub r#ref: &'a str,
-	pub message: &'a str,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub description: Option<&'a str>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub severity: Option<Severity>,
-	#[serde(rename = "occurredAt", skip_serializing_if = "Option::is_none")]
-	pub occurred_at: Option<Timestamp>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub active: Option<bool>,
 }
 
 /// HTTP client with auth configured for talking to a canopy server.
@@ -346,7 +310,7 @@ impl CanopyClient {
 			return Err(miette::miette!("canopy /status returned {status}: {body}"));
 		}
 
-		#[derive(Deserialize, Default)]
+		#[derive(serde::Deserialize, Default)]
 		struct StatusResponseTail {
 			#[serde(default)]
 			backup_now: Vec<String>,
@@ -406,7 +370,7 @@ impl CanopyClient {
 	///
 	/// In tailscale mode, `base_url` is ignored and [`TAILSCALE_URL`] is used.
 	/// In mTLS mode, posts to `{base_url}/events`.
-	pub async fn post_event(&self, base_url: &Url, event: NewEvent<'_>) -> Result<()> {
+	pub async fn post_event(&self, base_url: &Url, event: NewEvent) -> Result<()> {
 		let (http, url) = {
 			let state = self.state.read().await;
 			let url = match &*state {
@@ -425,7 +389,7 @@ impl CanopyClient {
 		debug!(
 			%url,
 			source = event.source,
-			r#ref = event.r#ref,
+			r#ref = event.ref_,
 			active = ?event.active,
 			"posting event to canopy"
 		);
@@ -542,7 +506,9 @@ impl CanopyClient {
 		let response = http
 			.post(url)
 			.header("X-Version", &self.tamanu_version)
-			.json(&CapabilitiesRequest { types })
+			.json(&CapabilitiesArgs {
+				types: types.to_vec(),
+			})
 			.send()
 			.await
 			.into_diagnostic()
@@ -566,16 +532,16 @@ impl CanopyClient {
 		&self,
 		base_url: &Url,
 		backup_type: &str,
-		purpose: Purpose,
-	) -> Result<BackupCredentials> {
+		purpose: BackupPurpose,
+	) -> Result<CredentialProcessOutput> {
 		let (http, url) = self.endpoint_url(base_url, "/backup-credentials").await?;
 		debug!(%url, backup_type, ?purpose, "requesting backup credentials from canopy");
 		let response = http
 			.post(url)
 			.header("X-Version", &self.tamanu_version)
-			.json(&BackupCredentialsRequest {
-				r#type: backup_type,
-				purpose,
+			.json(&CredentialsArgs {
+				type_: backup_type.to_owned(),
+				purpose: Some(purpose),
 			})
 			.send()
 			.await
@@ -590,7 +556,7 @@ impl CanopyClient {
 			));
 		}
 		response
-			.json::<BackupCredentials>()
+			.json::<CredentialProcessOutput>()
 			.await
 			.into_diagnostic()
 			.wrap_err("parsing backup credentials from canopy")
@@ -632,9 +598,9 @@ impl CanopyClient {
 	}
 
 	/// Report a completed backup/restore run (`POST /backup-report`).
-	pub async fn backup_report(&self, base_url: &Url, report: &BackupReport<'_>) -> Result<()> {
+	pub async fn backup_report(&self, base_url: &Url, report: &ReportArgs) -> Result<()> {
 		let (http, url) = self.endpoint_url(base_url, "/backup-report").await?;
-		debug!(%url, run_id = report.run_id, "reporting backup outcome to canopy");
+		debug!(%url, run_id = %report.run_id, "reporting backup outcome to canopy");
 		let response = http
 			.post(url)
 			.header("X-Version", &self.tamanu_version)
@@ -749,7 +715,7 @@ impl CanopyClient {
 	pub async fn restore_verification(
 		&self,
 		base_url: &Url,
-		report: &RestoreVerification<'_>,
+		report: &VerificationArgs,
 	) -> Result<()> {
 		let (http, url) = self.endpoint_url(base_url, "/restore-verification").await?;
 		debug!(%url, group = %report.group, "reporting restore verification to canopy");
@@ -1045,7 +1011,7 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 		(base, handle)
 	}
 
-	#[derive(Debug, Deserialize, PartialEq)]
+	#[derive(Debug, serde::Deserialize, PartialEq)]
 	struct Echo {
 		ok: bool,
 		who: String,
@@ -1146,56 +1112,5 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 		let mut decompressed = Vec::new();
 		decoder.read_to_end(&mut decompressed).unwrap();
 		assert_eq!(decompressed, original);
-	}
-
-	#[test]
-	fn severity_serialises_lowercase() {
-		assert_eq!(
-			serde_json::to_string(&Severity::Warning).unwrap(),
-			"\"warning\""
-		);
-		assert_eq!(
-			serde_json::to_string(&Severity::Critical).unwrap(),
-			"\"critical\""
-		);
-	}
-
-	#[test]
-	fn new_event_omits_optional_fields() {
-		let evt = NewEvent {
-			source: "src",
-			r#ref: "host/alert:tgt",
-			message: "msg",
-			description: None,
-			severity: None,
-			occurred_at: None,
-			active: None,
-		};
-		let json = serde_json::to_string(&evt).unwrap();
-		assert!(json.contains("\"source\":\"src\""));
-		assert!(json.contains("\"ref\":\"host/alert:tgt\""));
-		assert!(json.contains("\"message\":\"msg\""));
-		assert!(!json.contains("description"));
-		assert!(!json.contains("severity"));
-		assert!(!json.contains("occurredAt"));
-		assert!(!json.contains("active"));
-	}
-
-	#[test]
-	fn new_event_serialises_occurred_at_as_camel_case() {
-		let evt = NewEvent {
-			source: "src",
-			r#ref: "ref",
-			message: "msg",
-			description: Some("desc"),
-			severity: Some(Severity::Warning),
-			occurred_at: Some("2025-01-01T00:00:00Z".parse().unwrap()),
-			active: Some(true),
-		};
-		let json = serde_json::to_string(&evt).unwrap();
-		assert!(json.contains("\"occurredAt\":"));
-		assert!(json.contains("\"description\":\"desc\""));
-		assert!(json.contains("\"severity\":\"warning\""));
-		assert!(json.contains("\"active\":true"));
 	}
 }

--- a/crates/canopy/src/lib.rs
+++ b/crates/canopy/src/lib.rs
@@ -10,10 +10,12 @@ mod restore;
 /// Wire types generated at build time from canopy's OpenAPI document.
 ///
 /// These are the canonical request and response types for canopy's API, and the
-/// ones to reach for first. The build script fetches the live spec (falling back
-/// to a committed snapshot) and regenerates them on each build, so they track
-/// canopy as it evolves and nothing here is hand-maintained or committed. Each
-/// type carries the schema's own description as rustdoc.
+/// ones to reach for first. The build script fetches the live spec and
+/// regenerates them, so they track canopy as it evolves and nothing here is
+/// hand-maintained or committed. Each type carries the schema's own description
+/// as rustdoc. (A failed fetch fails the build rather than silently using the
+/// committed snapshot, which is reserved for docs.rs and explicit offline
+/// builds — see the build script.)
 ///
 /// Naming follows canopy's schema: request bodies are `…Args` (e.g.
 /// [`CredentialsArgs`], [`ReportArgs`], [`CapabilitiesArgs`]), and credentials

--- a/crates/canopy/src/lib.rs
+++ b/crates/canopy/src/lib.rs
@@ -9,28 +9,43 @@ mod restore;
 
 /// Wire types generated at build time from canopy's OpenAPI document.
 ///
-/// These track canopy's API as it evolves: the build script fetches the live
-/// spec (falling back to a committed snapshot) and regenerates on each build,
-/// so nothing here is hand-maintained or committed. Use them with the generic
-/// [`CanopyClient::request`]/[`CanopyClient::request_json`] methods; the
-/// bespoke endpoint methods keep their own hand-written types.
+/// These are the canonical request and response types for canopy's API, and the
+/// ones to reach for first. The build script fetches the live spec (falling back
+/// to a committed snapshot) and regenerates them on each build, so they track
+/// canopy as it evolves and nothing here is hand-maintained or committed. Each
+/// type carries the schema's own description as rustdoc.
+///
+/// Naming follows canopy's schema: request bodies are `…Args` (e.g.
+/// [`CredentialsArgs`], [`ReportArgs`], [`CapabilitiesArgs`]), and credentials
+/// come back as [`CredentialProcessOutput`].
+///
+/// The generated source is rewritten in two ways the raw JSON Schema can't
+/// express (see the build script): timestamp fields are [`jiff::Timestamp`]
+/// rather than strings, and credential secrets (`secret_access_key`,
+/// `session_token`, `repo_password`) are wrapped in [`Redacted`] so they never
+/// surface in `Debug` output or logs — read them through the inner value.
+///
+/// The typed endpoint methods on [`CanopyClient`] (e.g.
+/// [`CanopyClient::backup_credentials`], [`CanopyClient::backup_target`]) take
+/// and return these types. For an endpoint without a bespoke method, use the
+/// generic [`CanopyClient::request`]/[`CanopyClient::request_json`] with the
+/// matching schema type.
+///
+/// [`CredentialsArgs`]: schema::CredentialsArgs
+/// [`ReportArgs`]: schema::ReportArgs
+/// [`CapabilitiesArgs`]: schema::CapabilitiesArgs
+/// [`CredentialProcessOutput`]: schema::CredentialProcessOutput
 pub mod schema {
 	include!(concat!(env!("OUT_DIR"), "/canopy_schema.rs"));
 }
 
-pub use backup::{
-	BackupCredentials, BackupCredentialsRequest, BackupReport, BackupTarget, CapabilitiesRequest,
-	ContainerCreds, Outcome, Purpose, TargetOutcome,
-};
+pub use backup::{ContainerCreds, TargetOutcome};
 pub use client::{
-	CERT_RENEW_AFTER, CanopyClient, ClientBuilderFactory, DEFAULT_CANOPY_URL, NewEvent, Severity,
-	TAILSCALE_URL, client_builder, device_identity, tailscale_client, user_agent,
+	CERT_RENEW_AFTER, CanopyClient, ClientBuilderFactory, DEFAULT_CANOPY_URL, TAILSCALE_URL,
+	client_builder, device_identity, tailscale_client, user_agent,
 };
 pub use reqwest;
-pub use restore::{
-	RestoreCapabilitiesRequest, RestoreCredentials, RestoreCredentialsRequest, RestoreVerification,
-	WorklistEntry,
-};
+pub use restore::{RestoreCapabilitiesRequest, RestoreCredentialsRequest};
 
 /// Wraps a sensitive value so its `Debug` output doesn't leak the contents.
 #[derive(Clone)]

--- a/crates/canopy/src/restore.rs
+++ b/crates/canopy/src/restore.rs
@@ -1,16 +1,15 @@
-//! Wire types for Canopy's managed-restore endpoints (the PGRO restore consumer).
+//! Request bodies for the managed-restore endpoints that canopy's OpenAPI
+//! document doesn't expose as named schemas.
 //!
-//! Canopy drives the consumer via a worklist. The consumer registers the restore
-//! intents it supports, fetches the worklist of concrete replicas to restore,
-//! pulls per-group read-only credentials and the repo password, then reports each
-//! restore's health back. These types mirror the frozen canopy public-server
-//! contract; field renaming via serde matches the JSON.
+//! The restore responses and the verification report are generated wire types —
+//! see [`schema::WorklistEntry`](crate::schema::WorklistEntry),
+//! [`schema::RestoreCredentials`](crate::schema::RestoreCredentials), and
+//! [`schema::VerificationArgs`](crate::schema::VerificationArgs). Only the two
+//! request bodies below live here, because canopy declares them inline rather
+//! than as reusable schema components.
 
-use jiff::Timestamp;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use uuid::Uuid;
-
-use crate::{BackupCredentials, Outcome, Redacted};
 
 /// Body for `POST /restore-capabilities`: the restore intents this consumer supports.
 ///
@@ -21,81 +20,11 @@ pub struct RestoreCapabilitiesRequest<'a> {
 	pub intents: &'a [&'a str],
 }
 
-/// One entry of `GET /restore-worklist`: a concrete replica to restore.
-///
-/// Declarations are expanded per live server, capability-filtered, and
-/// server-specific-over-group-wide deduped, so there is one entry per replica.
-/// `intent` is an open set passed through to the consumer.
-#[derive(Debug, Clone, Deserialize)]
-pub struct WorklistEntry {
-	pub replica_id: Uuid,
-	pub group_id: Uuid,
-	pub server_id: Uuid,
-	pub r#type: String,
-	pub intent: String,
-	/// Operator label.
-	pub name: String,
-	/// Maximum acceptable age of the restored snapshot; `None` means always latest.
-	pub freshness_seconds: Option<i64>,
-	/// Kopia snapshot id to restore; `None` when the group has no successful backup yet.
-	pub snapshot_id: Option<String>,
-	/// RFC3339 timestamp of `snapshot_id`; `None` alongside it.
-	pub snapshot_at: Option<String>,
-	/// Always `"s3"`.
-	pub storage: String,
-	pub bucket: String,
-	pub prefix: String,
-	pub region: String,
-}
-
 /// Body for `POST /restore-credentials`.
 #[derive(Debug, Clone, Serialize)]
 pub struct RestoreCredentialsRequest<'a> {
 	pub group: Uuid,
 	pub r#type: &'a str,
-}
-
-/// Read-only S3 credentials plus the repo password, from `POST /restore-credentials`.
-///
-/// `credentials` is the `credential_process` shape the proxy re-signs onto kopia;
-/// `repo_password` opens the kopia repo. One per-group call fully opens the repo.
-#[derive(Debug, Clone, Deserialize)]
-pub struct RestoreCredentials {
-	pub credentials: BackupCredentials,
-	pub repo_password: Redacted<String>,
-}
-
-/// Body for `POST /restore-verification`: a restore's reported health.
-///
-/// Report `outcome = Success` with `replica_healthy = true` only when the
-/// deployment passed the readiness gate; anything else raises a group-level
-/// incident. Unsupported intents are handled by capability registration, never
-/// reported here.
-#[derive(Debug, Clone, Serialize)]
-pub struct RestoreVerification<'a> {
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub replica_id: Option<Uuid>,
-	pub group: Uuid,
-	pub server_id: Uuid,
-	pub r#type: &'a str,
-	pub intent: &'a str,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub snapshot_id: Option<&'a str>,
-	pub outcome: Outcome,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub error: Option<&'a str>,
-	pub replica_healthy: bool,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub postgres_version: Option<&'a str>,
-	pub observed_at: Timestamp,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_sent_raw_bytes: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_sent_payload_bytes: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_received_raw_bytes: Option<i64>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub s3_received_payload_bytes: Option<i64>,
 }
 
 #[cfg(test)]
@@ -126,163 +55,6 @@ mod tests {
 			json!({
 				"group": "11111111-1111-1111-1111-111111111111",
 				"type": "tamanu-postgres",
-			})
-		);
-	}
-
-	#[test]
-	fn worklist_entry_deserialises() {
-		let body = json!({
-			"replica_id": "11111111-1111-1111-1111-111111111111",
-			"group_id": "22222222-2222-2222-2222-222222222222",
-			"server_id": "33333333-3333-3333-3333-333333333333",
-			"type": "tamanu-postgres",
-			"intent": "verify",
-			"name": "nightly verify",
-			"freshness_seconds": 86400,
-			"snapshot_id": "kopia-snap",
-			"snapshot_at": "2026-06-30T00:00:00Z",
-			"storage": "s3",
-			"bucket": "my-bucket",
-			"prefix": "",
-			"region": "ap-southeast-2",
-		});
-		let entry: WorklistEntry = serde_json::from_value(body).unwrap();
-		assert_eq!(entry.r#type, "tamanu-postgres");
-		assert_eq!(entry.intent, "verify");
-		assert_eq!(entry.name, "nightly verify");
-		assert_eq!(entry.freshness_seconds, Some(86400));
-		assert_eq!(entry.snapshot_id.as_deref(), Some("kopia-snap"));
-		assert_eq!(entry.bucket, "my-bucket");
-	}
-
-	#[test]
-	fn worklist_entry_allows_null_snapshot_and_freshness() {
-		let body = json!({
-			"replica_id": "11111111-1111-1111-1111-111111111111",
-			"group_id": "22222222-2222-2222-2222-222222222222",
-			"server_id": "33333333-3333-3333-3333-333333333333",
-			"type": "tamanu-postgres",
-			"intent": "verify",
-			"name": "latest",
-			"freshness_seconds": null,
-			"snapshot_id": null,
-			"snapshot_at": null,
-			"storage": "s3",
-			"bucket": "my-bucket",
-			"prefix": "",
-			"region": "ap-southeast-2",
-		});
-		let entry: WorklistEntry = serde_json::from_value(body).unwrap();
-		assert_eq!(entry.freshness_seconds, None);
-		assert_eq!(entry.snapshot_id, None);
-		assert_eq!(entry.snapshot_at, None);
-	}
-
-	#[test]
-	fn restore_credentials_deserialise_composite() {
-		let body = json!({
-			"credentials": {
-				"Version": 1,
-				"AccessKeyId": "AKIA",
-				"SecretAccessKey": "secret",
-				"SessionToken": "token",
-				"Expiration": "2026-05-21T13:00:00Z",
-			},
-			"repo_password": "hunter2",
-		});
-		let creds: RestoreCredentials = serde_json::from_value(body).unwrap();
-		assert_eq!(creds.credentials.access_key_id, "AKIA");
-		assert_eq!(&*creds.repo_password, "hunter2");
-	}
-
-	#[test]
-	fn restore_credentials_debug_does_not_leak_password() {
-		let body = json!({
-			"credentials": {
-				"Version": 1,
-				"AccessKeyId": "AKIA",
-				"SecretAccessKey": "secret",
-				"SessionToken": "token",
-				"Expiration": "2026-05-21T13:00:00Z",
-			},
-			"repo_password": "super-secret-repo-pw",
-		});
-		let creds: RestoreCredentials = serde_json::from_value(body).unwrap();
-		let debug = format!("{creds:?}");
-		assert!(!debug.contains("super-secret-repo-pw"));
-		assert!(debug.contains("<redacted>"));
-	}
-
-	#[test]
-	fn verification_omits_optional_fields() {
-		let report = RestoreVerification {
-			replica_id: None,
-			group: "22222222-2222-2222-2222-222222222222".parse().unwrap(),
-			server_id: "33333333-3333-3333-3333-333333333333".parse().unwrap(),
-			r#type: "tamanu-postgres",
-			intent: "verify",
-			snapshot_id: None,
-			outcome: Outcome::Failure,
-			error: None,
-			replica_healthy: false,
-			postgres_version: None,
-			observed_at: "2026-06-30T00:00:00Z".parse().unwrap(),
-			s3_sent_raw_bytes: None,
-			s3_sent_payload_bytes: None,
-			s3_received_raw_bytes: None,
-			s3_received_payload_bytes: None,
-		};
-		assert_eq!(
-			serde_json::to_value(&report).unwrap(),
-			json!({
-				"group": "22222222-2222-2222-2222-222222222222",
-				"server_id": "33333333-3333-3333-3333-333333333333",
-				"type": "tamanu-postgres",
-				"intent": "verify",
-				"outcome": "failure",
-				"replica_healthy": false,
-				"observed_at": "2026-06-30T00:00:00Z",
-			})
-		);
-	}
-
-	#[test]
-	fn verification_includes_full_payload() {
-		let report = RestoreVerification {
-			replica_id: Some("11111111-1111-1111-1111-111111111111".parse().unwrap()),
-			group: "22222222-2222-2222-2222-222222222222".parse().unwrap(),
-			server_id: "33333333-3333-3333-3333-333333333333".parse().unwrap(),
-			r#type: "tamanu-postgres",
-			intent: "verify",
-			snapshot_id: Some("kopia-snap"),
-			outcome: Outcome::Success,
-			error: None,
-			replica_healthy: true,
-			postgres_version: Some("15"),
-			observed_at: "2026-06-30T00:00:00Z".parse().unwrap(),
-			s3_sent_raw_bytes: Some(123),
-			s3_sent_payload_bytes: Some(120),
-			s3_received_raw_bytes: Some(456),
-			s3_received_payload_bytes: Some(450),
-		};
-		assert_eq!(
-			serde_json::to_value(&report).unwrap(),
-			json!({
-				"replica_id": "11111111-1111-1111-1111-111111111111",
-				"group": "22222222-2222-2222-2222-222222222222",
-				"server_id": "33333333-3333-3333-3333-333333333333",
-				"type": "tamanu-postgres",
-				"intent": "verify",
-				"snapshot_id": "kopia-snap",
-				"outcome": "success",
-				"replica_healthy": true,
-				"postgres_version": "15",
-				"observed_at": "2026-06-30T00:00:00Z",
-				"s3_sent_raw_bytes": 123,
-				"s3_sent_payload_bytes": 120,
-				"s3_received_raw_bytes": 456,
-				"s3_received_payload_bytes": 450,
 			})
 		);
 	}

--- a/crates/canopy/tests/schema.rs
+++ b/crates/canopy/tests/schema.rs
@@ -4,8 +4,8 @@
 //! needed here.
 
 use bestool_canopy::schema::{
-	BackupPurpose, BackupTarget, BeginArgs, BeginResponse, CompleteArgs, CompleteResponse, Issue,
-	ReportArgs, RunOutcome,
+	BackupPurpose, BackupTarget, BeginArgs, BeginResponse, CompleteArgs, CompleteResponse,
+	CredentialProcessOutput, Issue, NewEvent, ReportArgs, RunOutcome, Severity,
 };
 
 #[test]
@@ -82,6 +82,86 @@ fn register_complete_types_roundtrip() {
 		resp.device_id.to_string(),
 		"1111aaaa-0000-4000-8000-000000000000"
 	);
+}
+
+#[test]
+fn credential_secrets_are_redacted_and_expiry_is_a_timestamp() {
+	let wire = serde_json::json!({
+		"Version": 1,
+		"AccessKeyId": "AKIA",
+		"SecretAccessKey": "super-secret-key",
+		"SessionToken": "super-secret-token",
+		"Expiration": "2026-05-21T13:00:00Z",
+	});
+	let creds: CredentialProcessOutput = serde_json::from_value(wire.clone()).unwrap();
+
+	// Secrets are readable through the inner value but never printed.
+	assert_eq!(&*creds.secret_access_key, "super-secret-key");
+	assert_eq!(&*creds.session_token, "super-secret-token");
+	let debug = format!("{creds:?}");
+	assert!(!debug.contains("super-secret-key"), "{debug}");
+	assert!(!debug.contains("super-secret-token"), "{debug}");
+	assert!(debug.contains("<redacted>"), "{debug}");
+
+	// The expiry is a jiff timestamp, not a bare string.
+	let _: jiff::Timestamp = creds.expiration;
+
+	// Redaction and the timestamp rewrite are serialisation-transparent.
+	assert_eq!(serde_json::to_value(&creds).unwrap(), wire);
+}
+
+#[test]
+fn backup_target_repo_password_is_redacted() {
+	let target: BackupTarget = serde_json::from_value(serde_json::json!({
+		"storage": "s3",
+		"bucket": "backups",
+		"prefix": "",
+		"region": "ap-southeast-2",
+		"repo_password": "hunter2",
+	}))
+	.unwrap();
+	assert_eq!(&*target.repo_password, "hunter2");
+	let debug = format!("{target:?}");
+	assert!(!debug.contains("hunter2"), "{debug}");
+	assert!(debug.contains("<redacted>"), "{debug}");
+}
+
+#[test]
+fn new_event_omits_optional_fields() {
+	let event = NewEvent {
+		source: "src".to_owned(),
+		ref_: "host/alert:tgt".to_owned(),
+		message: "msg".to_owned(),
+		description: None,
+		severity: None,
+		occurred_at: None,
+		active: None,
+	};
+	let json = serde_json::to_string(&event).unwrap();
+	assert!(json.contains("\"source\":\"src\""));
+	assert!(json.contains("\"ref\":\"host/alert:tgt\""));
+	assert!(json.contains("\"message\":\"msg\""));
+	assert!(!json.contains("description"));
+	assert!(!json.contains("severity"));
+	assert!(!json.contains("occurredAt"));
+	assert!(!json.contains("active"));
+}
+
+#[test]
+fn new_event_serialises_occurred_at_camel_case_and_severity_lowercase() {
+	let event = NewEvent {
+		source: "src".to_owned(),
+		ref_: "ref".to_owned(),
+		message: "msg".to_owned(),
+		description: Some("desc".to_owned()),
+		severity: Some(Severity::Warning),
+		occurred_at: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+		active: Some(true),
+	};
+	let json = serde_json::to_string(&event).unwrap();
+	assert!(json.contains("\"occurredAt\":"));
+	assert!(json.contains("\"severity\":\"warning\""));
+	assert!(json.contains("\"active\":true"));
 }
 
 #[test]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -14,3 +14,11 @@ name = "bestool"
 git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
 semver_check = false
+
+[[package]]
+name = "bestool-canopy"
+# The release job refreshes openapi.snapshot.json from live canopy just before
+# publishing (see .github/workflows/release-plz.yml), so the published crate
+# carries a current schema for offline / docs.rs consumers. That leaves the file
+# modified but uncommitted, so let cargo publish it anyway.
+publish_allow_dirty = true


### PR DESCRIPTION
🤖 Consolidates `bestool-canopy` onto its build-time generated schema, and makes the OpenAPI fetch reliable for external consumers.

## Schema types

The `schema` module (generated from canopy's OpenAPI) is now the single source of truth for wire types. Removed the hand-written types that duplicated it and routed every consumer to the schema types: `Purpose` → `BackupPurpose`, `Outcome` → `RunOutcome`, `Severity`, `NewEvent`, `BackupCredentials` → `CredentialProcessOutput`, `BackupTarget`, `BackupReport` → `ReportArgs`, `RestoreCredentials`, `WorklistEntry`, `RestoreVerification` → `VerificationArgs`, and register's `Begin`/`Complete` request/response types (now `schema::Begin*`/`Complete*`, whose `server_id`/`device_id` are `Uuid`).

To keep the properties the raw JSON Schema can't express, `build.rs` rewrites the generated source: credential secrets (`secret_access_key`, `session_token`, `repo_password`) are wrapped in `Redacted` so they stay out of `Debug`/logs, and the credential expiry becomes a `jiff::Timestamp`. Guard asserts fail the build if a rewrite stops matching.

Kept the shapes with no schema component: `Redacted<T>`, `ContainerCreds` (kopia minio-go, plus its `From<&CredentialProcessOutput>`), `TargetOutcome`, and the inline restore request bodies.

The `schema` module rustdoc now explains it's the canonical source, the `…Args`/`CredentialProcessOutput` naming, the redaction/`jiff` rewrites, and that the typed client methods and `request`/`request_json` take these types.

## Reliable fetch, no silent stale fallback

`build.rs` fetched the OpenAPI document with `ureq`, which in some environments couldn't reach canopy (e.g. an unreachable IPv6 route, no system-proxy handling) and silently fell back to the committed snapshot. That fallback is invisible to downstream builds, because cargo hides build-script warnings from dependencies — so an external consumer could ship stale wire types with no signal.

- The build fetch now uses `reqwest::blocking` (the client the runtime and contract tests already use, with dual-stack and proxy handling).
- A failed fetch is a hard build error rather than a silent stale fallback. The committed snapshot is used only where a live fetch is impossible by design: docs.rs (`DOCS_RS`) and explicit offline builds (`CANOPY_OPENAPI_OFFLINE`).
- The release job refreshes `openapi.snapshot.json` from live just before publishing, without committing it (`publish_allow_dirty` for `bestool-canopy`), so the published crate carries a current schema for its own offline/docs.rs consumers.

Note: offline workspace builds now need `CANOPY_OPENAPI_OFFLINE=1`.
