### PR TITLE
feat(self-update): add --from-file to install a local binary

### DIFF
--- a/crates/alertd/src/windows_service.rs
+++ b/crates/alertd/src/windows_service.rs
@@ -8,14 +8,13 @@
 
 use std::{
 	ffi::{OsStr, OsString},
-	path::PathBuf,
 	process::Command,
 	sync::{Arc, Mutex},
 	time::Duration,
 };
 
 use miette::{IntoDiagnostic, Result, miette};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 use windows_service::{
 	define_windows_service,
 	service::{
@@ -38,12 +37,6 @@ const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 /// Required because the Windows service dispatcher calls service_main with only
 /// command line arguments, so we store the config here before dispatching.
 static SERVICE_CONFIG: Mutex<Option<DaemonConfig>> = Mutex::new(None);
-
-/// Global storage for the path to the temporary copy of the executable.
-///
-/// This ensures the temp file persists for the lifetime of the service
-/// and can be cleaned up on shutdown.
-static TEMP_EXEC_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 define_windows_service!(ffi_service_main, service_main);
 
@@ -80,20 +73,16 @@ fn service_main(_arguments: Vec<OsString>) {
 /// Main service logic that manages the daemon lifecycle.
 ///
 /// This function:
-/// 1. Copies the executable to a temporary directory to avoid file locks
-/// 2. Retrieves the daemon configuration from global storage
-/// 3. Sets up a control handler for Windows service events (stop, shutdown)
-/// 4. Reports service status to Windows SCM
-/// 5. Runs the daemon with shutdown signal integration
-/// 6. Handles graceful shutdown when requested by Windows
+/// 1. Retrieves the daemon configuration from global storage
+/// 2. Sets up a control handler for Windows service events (stop, shutdown)
+/// 3. Reports service status to Windows SCM
+/// 4. Runs the daemon with shutdown signal integration
+/// 5. Handles graceful shutdown when requested by Windows
 ///
 /// # Errors
 ///
 /// Returns an error if the daemon fails to start or encounters a fatal error.
 fn run_service_main() -> Result<()> {
-	// Copy executable to temp directory to avoid file locks during updates
-	let _temp_exec = copy_executable_to_temp()?;
-
 	let config = {
 		let mut guard = SERVICE_CONFIG.lock().unwrap();
 		guard
@@ -223,58 +212,9 @@ fn run_service_main() -> Result<()> {
 		.set_service_status(final_state)
 		.into_diagnostic()?;
 
-	// Clean up temporary executable
-	cleanup_temp_executable();
-
 	result
 }
 
-/// Copy the executable to a temporary directory to avoid file locks.
-///
-/// This allows the original executable to be updated while the service is running.
-/// Returns the path to the temporary copy.
-fn copy_executable_to_temp() -> Result<PathBuf> {
-	let original = std::env::current_exe()
-		.map_err(|e| miette!("Failed to get current executable path: {}", e))?;
-
-	let temp_dir = std::env::temp_dir();
-	let exe_name = original
-		.file_name()
-		.and_then(|n| n.to_str())
-		.ok_or_else(|| miette!("Failed to get executable name"))?;
-
-	// Include the process ID to make the temp file somewhat unique per service instance
-	let temp_name = format!("{}.{}.tmp", exe_name, std::process::id());
-	let temp_path = temp_dir.join(&temp_name);
-
-	// Copy the executable to the temp directory
-	std::fs::copy(&original, &temp_path)
-		.map_err(|e| miette!("Failed to copy executable to temp directory: {}", e))?;
-
-	// Store the temp path for later cleanup
-	{
-		let mut guard = TEMP_EXEC_PATH.lock().unwrap();
-		*guard = Some(temp_path.clone());
-	}
-
-	info!("copied executable to temp: {}", temp_path.display());
-	Ok(temp_path)
-}
-
-/// Clean up the temporary executable copy.
-fn cleanup_temp_executable() {
-	let guard = TEMP_EXEC_PATH.lock().unwrap();
-	if let Some(temp_path) = guard.as_ref() {
-		match std::fs::remove_file(temp_path) {
-			Ok(_) => info!("cleaned up temp executable: {}", temp_path.display()),
-			Err(e) => warn!(
-				"failed to clean up temp executable {}: {}",
-				temp_path.display(),
-				e
-			),
-		}
-	}
-}
 ///
 /// Checks for common issues like Service Control Manager availability,
 /// disk space, and executable accessibility.

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1376,6 +1376,9 @@ Alias: self
 * `--target <TARGET>` — Target to download.
 
    Usually the auto-detected default is fine, in rare cases you may need to override it.
+* `--from-file <FROM_FILE>` — Update from a local file instead of downloading a release.
+
+   The file is copied into place over the running binary. When set, version resolution, download, and signature verification are all skipped, and the `--version`/`--target` inputs are ignored.
 * `--temp-dir <TEMP_DIR>` — Temporary directory to download to.
 
    Defaults to the system temp directory.

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 
@@ -76,6 +76,14 @@ pub struct SelfUpdateArgs {
 	#[arg(long)]
 	pub target: Option<String>,
 
+	/// Update from a local file instead of downloading a release.
+	///
+	/// The file is copied into place over the running binary. When set, version
+	/// resolution, download, and signature verification are all skipped, and the
+	/// `--version`/`--target` inputs are ignored.
+	#[arg(long)]
+	pub from_file: Option<PathBuf>,
+
 	/// Temporary directory to download to.
 	///
 	/// Defaults to the system temp directory.
@@ -110,6 +118,7 @@ pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
 		version,
 		target,
 		temp_dir,
+		from_file,
 		force,
 		#[cfg(windows)]
 		add_to_path,
@@ -120,7 +129,13 @@ pub async fn run(args: SelfUpdateArgs, _ctx: Context) -> Result<()> {
 		tracing::error!("{err:?}");
 	}
 
-	match perform_update(&version, target, temp_dir, force).await? {
+	let outcome = if let Some(path) = from_file {
+		perform_update_from_file(&path).await?
+	} else {
+		perform_update(&version, target, temp_dir, force).await?
+	};
+
+	match outcome {
 		UpdateOutcome::AlreadyCurrent { version } => {
 			info!(
 				version = %version,
@@ -224,6 +239,33 @@ pub(crate) async fn perform_update(
 	})
 }
 
+/// Replace the running binary in place with a local file supplied by the
+/// operator, without downloading or verifying anything.
+///
+/// The signature check that guards the download path is deliberately skipped:
+/// the file is an explicit operator-supplied local binary, analogous to
+/// `--force`. The operator's file is left in place — only the running binary is
+/// overwritten. Replacing the binary does not restart anything; the caller
+/// decides what happens next.
+pub(crate) async fn perform_update_from_file(path: &Path) -> Result<UpdateOutcome> {
+	let current = env!("CARGO_PKG_VERSION");
+
+	if !path.is_file() {
+		return Err(miette!(
+			"cannot update from {}: not an existing file",
+			path.display()
+		));
+	}
+
+	info!(from = %path.display(), "replacing binary from local file");
+	self_replace::self_replace(path).into_diagnostic()?;
+
+	Ok(UpdateOutcome::Updated {
+		from: current.to_string(),
+		to: format!("file:{}", path.display()),
+	})
+}
+
 /// Ask the running alert daemon to perform the update (and restart itself),
 /// rather than swapping the binary from this separate process.
 ///
@@ -245,6 +287,17 @@ async fn delegate_to_daemon(args: &SelfUpdateArgs) -> Result<()> {
 	url.query_pairs_mut()
 		.append_pair("version", &args.version)
 		.append_pair("force", if args.force { "true" } else { "false" });
+
+	if let Some(path) = &args.from_file {
+		// The daemon runs as LocalSystem with a different working directory, so
+		// a relative path won't resolve there: hand it an absolute one.
+		let absolute = std::fs::canonicalize(path)
+			.map_err(|err| miette!("could not resolve --from-file path {}: {err}", path.display()))?;
+		let absolute = absolute
+			.to_str()
+			.ok_or_else(|| miette!("--from-file path is not valid UTF-8: {}", absolute.display()))?;
+		url.query_pairs_mut().append_pair("from_file", absolute);
+	}
 
 	info!("alert daemon is running; delegating update to it");
 	let response = client
@@ -300,6 +353,20 @@ async fn is_alertd_service_running() -> bool {
 mod tests {
 	use std::fs;
 	use tempfile::TempDir;
+
+	use super::perform_update_from_file;
+
+	#[tokio::test]
+	async fn from_file_missing_path_errors_without_replacing() {
+		// A path that does not exist must be rejected before self_replace is
+		// called, so this test never swaps the running test binary.
+		let temp_dir = TempDir::new().unwrap();
+		let missing = temp_dir.path().join("does-not-exist");
+		assert!(!missing.exists());
+
+		let result = perform_update_from_file(&missing).await;
+		assert!(result.is_err());
+	}
 
 	#[test]
 	fn test_check_exe_writable_with_writable_dir() {

--- a/crates/bestool/src/actions/self_update/task.rs
+++ b/crates/bestool/src/actions/self_update/task.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info, warn};
 
 use bestool_alertd::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
 
-use super::{UpdateOutcome, perform_update};
+use super::{UpdateOutcome, perform_update, perform_update_from_file};
 use crate::download::{fetch_latest_version, remote_is_newer};
 
 /// How often to check for a new release once the initial stagger has elapsed.
@@ -144,6 +144,39 @@ async fn on_demand_update(
 	failed_version: Arc<Mutex<Option<String>>>,
 ) -> TaskEndpointResponse {
 	let current = env!("CARGO_PKG_VERSION");
+
+	// An operator-supplied local file takes precedence over any download inputs
+	// and skips version resolution entirely. Signature verification is bypassed
+	// deliberately: the file is an explicit local binary handed over by the
+	// operator (analogous to --force), and this endpoint is loopback-only.
+	if let Some(path) = ctx.query.get("from_file") {
+		let path = std::path::PathBuf::from(path);
+		let to = format!("file:{}", path.display());
+		let restart = ctx.restart.clone();
+		tokio::spawn(async move {
+			match perform_update_from_file(&path).await {
+				Ok(_) => {
+					info!(from = %path.display(), "on-demand self-update from file installed; restarting");
+					// Brief grace so the HTTP response flushes before the daemon exits.
+					tokio::time::sleep(Duration::from_secs(1)).await;
+					if let Some(restart) = restart {
+						restart.request_restart().await;
+					}
+				}
+				Err(err) => {
+					warn!(from = %path.display(), "on-demand self-update from file failed: {err}");
+					*failed_version.lock().unwrap() = Some(format!("file:{}", path.display()));
+				}
+			}
+		});
+
+		return TaskEndpointResponse::Json(json!({
+			"updating": true,
+			"from": current,
+			"to": to,
+		}));
+	}
+
 	let requested = ctx
 		.query
 		.get("version")


### PR DESCRIPTION
🤖 Two related changes to make deploying a locally-built binary on a live Windows box possible without a full download+release cycle.

## `self-update --from-file PATH`

Adds a `--from-file` flag to `bestool self-update`. When set, self-update skips version resolution, download, and signature verification, and copies the given local file into place over the running binary via `self_replace`. The operator's source file is left in place (unlike the download path, which removes its temp file). If combined with `--version`/`--target`, from-file wins and the download inputs are ignored.

Signature verification is intentionally bypassed for `--from-file`: the file is an explicit operator-supplied local binary, analogous to `--force`.

The interesting case is the live Windows service. `self-update` delegates to the running alertd daemon over loopback HTTP (`/tasks/self-update/update`) because the daemon owns the binary swap and its own restart. `--from-file` works through that delegation: the CLI canonicalises the path to an absolute one (the daemon runs as LocalSystem with a different working directory, so a relative path would not resolve) and passes it as a `from_file` query param. The endpoint is loopback-only.

A new hermetic test checks that `perform_update_from_file` rejects a non-existent path before calling `self_replace`, so the test never swaps the test binary.

## Remove inert temp-copy machinery in alertd's Windows service

`windows_service.rs` copied the running exe to `%TEMP%` on startup, claiming it "allows the original executable to be updated while the service is running". The copy was never executed and the claim is false: a running Windows image is locked regardless. Removed the static, the copy/cleanup functions, their call sites, and the now-unused imports; updated the `run_service_main` doc comment.
