### PR TITLE
refactor(canopy): drop X-Version/tamanu_version; self-identify user-agent

### DIFF
--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -87,7 +87,6 @@ pub async fn run_with_shutdown(
 	let pool = daemon_config.pg_pool.clone();
 
 	let canopy_client = match CanopyClient::new(
-		daemon_config.tamanu_version.clone(),
 		daemon_config.device_key_pem.as_ref().map(|r| r.0.as_str()),
 		crate::http_builder,
 	)

--- a/crates/alertd/src/doctor/task.rs
+++ b/crates/alertd/src/doctor/task.rs
@@ -129,9 +129,10 @@ impl DoctorTaskInner {
 		};
 
 		let backup_now = canopy
-			.post_status(&server_id, &sweep.payload)
+			.status(&server_id, &sweep.payload)
 			.await
-			.map_err(|err| miette!("posting doctor status to canopy: {err}"))?;
+			.map_err(|err| miette!("posting doctor status to canopy: {err}"))?
+			.backup_now;
 
 		if !backup_now.is_empty() {
 			match &self.backup_dispatch {

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -23,12 +23,11 @@ pub use tasks::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse}
 /// The version of the alertd library
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Base builder for alertd's outbound HTTP clients.
-///
-/// Carries the browser-style `bestool/<version>` User-Agent (and whatever else
-/// [`canopy::client_builder`] sets). Call sites add their own timeouts etc.
+/// Base builder for alertd's outbound HTTP clients. Call sites add their own
+/// timeouts etc. Canopy sets its own User-Agent, so this one applies to alertd's
+/// other requests.
 pub fn http_builder() -> reqwest::ClientBuilder {
-	canopy::client_builder(VERSION)
+	reqwest::Client::builder().user_agent(concat!("bestool-alertd/", env!("CARGO_PKG_VERSION")))
 }
 
 /// A built [`reqwest::Client`] from [`http_builder`].
@@ -58,11 +57,6 @@ pub struct DaemonConfig {
 	/// then dropped. Wrapped in `Redacted` so debug-logging the config can't
 	/// leak the key.
 	pub device_key_pem: Option<Redacted<String>>,
-
-	/// Tamanu version of the install this daemon is monitoring. Sent in the
-	/// `X-Version` header on every canopy request — canopy rejects requests
-	/// without one.
-	pub tamanu_version: String,
 
 	/// Whether to disable the HTTP server
 	pub no_server: bool,
@@ -99,7 +93,6 @@ impl fmt::Debug for DaemonConfig {
 		f.debug_struct("DaemonConfig")
 			.field("database_url", &self.database_url)
 			.field("device_key_pem", &self.device_key_pem)
-			.field("tamanu_version", &self.tamanu_version)
 			.field("binary_version", &self.binary_version)
 			.field("no_server", &self.no_server)
 			.field("server_addrs", &self.server_addrs)
@@ -120,13 +113,11 @@ impl DaemonConfig {
 	pub fn new(
 		pg_pool: Option<bestool_postgres::pool::PgPool>,
 		database_url: Option<String>,
-		tamanu_version: String,
 	) -> Self {
 		Self {
 			pg_pool,
 			database_url,
 			device_key_pem: None,
-			tamanu_version,
 			no_server: false,
 			server_addrs: Vec::new(),
 			watchdog_timeout: Some(Duration::from_secs(10 * 60)),

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -369,7 +369,11 @@ mod backup {
 		if types.is_empty() {
 			return Ok(());
 		}
-		client.backup_capabilities(&types).await?;
+		client
+			.backup_capabilities(&bestool_canopy::schema::CapabilitiesArgs {
+				types: types.clone(),
+			})
+			.await?;
 		info!(?types, "registered backup capabilities with canopy");
 		Ok(())
 	}

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -690,17 +690,9 @@ async fn build_config(ctx: &Context, daemon: DaemonArgs) -> Result<bestool_alert
 	})
 	.await;
 
-	// Canopy requires a version on every request; `0.0.0` is the agreed
-	// sentinel for hosts with no Tamanu.
-	let tamanu_version = tamanu
-		.as_ref()
-		.map(|t| t.version.to_string())
-		.unwrap_or_else(|| "0.0.0".into());
-
 	let base = bestool_alertd::DaemonConfig::new(
 		pg_pool.clone(),
 		tamanu.as_ref().map(|t| t.database_url.clone()),
-		tamanu_version,
 	)
 	.with_binary_version(env!("CARGO_PKG_VERSION").to_string())
 	.with_no_server(no_server)
@@ -747,9 +739,7 @@ async fn build_config(_ctx: &Context, daemon: DaemonArgs) -> Result<bestool_aler
 		.flatten()
 		.and_then(|reg| reg.device_key);
 
-	// Canopy requires a version on every request; `0.0.0` is the agreed
-	// sentinel for hosts with no Tamanu.
-	let base = bestool_alertd::DaemonConfig::new(None, None, "0.0.0".to_string())
+	let base = bestool_alertd::DaemonConfig::new(None, None)
 		.with_binary_version(env!("CARGO_PKG_VERSION").to_string())
 		.with_no_server(no_server)
 		.with_server_addrs(server_addr)

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -420,7 +420,7 @@ async fn backup_after_start(
 
 	let client = build_client(base_url_of(&reg)?, &device_key).await?;
 
-	let target = match client.backup_target().await? {
+	let target = match TargetOutcome::from_result(client.backup_target().await)? {
 		TargetOutcome::Dormant => {
 			info!(
 				backup_type,

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -848,16 +848,14 @@ pub(super) fn base_url_of(reg: &Registration) -> Result<Url> {
 
 /// Build a canopy client for an already-enrolled host (tailscale, then mTLS).
 pub(super) async fn build_client(base_url: Url, device_key: &str) -> Result<Arc<CanopyClient>> {
-	let version = env!("CARGO_PKG_VERSION");
 	let tailscale_url = bestool_canopy::TAILSCALE_URL
 		.parse()
 		.into_diagnostic()
 		.wrap_err("parsing default canopy tailscale URL")?;
-	let client = CanopyClient::with_urls(base_url, tailscale_url, version, Some(device_key), move || {
-		bestool_canopy::client_builder(version)
-	})
-	.await?
-	.ok_or_else(|| miette!("could not build a canopy client (no auth path available)"))?;
+	let client =
+		CanopyClient::with_urls(base_url, tailscale_url, Some(device_key), crate::http::client_builder)
+			.await?
+			.ok_or_else(|| miette!("could not build a canopy client (no auth path available)"))?;
 	Ok(Arc::new(client))
 }
 

--- a/crates/bestool/src/actions/canopy/backup/provider.rs
+++ b/crates/bestool/src/actions/canopy/backup/provider.rs
@@ -10,7 +10,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 use bestool_canopy::{
 	CanopyClient,
-	schema::{BackupPurpose, CredentialProcessOutput},
+	schema::{BackupPurpose, CredentialProcessOutput, CredentialsArgs},
 };
 use bestool_kopia::proxy::{BoxError, CredentialProvider, Credentials};
 use futures::future::BoxFuture;
@@ -40,7 +40,10 @@ impl CanopyCredentialProvider {
 			let backup_type = backup_type.clone();
 			Box::pin(async move {
 				client
-					.backup_credentials(&backup_type, purpose)
+					.backup_credentials(&CredentialsArgs {
+						type_: backup_type.clone(),
+						purpose: Some(purpose),
+					})
 					.await
 					.map_err(|err| format!("{err}"))
 			})

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -87,7 +87,7 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		.ok_or_else(|| miette!("registration has no server id"))?;
 	let client = build_client(base_url_of(&reg)?, &device_key).await?;
 
-	let target = match client.backup_target().await? {
+	let target = match TargetOutcome::from_result(client.backup_target().await)? {
 		TargetOutcome::Ready(target) => target,
 		TargetOutcome::Dormant => {
 			bail!("device is not authorised for this backup repository (cannot restore)")

--- a/crates/bestool/src/actions/canopy/tags.rs
+++ b/crates/bestool/src/actions/canopy/tags.rs
@@ -130,25 +130,10 @@ async fn fetch_online() -> Result<BTreeMap<String, String>> {
 		"fetching tags"
 	);
 
-	// `/public/tags` is reachable from tagged-device tailscale callers
-	// (the only mount that admits them); `/tags` is the mTLS path on
-	// the main canopy host. Returns the merged server+group tag map.
-	let response = canopy
-		.get("/public/tags", "/tags")
-		.await
-		.wrap_err("GET /tags via canopy")?;
-
-	let status = response.status();
-	if !status.is_success() {
-		let body = response.text().await.unwrap_or_default();
-		bail!("canopy /tags returned {status}: {body}");
-	}
-
-	response
-		.json::<BTreeMap<String, String>>()
-		.await
-		.into_diagnostic()
-		.wrap_err("decoding canopy tags response")
+	// Returns the merged server+group tag map. An error (including a non-2xx)
+	// propagates to the caller, which falls back to the cache.
+	let tags = canopy.tags().await.wrap_err("GET /tags via canopy")?;
+	Ok(tags.0.into_iter().collect())
 }
 
 fn render_json(tags: &BTreeMap<String, String>, source: Source) -> Result<()> {

--- a/crates/bestool/src/actions/canopy/tags.rs
+++ b/crates/bestool/src/actions/canopy/tags.rs
@@ -66,10 +66,9 @@ pub async fn run(args: TagsArgs, ctx: Context) -> Result<()> {
 	// `--root` only exists on the `tamanu` alias path; under `canopy` there's
 	// no `TamanuArgs` in the context, so fall back to default discovery.
 	let root_arg = ctx.get::<TamanuArgs>().and_then(|t| t.root.clone());
-	let (version, root) = bestool_tamanu::find_tamanu(root_arg.as_deref()).await?;
+	let (_version, root) = bestool_tamanu::find_tamanu(root_arg.as_deref()).await?;
 	let config = Arc::new(load_config(&root, None)?);
 
-	let tamanu_version = version.to_string();
 	let cache_path = standard_tags_path();
 
 	let (tags, source) = if args.offline {
@@ -81,7 +80,7 @@ pub async fn run(args: TagsArgs, ctx: Context) -> Result<()> {
 			),
 		}
 	} else {
-		match fetch_online(&tamanu_version).await {
+		match fetch_online().await {
 			Ok(tags) => {
 				let cache = TagsCache {
 					tags: tags.clone(),
@@ -120,15 +119,11 @@ enum Source {
 	Cache(Option<jiff::Timestamp>),
 }
 
-async fn fetch_online(tamanu_version: &str) -> Result<BTreeMap<String, String>> {
+async fn fetch_online() -> Result<BTreeMap<String, String>> {
 	let device_key = bestool_tamanu::server_info::fetch_device_key().await;
-	let canopy = CanopyClient::new(
-		tamanu_version.to_owned(),
-		device_key.as_deref(),
-		crate::http::client_builder,
-	)
-	.await?
-	.ok_or_else(|| miette!("no canopy auth path: no tailscale, no device key"))?;
+	let canopy = CanopyClient::new(device_key.as_deref(), crate::http::client_builder)
+		.await?
+		.ok_or_else(|| miette!("no canopy auth path: no tailscale, no device key"))?;
 
 	debug!(
 		via = if canopy.is_tailscale().await { "tailscale" } else { "mtls" },

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -130,19 +130,13 @@ impl AsyncSnippetProvider {
 		let meta_url = DownloadSource::Meta.host();
 
 		if let Some(canopy) = &self.canopy {
-			match canopy
-				.get("/public/bestool/snippets", "/bestool/snippets")
-				.await
-			{
-				Ok(response) if response.status().is_success() => {
-					return response.json().await.into_diagnostic();
-				}
-				Ok(response) => {
-					debug!(
-						status = %response.status(),
-						"canopy snippets fetch returned non-success; falling back to direct"
-					);
-				}
+			match canopy.bestool_snippets().await {
+				Ok(value) => match serde_json::from_value::<BTreeMap<String, Snippet>>(value) {
+					Ok(snippets) => return Ok(snippets),
+					Err(err) => {
+						debug!("decoding canopy snippets failed ({err:#}); falling back to direct")
+					}
+				},
 				Err(err) => {
 					debug!("canopy snippets fetch failed ({err:#}); falling back to direct");
 				}

--- a/crates/bestool/src/actions/tamanu/psql.rs
+++ b/crates/bestool/src/actions/tamanu/psql.rs
@@ -419,13 +419,9 @@ pub async fn run(args: PsqlArgs, ctx: Context) -> Result<()> {
 		(false, HashSet::new())
 	};
 
-	let canopy = if let Some(ref tamanu_version) = version {
+	let canopy = if version.is_some() {
 		let device_key = bestool_tamanu::server_info::fetch_device_key().await;
-		match CanopyClient::new(
-			tamanu_version.clone(),
-			device_key.as_deref(),
-			crate::http::client_builder,
-		)
+		match CanopyClient::new(device_key.as_deref(), crate::http::client_builder)
 		.await
 		{
 			Ok(Some(client)) => {

--- a/crates/canopy/Cargo.toml
+++ b/crates/canopy/Cargo.toml
@@ -8,6 +8,12 @@ description = "(Internal) BES tooling: Canopy client"
 repository = "https://github.com/beyondessential/bestool/tree/main/crates/canopy"
 exclude.workspace = true
 
+[features]
+default = []
+# Exposes the generic escape-hatch methods (`get`, `request`, `request_json`).
+# Off by default: prefer the generated per-endpoint methods.
+raw-requests = []
+
 [lints]
 workspace = true
 

--- a/crates/canopy/build.rs
+++ b/crates/canopy/build.rs
@@ -75,11 +75,193 @@ fn main() {
 		.expect("generating types from canopy schemas");
 
 	let file = syn::parse2(type_space.to_stream()).expect("parsing generated canopy schema tokens");
-	let generated = rewrite_types(&prettyplease::unparse(&file));
+	let mut generated = rewrite_types(&prettyplease::unparse(&file));
+	generated.push_str(&generate_client_methods(&spec));
 
 	let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR is set for build scripts");
 	fs::write(Path::new(&out_dir).join("canopy_schema.rs"), generated)
 		.expect("writing generated canopy schema");
+}
+
+const HTTP_VERBS: [&str; 5] = ["get", "post", "put", "delete", "patch"];
+
+/// One endpoint's inputs, gathered from the OpenAPI operation.
+struct Endpoint {
+	/// Base method name derived from the path (params dropped, `-`→`_`).
+	name: String,
+	verb: String,
+	path: String,
+	/// Path-parameter names in order of appearance.
+	params: Vec<String>,
+	/// Rust type of the JSON request body, if any.
+	body: Option<String>,
+	/// Rust return type: `Some(ty)` parses JSON into `ty`, `None` expects no body.
+	response: Option<String>,
+}
+
+/// Generate an `impl crate::CanopyClient` block with one method per OpenAPI
+/// operation, routing through the client's shared transport (`call_json` /
+/// `call_empty`). Method names come from the path; where a path is served by
+/// more than one verb the verb is prefixed to disambiguate.
+fn generate_client_methods(spec: &Value) -> String {
+	let paths = spec
+		.get("paths")
+		.and_then(Value::as_object)
+		.expect("canopy OpenAPI document has no paths");
+
+	let mut endpoints = Vec::new();
+	for (path, item) in paths {
+		let item = item.as_object().expect("openapi path item is an object");
+		for (verb, op) in item {
+			if !HTTP_VERBS.contains(&verb.as_str()) {
+				continue;
+			}
+			let params: Vec<String> = path
+				.split('/')
+				.filter_map(|seg| seg.strip_prefix('{').and_then(|s| s.strip_suffix('}')))
+				.map(str::to_owned)
+				.collect();
+			let name = path
+				.split('/')
+				.filter(|seg| !seg.is_empty() && !seg.starts_with('{'))
+				.map(|seg| seg.replace('-', "_"))
+				.collect::<Vec<_>>()
+				.join("_");
+			endpoints.push(Endpoint {
+				name,
+				verb: verb.clone(),
+				path: path.clone(),
+				params,
+				body: request_body_type(spec, op),
+				response: response_type(op),
+			});
+		}
+	}
+
+	// Disambiguate names shared by multiple verbs (e.g. /versions/{version}).
+	let mut counts = std::collections::HashMap::<&str, usize>::new();
+	for ep in &endpoints {
+		*counts.entry(ep.name.as_str()).or_default() += 1;
+	}
+	let collides: std::collections::HashSet<String> = endpoints
+		.iter()
+		.filter(|ep| counts[ep.name.as_str()] > 1)
+		.map(|ep| ep.name.clone())
+		.collect();
+
+	endpoints.sort_by(|a, b| (&a.path, &a.verb).cmp(&(&b.path, &b.verb)));
+
+	let mut out = String::from("impl crate::CanopyClient {\n");
+	for ep in &endpoints {
+		let method_name = if collides.contains(&ep.name) {
+			format!("{}_{}", ep.verb, ep.name)
+		} else {
+			ep.name.clone()
+		};
+		let http_method = format!("::reqwest::Method::{}", ep.verb.to_uppercase());
+
+		let mut args = String::new();
+		for param in &ep.params {
+			args.push_str(&format!(", {param}: &str"));
+		}
+		if let Some(body) = &ep.body {
+			args.push_str(&format!(", body: &{body}"));
+		}
+
+		let path_expr = if ep.params.is_empty() {
+			format!("{:?}", ep.path)
+		} else {
+			let mut template = ep.path.clone();
+			for param in &ep.params {
+				template = template.replace(&format!("{{{param}}}"), "{}");
+			}
+			format!("&format!({template:?}, {})", ep.params.join(", "))
+		};
+		let body_arg = if ep.body.is_some() {
+			"Some(body)"
+		} else {
+			"None::<&()>"
+		};
+
+		let (call, ret) = match &ep.response {
+			Some(ty) => ("call_json", format!("::miette::Result<{ty}>")),
+			None => ("call_empty", "::miette::Result<()>".to_owned()),
+		};
+
+		out.push_str(&format!(
+			"    /// `{verb} {path}`\n    pub async fn {method_name}(&self{args}) -> {ret} {{\n        self.{call}({http_method}, {path_expr}, {body_arg}).await\n    }}\n",
+			verb = ep.verb.to_uppercase(),
+			path = ep.path,
+		));
+	}
+	out.push_str("}\n");
+	out
+}
+
+/// Rust type for an operation's JSON request body, or `None` if it has none.
+///
+/// A `$ref` to an open schema (an `allOf` that includes a free-form object, like
+/// canopy's `StatusPayload`) can't be losslessly typed, so it maps to
+/// `serde_json::Value`; other `$ref`s use the generated type.
+fn request_body_type(spec: &Value, op: &Value) -> Option<String> {
+	let schema = op.pointer("/requestBody/content/application~1json/schema")?;
+	Some(match schema.get("$ref").and_then(Value::as_str) {
+		Some(reference) => {
+			let name = type_name(reference);
+			if is_open_schema(spec, &name) {
+				"::serde_json::Value".to_owned()
+			} else {
+				name
+			}
+		}
+		None => "::serde_json::Value".to_owned(),
+	})
+}
+
+/// Rust return type for an operation's 200 response: `Some(ty)` to parse JSON,
+/// `None` when there's no JSON body to parse.
+fn response_type(op: &Value) -> Option<String> {
+	let schema = op.pointer("/responses/200/content/application~1json/schema")?;
+	if let Some(reference) = schema.get("$ref").and_then(Value::as_str) {
+		return Some(type_name(reference));
+	}
+	match schema.get("type").and_then(Value::as_str) {
+		Some("array") => {
+			let item = schema
+				.pointer("/items/$ref")
+				.and_then(Value::as_str)
+				.map(type_name)
+				.unwrap_or_else(|| "::serde_json::Value".to_owned());
+			Some(format!("::std::vec::Vec<{item}>"))
+		}
+		_ => Some("::serde_json::Value".to_owned()),
+	}
+}
+
+/// Last path segment of a `#/components/schemas/Foo` reference.
+fn type_name(reference: &str) -> String {
+	reference
+		.rsplit('/')
+		.next()
+		.expect("schema $ref is non-empty")
+		.to_owned()
+}
+
+/// Whether `components.schemas[name]` is an open `allOf` — one whose members
+/// include a free-form object (no `properties`, no `$ref`). typify drops the
+/// free-form part, so such schemas can't be sent losslessly as their typed form.
+fn is_open_schema(spec: &Value, name: &str) -> bool {
+	let Some(schema) = spec.pointer(&format!("/components/schemas/{name}")) else {
+		return false;
+	};
+	let Some(all_of) = schema.get("allOf").and_then(Value::as_array) else {
+		return false;
+	};
+	all_of.iter().any(|member| {
+		member.get("type").and_then(Value::as_str) == Some("object")
+			&& member.get("properties").is_none()
+			&& member.get("$ref").is_none()
+	})
 }
 
 /// Post-process the generated wire types.

--- a/crates/canopy/src/backup.rs
+++ b/crates/canopy/src/backup.rs
@@ -8,10 +8,13 @@
 //! dormant device state into an enum.
 
 use jiff::Timestamp;
+use miette::Result;
+use reqwest::StatusCode;
 use serde::Serialize;
 
 use crate::{
 	Redacted,
+	client::CanopyHttpError,
 	schema::{BackupTarget, CredentialProcessOutput},
 };
 
@@ -44,6 +47,27 @@ impl From<&CredentialProcessOutput> for ContainerCreds {
 pub enum TargetOutcome {
 	Ready(BackupTarget),
 	Dormant,
+}
+
+impl TargetOutcome {
+	/// Interpret a [`backup_target`](crate::CanopyClient::backup_target) result:
+	/// a `412`/`409` (the device isn't yet authorised for backups) becomes
+	/// [`Dormant`](Self::Dormant), a target becomes [`Ready`](Self::Ready), and
+	/// any other error propagates.
+	pub fn from_result(result: Result<BackupTarget>) -> Result<Self> {
+		match result {
+			Ok(target) => Ok(Self::Ready(target)),
+			Err(report) => match report.downcast_ref::<CanopyHttpError>() {
+				Some(err)
+					if err.status == StatusCode::PRECONDITION_FAILED
+						|| err.status == StatusCode::CONFLICT =>
+				{
+					Ok(Self::Dormant)
+				}
+				_ => Err(report),
+			},
+		}
+	}
 }
 
 #[cfg(test)]

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -62,33 +62,32 @@ const TAILSCALE_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Factory producing the base [`reqwest::ClientBuilder`] for canopy's clients.
 ///
-/// The caller supplies this so it owns cross-cutting client config (user-agent,
-/// `SSLKEYLOGFILE`, proxies, …). Canopy invokes it whenever it needs to build or
+/// The caller supplies this so it owns cross-cutting client config
+/// (`SSLKEYLOGFILE`, proxies, …). Canopy invokes it whenever it needs to build or
 /// rebuild a client — at probe time, on mTLS cert renewal, and on reload — then
-/// layers its own concerns (mTLS identity, DNS overrides, timeouts) on top.
+/// layers its own concerns (its [`user_agent`], mTLS identity, DNS overrides,
+/// timeouts) on top.
 pub type ClientBuilderFactory = Arc<dyn Fn() -> reqwest::ClientBuilder + Send + Sync>;
 
-/// Browser-style user-agent string, e.g. `bestool/1.2.3 (Linux 7.0.9 Arch Linux; x86_64)`.
+/// User-agent set on every canopy request, e.g.
+/// `bestool-canopy/0.5.0 (Linux 7.0.9 Arch Linux; x86_64)`.
 ///
-/// `product` and `version` identify the calling binary; the OS comment is
-/// detected at runtime and cached.
-pub fn user_agent(product: &str, version: &str) -> String {
-	static OS_COMMENT: OnceLock<String> = OnceLock::new();
-	let os_comment = OS_COMMENT.get_or_init(|| {
+/// Identifies this client crate and its version; the OS comment is detected at
+/// runtime and cached. The client sets this itself on top of the caller's
+/// [`ClientBuilderFactory`], so canopy traffic identifies the client library
+/// regardless of the calling binary.
+fn user_agent() -> &'static str {
+	static UA: OnceLock<String> = OnceLock::new();
+	UA.get_or_init(|| {
 		let os = sysinfo::System::long_os_version()
 			.or_else(sysinfo::System::name)
 			.unwrap_or_else(|| std::env::consts::OS.to_owned());
-		format!("{os}; {}", sysinfo::System::cpu_arch())
-	});
-	format!("{product}/{version} ({os_comment})")
-}
-
-/// A [`reqwest::ClientBuilder`] carrying the `bestool` [`user_agent`] for `version`.
-///
-/// Convenience for callers that don't need any extra client config; suitable as
-/// the base of a [`ClientBuilderFactory`].
-pub fn client_builder(version: &str) -> reqwest::ClientBuilder {
-	reqwest::Client::builder().user_agent(user_agent("bestool", version))
+		format!(
+			"bestool-canopy/{} ({os}; {})",
+			env!("CARGO_PKG_VERSION"),
+			sysinfo::System::cpu_arch(),
+		)
+	})
 }
 
 /// Probe the canopy tailnet endpoint, returning a client routed to it if
@@ -124,11 +123,6 @@ pub struct CanopyClient {
 	/// on the tailscale path. Fixed for the client's lifetime.
 	tailscale_url: Url,
 	device_key: Option<Redacted<String>>,
-	/// Tamanu version of the install this client speaks for. Sent verbatim in
-	/// the `X-Version` request header — canopy rejects events / status pushes
-	/// that don't carry one. Sourced from the running Tamanu install's
-	/// `package.json` (via `find_tamanu`); not the bestool / alertd version.
-	tamanu_version: String,
 	/// Produces the base client builder; see [`ClientBuilderFactory`].
 	make_builder: ClientBuilderFactory,
 	state: RwLock<State>,
@@ -166,13 +160,9 @@ impl CanopyClient {
 	/// a device key PEM is provided, builds an mTLS client. Returns `Ok(None)` if
 	/// neither path is available.
 	///
-	/// `tamanu_version` is the version of the Tamanu install this client
-	/// speaks for; sent on every request via the `X-Version` header.
-	///
 	/// `make_builder` supplies the base [`reqwest::ClientBuilder`] — see
-	/// [`ClientBuilderFactory`]. Use [`client_builder`] for a sensible default.
+	/// [`ClientBuilderFactory`].
 	pub async fn new(
-		tamanu_version: impl Into<String>,
 		device_key_pem: Option<&str>,
 		make_builder: impl Fn() -> reqwest::ClientBuilder + Send + Sync + 'static,
 	) -> Result<Option<Self>> {
@@ -183,7 +173,6 @@ impl CanopyClient {
 			TAILSCALE_URL
 				.parse()
 				.expect("default tailscale URL is valid"),
-			tamanu_version,
 			device_key_pem,
 			make_builder,
 		)
@@ -199,11 +188,9 @@ impl CanopyClient {
 	pub async fn with_urls(
 		base_url: Url,
 		tailscale_url: Url,
-		tamanu_version: impl Into<String>,
 		device_key_pem: Option<&str>,
 		make_builder: impl Fn() -> reqwest::ClientBuilder + Send + Sync + 'static,
 	) -> Result<Option<Self>> {
-		let tamanu_version = tamanu_version.into();
 		let device_key = device_key_pem.map(|s| Redacted(s.to_owned()));
 		let make_builder: ClientBuilderFactory = Arc::new(make_builder);
 
@@ -213,7 +200,6 @@ impl CanopyClient {
 				base_url,
 				tailscale_url,
 				device_key,
-				tamanu_version,
 				make_builder,
 				state: RwLock::new(State::Tailscale(http)),
 			}));
@@ -226,7 +212,6 @@ impl CanopyClient {
 				base_url,
 				tailscale_url,
 				device_key,
-				tamanu_version,
 				make_builder,
 				state: RwLock::new(State::Mtls(http)),
 			}));
@@ -337,7 +322,6 @@ impl CanopyClient {
 
 		let response = http
 			.post(url)
-			.header("X-Version", &self.tamanu_version)
 			.header(reqwest::header::CONTENT_TYPE, "application/json")
 			.header(reqwest::header::CONTENT_ENCODING, "gzip")
 			.body(compressed)
@@ -399,7 +383,6 @@ impl CanopyClient {
 
 		debug!(%url, "GET via canopy");
 		http.get(url)
-			.header("X-Version", &self.tamanu_version)
 			.send()
 			.await
 			.into_diagnostic()
@@ -430,10 +413,9 @@ impl CanopyClient {
 	/// Start a request to an arbitrary canopy endpoint on the current auth path.
 	///
 	/// This is the generic escape hatch behind the typed endpoint methods: it
-	/// resolves the right HTTP client and URL for the active auth mode, begins
-	/// the request, and sets the `X-Version` header. The returned builder is
-	/// yours to finish — add query params, a body, or extra headers, then
-	/// `.send()` and parse the response however suits.
+	/// resolves the right HTTP client and URL for the active auth mode and begins
+	/// the request. The returned builder is yours to finish — add query params, a
+	/// body, or extra headers, then `.send()` and parse the response however suits.
 	///
 	/// `path` is the mTLS-mode path (e.g. `/backup-target`); over tailscale the
 	/// same endpoint is mounted under `/public`, so this routes it there, the
@@ -445,9 +427,7 @@ impl CanopyClient {
 	) -> Result<reqwest::RequestBuilder> {
 		let (http, url) = self.endpoint_url(path).await?;
 		debug!(%url, %method, "arbitrary canopy request");
-		Ok(http
-			.request(method, url)
-			.header("X-Version", &self.tamanu_version))
+		Ok(http.request(method, url))
 	}
 
 	/// Call an arbitrary canopy endpoint and parse its JSON response.
@@ -499,7 +479,6 @@ impl CanopyClient {
 		debug!(%url, ?types, "registering backup capabilities with canopy");
 		let response = http
 			.post(url)
-			.header("X-Version", &self.tamanu_version)
 			.json(&CapabilitiesArgs {
 				types: types.to_vec(),
 			})
@@ -531,7 +510,6 @@ impl CanopyClient {
 		debug!(%url, backup_type, ?purpose, "requesting backup credentials from canopy");
 		let response = http
 			.post(url)
-			.header("X-Version", &self.tamanu_version)
 			.json(&CredentialsArgs {
 				type_: backup_type.to_owned(),
 				purpose: Some(purpose),
@@ -564,7 +542,6 @@ impl CanopyClient {
 		debug!(%url, "fetching backup target from canopy");
 		let response = http
 			.get(url)
-			.header("X-Version", &self.tamanu_version)
 			.send()
 			.await
 			.into_diagnostic()
@@ -596,7 +573,6 @@ impl CanopyClient {
 		debug!(%url, run_id = %report.run_id, "reporting backup outcome to canopy");
 		let response = http
 			.post(url)
-			.header("X-Version", &self.tamanu_version)
 			.json(report)
 			.send()
 			.await
@@ -673,7 +649,9 @@ async fn try_probe(
 	addrs: &[SocketAddr],
 	make_builder: &ClientBuilderFactory,
 ) -> Option<reqwest::Client> {
-	let mut builder = make_builder().timeout(TAILSCALE_PROBE_TIMEOUT);
+	let mut builder = make_builder()
+		.user_agent(user_agent())
+		.timeout(TAILSCALE_PROBE_TIMEOUT);
 	if !addrs.is_empty() {
 		builder = builder.resolve_to_addrs(host, addrs);
 	}
@@ -762,6 +740,7 @@ fn build_mtls_http(
 	let identity = device_identity(device_key_pem)?;
 
 	make_builder()
+		.user_agent(user_agent())
 		.identity(identity)
 		.use_rustls_tls()
 		.timeout(Duration::from_secs(30))
@@ -805,7 +784,6 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 			base_url: DEFAULT_CANOPY_URL.parse().unwrap(),
 			tailscale_url: TAILSCALE_URL.parse().unwrap(),
 			device_key: Some(Redacted(TEST_DEVICE_KEY.to_owned())),
-			tamanu_version: "2.54.2".into(),
 			make_builder: test_factory(),
 			state: RwLock::new(State::Mtls(http)),
 		};
@@ -821,7 +799,6 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 			base_url: DEFAULT_CANOPY_URL.parse().unwrap(),
 			tailscale_url: TAILSCALE_URL.parse().unwrap(),
 			device_key: None,
-			tamanu_version: "2.54.2".into(),
 			make_builder: test_factory(),
 			state: RwLock::new(State::Tailscale(http)),
 		};
@@ -835,7 +812,6 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 			base_url: base.parse().unwrap(),
 			tailscale_url: TAILSCALE_URL.parse().unwrap(),
 			device_key: Some(Redacted(TEST_DEVICE_KEY.to_owned())),
-			tamanu_version: "2.54.2".into(),
 			make_builder: test_factory(),
 			state: RwLock::new(State::Mtls(http)),
 		}
@@ -943,8 +919,8 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 			captured
 				.headers
 				.to_ascii_lowercase()
-				.contains("x-version: 2.54.2"),
-			"missing X-Version header in:\n{}",
+				.contains("user-agent: bestool-canopy/"),
+			"missing canopy user-agent in:\n{}",
 			captured.headers
 		);
 		let sent: serde_json::Value = serde_json::from_slice(&captured.body).unwrap();
@@ -973,10 +949,10 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 	}
 
 	#[test]
-	fn user_agent_has_product_and_os_comment() {
-		let ua = user_agent("bestool", "1.2.3");
+	fn user_agent_identifies_the_crate_with_os_comment() {
+		let ua = user_agent();
 		assert!(
-			ua.starts_with("bestool/1.2.3 "),
+			ua.starts_with(concat!("bestool-canopy/", env!("CARGO_PKG_VERSION"), " ")),
 			"unexpected user-agent: {ua}"
 		);
 		assert!(ua.contains('('), "expected OS comment in: {ua}");

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -19,14 +19,7 @@ use time::{Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::RwLock;
 use tracing::debug;
 
-use crate::{
-	Redacted,
-	backup::TargetOutcome,
-	schema::{
-		BackupPurpose, BackupTarget, CapabilitiesArgs, CredentialProcessOutput, CredentialsArgs,
-		ReportArgs,
-	},
-};
+use crate::Redacted;
 
 pub const DEFAULT_CANOPY_URL: &str = "https://meta.tamanu.app";
 
@@ -68,6 +61,35 @@ const TAILSCALE_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// layers its own concerns (its [`user_agent`], mTLS identity, DNS overrides,
 /// timeouts) on top.
 pub type ClientBuilderFactory = Arc<dyn Fn() -> reqwest::ClientBuilder + Send + Sync>;
+
+/// A non-2xx response from a canopy endpoint.
+///
+/// The generated endpoint methods return this (wrapped in a [`miette::Report`])
+/// on any non-success status; downcast the report to it to branch on the code,
+/// e.g. [`TargetOutcome::from_result`](crate::TargetOutcome::from_result) maps a
+/// backup-target `412`/`409` to a dormant device.
+#[derive(Debug, Clone)]
+pub struct CanopyHttpError {
+	/// HTTP status returned by canopy.
+	pub status: reqwest::StatusCode,
+	/// The endpoint path that was called (mTLS-mode form, e.g. `/backup-target`).
+	pub path: String,
+	/// Response body, best-effort (empty if it couldn't be read).
+	pub body: String,
+}
+
+impl fmt::Display for CanopyHttpError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(
+			f,
+			"canopy {} returned {}: {}",
+			self.path, self.status, self.body
+		)
+	}
+}
+
+impl std::error::Error for CanopyHttpError {}
+impl miette::Diagnostic for CanopyHttpError {}
 
 /// User-agent set on every canopy request, e.g.
 /// `bestool-canopy/0.5.0 (Linux 7.0.9 Arch Linux; x86_64)`.
@@ -269,100 +291,108 @@ impl CanopyClient {
 		Ok(())
 	}
 
-	/// POST a status snapshot to the canopy server.
+	/// Resolve the HTTP client + URL for `path` on the current auth path.
 	///
-	/// In tailscale mode a `{TAILSCALE_URL}/public/status/{server_id}` URL is
-	/// used; in mTLS mode it posts to `{base_url}/status/{server_id}` for the
-	/// client's configured base URL.
-	///
-	/// The payload is free-form JSON; the canopy `/status` contract reserves the
-	/// top-level `health: []` key, whose entries each carry a `result` of
-	/// `passed | warning | failed | broken | skipped`. The body is gzip-encoded
-	/// with `Content-Encoding: gzip`.
-	///
-	/// Returns `backup_now`: the backup-type names canopy says this server should
-	/// back up right now (operator one-offs + schedule-due). Empty means nothing
-	/// to do. A response that predates the field (no `backup_now`) yields an empty
-	/// list, so older canopy deployments keep working.
-	pub async fn post_status(
-		&self,
-		server_id: &str,
-		payload: &serde_json::Value,
-	) -> Result<Vec<String>> {
-		let (http, url) = {
-			let state = self.state.read().await;
-			let url = match &*state {
-				State::Tailscale(_) => self
-					.tailscale_url
-					.join(&format!("/public/status/{server_id}"))
-					.into_diagnostic()
-					.wrap_err("building tailscale /public/status URL")?,
-				State::Mtls(_) => self
-					.base_url
-					.join(&format!("/status/{server_id}"))
-					.into_diagnostic()
-					.wrap_err("building /status URL")?,
-			};
-			(state.http(), url)
+	/// `path` is the mTLS-mode path (e.g. `/backup-target`); over tailscale the
+	/// same endpoint is mounted under `/public`, so this prepends it.
+	async fn endpoint_url(&self, path: &str) -> Result<(reqwest::Client, Url)> {
+		let state = self.state.read().await;
+		let url = match &*state {
+			State::Tailscale(_) => self
+				.tailscale_url
+				.join(&format!("/public{path}"))
+				.into_diagnostic()
+				.wrap_err_with(|| format!("building tailscale /public{path} URL"))?,
+			State::Mtls(_) => self
+				.base_url
+				.join(path)
+				.into_diagnostic()
+				.wrap_err_with(|| format!("building {path} URL"))?,
 		};
+		Ok((state.http(), url))
+	}
 
-		let raw = serde_json::to_vec(payload)
-			.into_diagnostic()
-			.wrap_err("serialising canopy /status payload")?;
-		let compressed = gzip_bytes(&raw)
-			.into_diagnostic()
-			.wrap_err("gzipping canopy /status payload")?;
+	/// Send a request to `path` on the current auth path, gzipping the JSON body
+	/// when there is one.
+	///
+	/// A non-success status becomes a [`CanopyHttpError`] (downcast the returned
+	/// report to inspect the status — e.g. [`TargetOutcome::from_result`]). This
+	/// is the shared core behind the generated endpoint methods.
+	async fn send_call<B: serde::Serialize + ?Sized>(
+		&self,
+		method: reqwest::Method,
+		path: &str,
+		body: Option<&B>,
+	) -> Result<reqwest::Response> {
+		let (http, url) = self.endpoint_url(path).await?;
+		debug!(%url, %method, "canopy request");
+		let mut req = http.request(method, url);
+		if let Some(body) = body {
+			let raw = serde_json::to_vec(body)
+				.into_diagnostic()
+				.wrap_err_with(|| format!("serialising canopy {path} body"))?;
+			let compressed = gzip_bytes(&raw)
+				.into_diagnostic()
+				.wrap_err_with(|| format!("gzipping canopy {path} body"))?;
+			req = req
+				.header(reqwest::header::CONTENT_TYPE, "application/json")
+				.header(reqwest::header::CONTENT_ENCODING, "gzip")
+				.body(compressed);
+		}
 
-		debug!(
-			%url,
-			raw_bytes = raw.len(),
-			gzip_bytes = compressed.len(),
-			"posting status snapshot to canopy",
-		);
-
-		let response = http
-			.post(url)
-			.header(reqwest::header::CONTENT_TYPE, "application/json")
-			.header(reqwest::header::CONTENT_ENCODING, "gzip")
-			.body(compressed)
+		let response = req
 			.send()
 			.await
 			.into_diagnostic()
-			.wrap_err("posting status to canopy")?;
+			.wrap_err_with(|| format!("calling canopy {path}"))?;
 
 		let status = response.status();
 		if !status.is_success() {
 			let body = response.text().await.unwrap_or_default();
-			return Err(miette::miette!("canopy /status returned {status}: {body}"));
+			return Err(miette::Report::new(CanopyHttpError {
+				status,
+				path: path.to_owned(),
+				body,
+			}));
 		}
-
-		#[derive(serde::Deserialize, Default)]
-		struct StatusResponseTail {
-			#[serde(default)]
-			backup_now: Vec<String>,
-		}
-
-		// The response flattens the persisted Status plus `backup_now`; we read
-		// only the latter and ignore the rest. A body that fails to parse (or
-		// predates the field) is treated as "nothing to do" rather than failing
-		// the status push.
-		let tail = response
-			.json::<StatusResponseTail>()
-			.await
-			.unwrap_or_default();
-		Ok(tail.backup_now)
+		Ok(response)
 	}
 
-	/// GET a path on the canopy server, routed via tailscale when available.
+	/// Call an endpoint and parse its JSON response. Backs the generated methods.
+	pub(crate) async fn call_json<B, R>(
+		&self,
+		method: reqwest::Method,
+		path: &str,
+		body: Option<&B>,
+	) -> Result<R>
+	where
+		B: serde::Serialize + ?Sized,
+		R: serde::de::DeserializeOwned,
+	{
+		let response = self.send_call(method, path, body).await?;
+		response
+			.json::<R>()
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("parsing canopy {path} response"))
+	}
+
+	/// Call an endpoint that returns no body. Backs the generated methods.
+	pub(crate) async fn call_empty<B: serde::Serialize + ?Sized>(
+		&self,
+		method: reqwest::Method,
+		path: &str,
+		body: Option<&B>,
+	) -> Result<()> {
+		self.send_call(method, path, body).await.map(drop)
+	}
+
+	/// GET a path, routed via tailscale when available, returning the raw response.
 	///
-	/// In tailscale mode, the request goes to `{TAILSCALE_URL}{tailscale_path}`
-	/// (typically `/public/...`, the only mount that accepts tagged-device
-	/// tailscale callers). In mTLS mode, the request goes to `{base_url}{mtls_path}`
-	/// for the client's configured base URL.
-	///
-	/// Returns the raw response — the caller is responsible for status checks
-	/// and body parsing so they can choose how to fall back if the response
-	/// isn't usable.
+	/// Escape hatch behind the generated endpoint methods; needs the `raw-requests`
+	/// feature. In tailscale mode the request goes to `{tailscale_url}{tailscale_path}`
+	/// (typically `/public/...`); in mTLS mode to `{base_url}{mtls_path}`.
+	#[cfg(feature = "raw-requests")]
 	pub async fn get(&self, tailscale_path: &str, mtls_path: &str) -> Result<reqwest::Response> {
 		let (http, url) = {
 			let state = self.state.read().await;
@@ -389,37 +419,12 @@ impl CanopyClient {
 			.wrap_err("GET via canopy")
 	}
 
-	/// Resolve an endpoint URL for the current auth path.
-	///
-	/// `path` is the mTLS-mode path (e.g. `/backup-target`); over tailscale the
-	/// same endpoint is mounted under `/public`, so this prepends it.
-	async fn endpoint_url(&self, path: &str) -> Result<(reqwest::Client, Url)> {
-		let state = self.state.read().await;
-		let url = match &*state {
-			State::Tailscale(_) => self
-				.tailscale_url
-				.join(&format!("/public{path}"))
-				.into_diagnostic()
-				.wrap_err_with(|| format!("building tailscale /public{path} URL"))?,
-			State::Mtls(_) => self
-				.base_url
-				.join(path)
-				.into_diagnostic()
-				.wrap_err_with(|| format!("building {path} URL"))?,
-		};
-		Ok((state.http(), url))
-	}
-
 	/// Start a request to an arbitrary canopy endpoint on the current auth path.
 	///
-	/// This is the generic escape hatch behind the typed endpoint methods: it
-	/// resolves the right HTTP client and URL for the active auth mode and begins
-	/// the request. The returned builder is yours to finish — add query params, a
-	/// body, or extra headers, then `.send()` and parse the response however suits.
-	///
-	/// `path` is the mTLS-mode path (e.g. `/backup-target`); over tailscale the
-	/// same endpoint is mounted under `/public`, so this routes it there, the
-	/// same convention the other endpoint methods follow.
+	/// Escape hatch behind the generated endpoint methods; needs the `raw-requests`
+	/// feature. `path` is the mTLS-mode path; over tailscale it's routed under
+	/// `/public`, the same convention the generated methods follow.
+	#[cfg(feature = "raw-requests")]
 	pub async fn request(
 		&self,
 		method: reqwest::Method,
@@ -432,161 +437,18 @@ impl CanopyClient {
 
 	/// Call an arbitrary canopy endpoint and parse its JSON response.
 	///
-	/// Builds the request via [`Self::request`], attaches `body` as JSON when
-	/// it's `Some`, sends it, and on a 2xx response parses the body into `Res`.
-	/// A non-success status becomes an error carrying the status and response
-	/// body, matching the other endpoint methods. This absorbs the status-check
-	/// and parse boilerplate.
-	///
-	/// Use [`serde_json::Value`] for `Res` (and/or the body) for fully dynamic
-	/// calls, or any concrete type for typed calls. When passing no body, pin
-	/// the inference with a turbofish, e.g. `None::<&()>`.
-	///
-	/// `path` follows the same mTLS/tailscale convention as [`Self::request`].
+	/// Escape hatch behind the generated endpoint methods; needs the `raw-requests`
+	/// feature. Prefer a generated method where one exists. When passing no body,
+	/// pin the inference with a turbofish, e.g. `None::<&()>`. The body is gzipped,
+	/// like every canopy request.
+	#[cfg(feature = "raw-requests")]
 	pub async fn request_json<Res: serde::de::DeserializeOwned>(
 		&self,
 		method: reqwest::Method,
 		path: &str,
 		body: Option<&(impl serde::Serialize + ?Sized)>,
 	) -> Result<Res> {
-		let mut req = self.request(method, path).await?;
-		if let Some(body) = body {
-			req = req.json(body);
-		}
-
-		let response = req
-			.send()
-			.await
-			.into_diagnostic()
-			.wrap_err_with(|| format!("calling canopy {path}"))?;
-
-		let status = response.status();
-		if !status.is_success() {
-			let body = response.text().await.unwrap_or_default();
-			return Err(miette::miette!("canopy {path} returned {status}: {body}"));
-		}
-
-		response
-			.json::<Res>()
-			.await
-			.into_diagnostic()
-			.wrap_err_with(|| format!("parsing canopy {path} response"))
-	}
-
-	/// Register the backup types this server can run (`POST /backup-capabilities`).
-	pub async fn backup_capabilities(&self, types: &[String]) -> Result<()> {
-		let (http, url) = self.endpoint_url("/backup-capabilities").await?;
-		debug!(%url, ?types, "registering backup capabilities with canopy");
-		let response = http
-			.post(url)
-			.json(&CapabilitiesArgs {
-				types: types.to_vec(),
-			})
-			.send()
-			.await
-			.into_diagnostic()
-			.wrap_err("posting backup capabilities to canopy")?;
-
-		let status = response.status();
-		if !status.is_success() {
-			let body = response.text().await.unwrap_or_default();
-			return Err(miette::miette!(
-				"canopy /backup-capabilities returned {status}: {body}"
-			));
-		}
-		Ok(())
-	}
-
-	/// Obtain short-lived S3 credentials for a backup type (`POST /backup-credentials`).
-	///
-	/// Returns the `credential_process`-shaped creds; the caller translates them
-	/// to the container-creds shape for kopia. `412`/`409`/`502` surface as errors.
-	pub async fn backup_credentials(
-		&self,
-		backup_type: &str,
-		purpose: BackupPurpose,
-	) -> Result<CredentialProcessOutput> {
-		let (http, url) = self.endpoint_url("/backup-credentials").await?;
-		debug!(%url, backup_type, ?purpose, "requesting backup credentials from canopy");
-		let response = http
-			.post(url)
-			.json(&CredentialsArgs {
-				type_: backup_type.to_owned(),
-				purpose: Some(purpose),
-			})
-			.send()
-			.await
-			.into_diagnostic()
-			.wrap_err("posting backup credentials request to canopy")?;
-
-		let status = response.status();
-		if !status.is_success() {
-			let body = response.text().await.unwrap_or_default();
-			return Err(miette::miette!(
-				"canopy /backup-credentials returned {status}: {body}"
-			));
-		}
-		response
-			.json::<CredentialProcessOutput>()
-			.await
-			.into_diagnostic()
-			.wrap_err("parsing backup credentials from canopy")
-	}
-
-	/// Fetch the S3 repo target (`GET /backup-target`).
-	///
-	/// `412`/`409` mean the device isn't yet authorised for backups; these map to
-	/// [`TargetOutcome::Dormant`] (a benign idle state) rather than an error.
-	pub async fn backup_target(&self) -> Result<TargetOutcome> {
-		let (http, url) = self.endpoint_url("/backup-target").await?;
-		debug!(%url, "fetching backup target from canopy");
-		let response = http
-			.get(url)
-			.send()
-			.await
-			.into_diagnostic()
-			.wrap_err("fetching backup target from canopy")?;
-
-		let status = response.status();
-		if status == reqwest::StatusCode::PRECONDITION_FAILED
-			|| status == reqwest::StatusCode::CONFLICT
-		{
-			return Ok(TargetOutcome::Dormant);
-		}
-		if !status.is_success() {
-			let body = response.text().await.unwrap_or_default();
-			return Err(miette::miette!(
-				"canopy /backup-target returned {status}: {body}"
-			));
-		}
-		let target = response
-			.json::<BackupTarget>()
-			.await
-			.into_diagnostic()
-			.wrap_err("parsing backup target from canopy")?;
-		Ok(TargetOutcome::Ready(target))
-	}
-
-	/// Report a completed backup/restore run (`POST /backup-report`).
-	pub async fn backup_report(&self, report: &ReportArgs) -> Result<()> {
-		let (http, url) = self.endpoint_url("/backup-report").await?;
-		debug!(%url, run_id = %report.run_id, "reporting backup outcome to canopy");
-		let response = http
-			.post(url)
-			.json(report)
-			.send()
-			.await
-			.into_diagnostic()
-			.wrap_err("posting backup report to canopy")?;
-
-		let status = response.status();
-		if !status.is_success() {
-			let body = response.text().await.unwrap_or_default();
-			return Err(miette::miette!(
-				"canopy /backup-report returned {status}: {body}"
-			));
-		}
-		Ok(())
+		self.call_json(method, path, body).await
 	}
 }
 
@@ -889,7 +751,7 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 	}
 
 	#[tokio::test]
-	async fn request_json_sends_version_and_body_and_parses_response() {
+	async fn call_json_gzips_body_sets_user_agent_and_parses_response() {
 		let (base, handle) = serve_once(
 			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 26\r\n\r\n{\"ok\":true,\"who\":\"device\"}",
 		);
@@ -897,9 +759,9 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 
 		let payload = serde_json::json!({ "hello": "world" });
 		let got: Echo = client
-			.request_json(reqwest::Method::POST, "/thing", Some(&payload))
+			.call_json(reqwest::Method::POST, "/thing", Some(&payload))
 			.await
-			.expect("request_json should succeed");
+			.expect("call_json should succeed");
 
 		assert_eq!(
 			got,
@@ -915,26 +777,37 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 			"unexpected request line: {}",
 			captured.request_line
 		);
+		let headers = captured.headers.to_ascii_lowercase();
 		assert!(
-			captured
-				.headers
-				.to_ascii_lowercase()
-				.contains("user-agent: bestool-canopy/"),
+			headers.contains("user-agent: bestool-canopy/"),
 			"missing canopy user-agent in:\n{}",
 			captured.headers
 		);
-		let sent: serde_json::Value = serde_json::from_slice(&captured.body).unwrap();
+		assert!(
+			headers.contains("content-encoding: gzip"),
+			"body should be gzipped:\n{}",
+			captured.headers
+		);
+		// The body is gzipped on the wire; decompress before comparing.
+		use flate2::read::GzDecoder;
+		use std::io::Read as _;
+		let mut decoder = GzDecoder::new(&captured.body[..]);
+		let mut raw = Vec::new();
+		decoder
+			.read_to_end(&mut raw)
+			.expect("body should be valid gzip");
+		let sent: serde_json::Value = serde_json::from_slice(&raw).unwrap();
 		assert_eq!(sent, payload);
 	}
 
 	#[tokio::test]
-	async fn request_json_errors_on_non_success_with_body() {
+	async fn call_json_errors_on_non_success_with_body() {
 		let (base, handle) =
 			serve_once("HTTP/1.1 418 I'm a teapot\r\nContent-Length: 14\r\n\r\nno coffee here");
 		let client = mtls_client_against(&base);
 
 		let err = client
-			.request_json::<serde_json::Value>(reqwest::Method::GET, "/brew", None::<&()>)
+			.call_json::<(), serde_json::Value>(reqwest::Method::GET, "/brew", None::<&()>)
 			.await
 			.expect_err("non-2xx should error");
 		let msg = err.to_string();

--- a/crates/canopy/src/lib.rs
+++ b/crates/canopy/src/lib.rs
@@ -43,7 +43,7 @@ pub mod schema {
 pub use backup::{ContainerCreds, TargetOutcome};
 pub use client::{
 	CERT_RENEW_AFTER, CanopyClient, ClientBuilderFactory, DEFAULT_CANOPY_URL, TAILSCALE_URL,
-	client_builder, device_identity, tailscale_client, user_agent,
+	device_identity, tailscale_client,
 };
 pub use reqwest;
 

--- a/crates/canopy/src/lib.rs
+++ b/crates/canopy/src/lib.rs
@@ -26,11 +26,16 @@ pub mod registration;
 /// `session_token`, `repo_password`) are wrapped in [`Redacted`] so they never
 /// surface in `Debug` output or logs — read them through the inner value.
 ///
-/// The typed endpoint methods on [`CanopyClient`] (e.g.
-/// [`CanopyClient::backup_credentials`], [`CanopyClient::backup_target`]) take
-/// and return these types. For an endpoint without a bespoke method, use the
-/// generic [`CanopyClient::request`]/[`CanopyClient::request_json`] with the
-/// matching schema type.
+/// [`CanopyClient`] has one generated method per endpoint (also emitted from the
+/// spec into this module — e.g. `backup_credentials`, `restore_worklist`,
+/// `tags`), taking and returning these types; that's how you call canopy. The
+/// method name is the path (`/backup-credentials` → `backup_credentials`), verb-
+/// prefixed only where a path is served by several verbs. `backup_target`'s
+/// dormant-device case is read from its result via [`TargetOutcome::from_result`];
+/// any non-2xx surfaces as [`CanopyHttpError`]. The generic
+/// `get`/`request`/`request_json` escape hatch is behind the off-by-default
+/// `raw-requests` feature — reach for it only for something the generated methods
+/// don't cover.
 ///
 /// [`CredentialsArgs`]: schema::CredentialsArgs
 /// [`ReportArgs`]: schema::ReportArgs
@@ -42,8 +47,8 @@ pub mod schema {
 
 pub use backup::{ContainerCreds, TargetOutcome};
 pub use client::{
-	CERT_RENEW_AFTER, CanopyClient, ClientBuilderFactory, DEFAULT_CANOPY_URL, TAILSCALE_URL,
-	device_identity, tailscale_client,
+	CERT_RENEW_AFTER, CanopyClient, CanopyHttpError, ClientBuilderFactory, DEFAULT_CANOPY_URL,
+	TAILSCALE_URL, device_identity, tailscale_client,
 };
 pub use reqwest;
 


### PR DESCRIPTION
🤖 Simplifies canopy client construction now that canopy is dropping the `X-Version` requirement, and gives the client crate its own user-agent. Stacked on #634.

## Drop X-Version / tamanu_version

Canopy no longer requires the `X-Version` header, so the client stops sending it. `tamanu_version` is removed from `CanopyClient` (the field, the `new`/`with_urls` params, and the header on every request) and from the alertd / tags / psql plumbing whose only job was to resolve it for that header — including `DaemonConfig::tamanu_version` and the `0.0.0` sentinel.

The doctor sweep still resolves its own Tamanu version (for the status payload and the version-drift checks) — that path is untouched. psql likewise keeps resolving its version for redaction loading.

## Self-identifying user-agent

The client now sets its own user-agent — `bestool-canopy/{this crate's version} (<os>; <arch>)` — on top of the caller's builder factory, so canopy traffic identifies the client library regardless of the calling binary. The `client_builder(version)` helper is gone; alertd and bestool build their own base builders (bestool for `SSLKEYLOGFILE` etc., alertd for its own non-canopy requests).
