### PR TITLE
feat(canopy): record OpenAPI provenance on generated wire types

### DIFF
--- a/crates/canopy/Cargo.toml
+++ b/crates/canopy/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { version = "1.23.2", features = ["serde"] }
 tempfile = "3.21.0"
 
 [build-dependencies]
+blake3 = "1.8.5"
 prettyplease = "0.2.37"
 reqwest = { workspace = true, features = ["blocking"] }
 schemars = "0.8.22"

--- a/crates/canopy/build.rs
+++ b/crates/canopy/build.rs
@@ -36,13 +36,16 @@ fn main() {
 	println!("cargo:rerun-if-env-changed={DOCS_RS_ENV}");
 	println!("cargo:rerun-if-env-changed={OFFLINE_ENV}");
 
-	let spec_text = match fetch_live() {
-		Ok(text) => text,
+	let (spec_text, source) = match fetch_live() {
+		Ok(text) => (text, Source::Live),
 		Err(err) if snapshot_allowed() => {
 			println!(
 				"cargo:warning=canopy OpenAPI live fetch failed ({err}); using committed snapshot"
 			);
-			fs::read_to_string(SNAPSHOT).expect("reading canopy OpenAPI snapshot")
+			(
+				fs::read_to_string(SNAPSHOT).expect("reading canopy OpenAPI snapshot"),
+				Source::Snapshot,
+			)
 		}
 		Err(err) => panic!(
 			"canopy OpenAPI live fetch from {SPEC_URL} failed: {err}\n\
@@ -75,12 +78,59 @@ fn main() {
 		.expect("generating types from canopy schemas");
 
 	let file = syn::parse2(type_space.to_stream()).expect("parsing generated canopy schema tokens");
-	let mut generated = rewrite_types(&prettyplease::unparse(&file));
+	let mut generated = provenance(&spec_text, source);
+	generated.push_str(&rewrite_types(&prettyplease::unparse(&file)));
 	generated.push_str(&generate_client_methods(&spec));
 
 	let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR is set for build scripts");
 	fs::write(Path::new(&out_dir).join("canopy_schema.rs"), generated)
 		.expect("writing generated canopy schema");
+}
+
+/// Where the OpenAPI document was obtained for this build.
+#[derive(Clone, Copy)]
+enum Source {
+	/// Fetched live from the running canopy deployment.
+	Live,
+	/// Read from the committed snapshot (offline / docs.rs build).
+	Snapshot,
+}
+
+/// Emit the provenance constants for the generated module: [`OPENAPI_SOURCE`]
+/// and [`OPENAPI_BLAKE3`], so consumers can tell which document these types were
+/// generated from and check whether it is still current.
+///
+/// The digest is blake3 over the document's raw bytes exactly as served, so it
+/// reproduces with `curl -fsS <SPEC_URL> | b3sum`. An inner `#![doc]` attribute
+/// can't be used here — `include!` forbids one in this position — so the
+/// provenance surfaces through these documented constants instead, which the
+/// module docs in `lib.rs` point at.
+fn provenance(spec_text: &str, source: Source) -> String {
+	let hash = blake3::hash(spec_text.as_bytes()).to_hex();
+	let (source_const, source_doc) = match source {
+		Source::Live => (
+			"live",
+			format!("fetched live from the canopy deployment at <{SPEC_URL}>"),
+		),
+		Source::Snapshot => (
+			"snapshot",
+			"read from the committed `openapi.snapshot.json` because the live spec was \
+			 unavailable (an offline or docs.rs build), so these types may lag canopy"
+				.to_owned(),
+		),
+	};
+	format!(
+		"/// How the OpenAPI document was obtained when these types were generated: `\"live\"`\n\
+		 /// when fetched live from the running canopy deployment, `\"snapshot\"` for an offline\n\
+		 /// or docs.rs build against the committed `openapi.snapshot.json`.\n\
+		 ///\n\
+		 /// This build: {source_doc}.\n\
+		 pub const OPENAPI_SOURCE: &str = \"{source_const}\";\n\n\
+		 /// blake3 digest of the canopy OpenAPI document these wire types were generated from,\n\
+		 /// over its raw bytes exactly as served. Compare against `curl -fsS {SPEC_URL} | b3sum`\n\
+		 /// to check the generated types are current.\n\
+		 pub const OPENAPI_BLAKE3: &str = \"{hash}\";\n\n"
+	)
 }
 
 const HTTP_VERBS: [&str; 5] = ["get", "post", "put", "delete", "patch"];

--- a/crates/canopy/src/lib.rs
+++ b/crates/canopy/src/lib.rs
@@ -37,6 +37,12 @@ pub mod registration;
 /// `raw-requests` feature — reach for it only for something the generated methods
 /// don't cover.
 ///
+/// To check these types are current, [`schema::OPENAPI_BLAKE3`] is the blake3
+/// digest of the OpenAPI document they were generated from (compare it against
+/// `curl -fsS https://meta.tamanu.app/api/openapi.json | b3sum`), and
+/// [`schema::OPENAPI_SOURCE`] records whether that document was fetched live or
+/// read from the committed snapshot.
+///
 /// [`BackupCredentialsArgs`]: schema::BackupCredentialsArgs
 /// [`ReportArgs`]: schema::ReportArgs
 /// [`BackupCapabilitiesArgs`]: schema::BackupCapabilitiesArgs


### PR DESCRIPTION
🤖 The generated `bestool-canopy` wire types track canopy's live OpenAPI document, but nothing recorded *which* document a given build was generated from — so there was no easy way to tell whether checked-in docs or a deployed binary were current.

This emits two documented constants alongside the generated `schema` module:

- `OPENAPI_BLAKE3` — blake3 digest of the OpenAPI document the types were generated from, over its raw bytes exactly as served. Reproduce and compare with `curl -fsS https://meta.tamanu.app/api/openapi.json | b3sum`.
- `OPENAPI_SOURCE` — `"live"` when fetched from the running deployment, `"snapshot"` for an offline/docs.rs build against the committed snapshot. The doc also states which was used for that build.

The `schema` module rustdoc points at both. An inner `#![doc]` in the generated file would be cleaner but `include!` forbids one in that position, so the provenance lives on the constants instead.

Verified both paths: a live build produces the digest matching `curl … | b3sum`, and a forced-offline build produces the digest matching `b3sum` of the committed snapshot with `OPENAPI_SOURCE = "snapshot"`.
