### PR TITLE
fix(canopy): report pg_basebackup stderr to canopy

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -871,7 +871,13 @@ pub(super) async fn load_registration(config: Option<&Path>) -> Result<Option<Re
 const MAX_ERROR_LEN: usize = 1500;
 
 fn trim_error(err: &miette::Report) -> String {
-	let msg = format!("{err}");
+	// Render the whole cause chain: `Display` on a report shows only the outermost
+	// context ("spawning pg_basebackup"), and the cause is the part worth reporting.
+	let msg = err
+		.chain()
+		.map(|e| e.to_string())
+		.collect::<Vec<_>>()
+		.join(": ");
 	let len = msg.chars().count();
 	if len <= MAX_ERROR_LEN {
 		return msg;
@@ -924,6 +930,21 @@ async fn try_acquire_lock(path: &Path) -> Result<Option<tokio::fs::File>> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn trim_error_renders_the_cause_chain() {
+		let err = Err::<(), _>(std::io::Error::new(
+			std::io::ErrorKind::NotFound,
+			"No such file or directory",
+		))
+		.into_diagnostic()
+		.wrap_err("spawning pg_basebackup")
+		.unwrap_err();
+		assert_eq!(
+			trim_error(&err),
+			"spawning pg_basebackup: No such file or directory"
+		);
+	}
 
 	#[test]
 	fn trim_error_keeps_the_operative_tail() {

--- a/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
@@ -72,18 +72,35 @@ pub async fn prepare(
 	cmd.args(basebackup_args(&dest));
 	super::apply_connection(&mut cmd, config);
 	cmd.stdin(Stdio::null());
-	let status = cmd
-		.status()
+	// Capture stderr: it carries the operative error (auth, WAL config, disk), and
+	// with inherited stderr all that reaches canopy is the exit status.
+	let output = cmd
+		.output()
 		.await
 		.into_diagnostic()
 		.wrap_err("spawning pg_basebackup")?;
-	if !status.success() {
-		bail!("pg_basebackup failed ({status})");
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	if !output.status.success() {
+		bail!("{}", failure_message(output.status, &stderr));
+	}
+	if !stderr.trim().is_empty() {
+		info!(stderr = %stderr.trim(), "pg_basebackup");
 	}
 
 	#[cfg(unix)]
 	make_readable_by_kopia(&root).await;
 	Ok((dest, root))
+}
+
+/// The error for a failed run: exit status plus what pg_basebackup said on
+/// stderr, so the report to canopy carries the actual cause.
+fn failure_message(status: impl std::fmt::Display, stderr: &str) -> String {
+	let stderr = stderr.trim();
+	if stderr.is_empty() {
+		format!("pg_basebackup failed ({status})")
+	} else {
+		format!("pg_basebackup failed ({status}): {stderr}")
+	}
 }
 
 /// Remove the streamed base backup (a full copy; reclaim the space).
@@ -173,6 +190,25 @@ mod tests {
 			super::super::stable_source_dir("tamanu-postgres")
 				.join("16")
 				.join("main")
+		);
+	}
+
+	#[test]
+	fn failure_message_carries_stderr() {
+		assert_eq!(
+			failure_message(
+				"exit code: 1",
+				"pg_basebackup: error: connection to server at \"localhost\" failed: FATAL: role \"SYSTEM\" does not exist\n",
+			),
+			"pg_basebackup failed (exit code: 1): pg_basebackup: error: connection to server at \"localhost\" failed: FATAL: role \"SYSTEM\" does not exist"
+		);
+	}
+
+	#[test]
+	fn failure_message_without_stderr_is_just_the_status() {
+		assert_eq!(
+			failure_message("exit code: 1", "  \n"),
+			"pg_basebackup failed (exit code: 1)"
 		);
 	}
 


### PR DESCRIPTION
🤖 When a `pg_basebackup` run fails, the failure reported to canopy was only the exit status — `pg_basebackup failed (exit code: 1)` — with the operative cause (auth, WAL/replication config, disk) lost to inherited stderr. 

This captures `pg_basebackup`'s stderr and includes it in the error, so canopy's backup-run history carries the real cause. `trim_error` (which caps the reported length) now renders the whole miette cause chain rather than just the outermost context, so a wrapped error still surfaces its root cause.
