### PR TITLE
fix(tamanu): find the Windows Caddyfile when it's named Caddyfile.txt

### DIFF
--- a/crates/bestool/src/actions/tamanu/lifecycle.rs
+++ b/crates/bestool/src/actions/tamanu/lifecycle.rs
@@ -642,8 +642,8 @@ pub async fn reload_caddy() {
 
 #[cfg(target_os = "windows")]
 pub async fn reload_caddy() {
-	let path = r"C:\Caddy\Caddyfile";
-	match reload_caddy_via_admin_api(path).await {
+	let path = bestool_tamanu::caddy::caddyfile_path();
+	match reload_caddy_via_admin_api(&path).await {
 		Ok(()) => {
 			debug!("caddy reloaded via admin API");
 			return;
@@ -655,7 +655,10 @@ pub async fn reload_caddy() {
 	// path above; this fallback handles the case where caddy is running
 	// but the admin endpoint is locked down or relocated.
 	let status = Command::new(bestool_tamanu::caddy::program())
-		.args(["reload", "--config", path, "--adapter", "caddyfile"])
+		.arg("reload")
+		.arg("--config")
+		.arg(&path)
+		.args(["--adapter", "caddyfile"])
 		.status();
 	match status {
 		Ok(s) if s.success() => debug!("caddy reloaded via CLI"),
@@ -676,8 +679,9 @@ pub async fn reload_caddy() {
 /// doesn't respond, or it returns a non-2xx — the caller logs at debug
 /// and falls back to the platform CLI.
 #[cfg(target_os = "windows")]
-async fn reload_caddy_via_admin_api(path: &str) -> std::result::Result<(), String> {
-	let content = std::fs::read(path).map_err(|e| format!("read {path}: {e}"))?;
+async fn reload_caddy_via_admin_api(path: &std::path::Path) -> std::result::Result<(), String> {
+	let content =
+		std::fs::read(path).map_err(|e| format!("read {path}: {e}", path = path.display()))?;
 	let client = crate::http::client_builder()
 		.timeout(Duration::from_secs(5))
 		.build()

--- a/crates/tamanu/src/caddy.rs
+++ b/crates/tamanu/src/caddy.rs
@@ -1,5 +1,7 @@
-//! Locating the caddy executable.
+//! Locating the caddy executable and its config file.
 
+#[cfg(any(windows, test))]
+use std::path::Path;
 use std::path::PathBuf;
 
 /// The caddy executable to invoke.
@@ -18,4 +20,69 @@ pub fn program() -> PathBuf {
 		}
 	}
 	PathBuf::from("caddy")
+}
+
+/// The on-disk Caddyfile to read or reload.
+///
+/// On Windows the file lives under `C:\Caddy`, but a stock install often leaves
+/// it as `Caddyfile.txt` (Notepad appends `.txt`, and browser downloads keep
+/// the extension) rather than the extensionless `Caddyfile`; prefer whichever
+/// exists, falling back to the extensionless name so error messages name the
+/// canonical path. Everywhere else it's the standard `/etc/caddy/Caddyfile`.
+pub fn caddyfile_path() -> PathBuf {
+	#[cfg(windows)]
+	{
+		resolve_caddyfile(Path::new(r"C:\Caddy"))
+	}
+	#[cfg(not(windows))]
+	PathBuf::from("/etc/caddy/Caddyfile")
+}
+
+/// Within `dir`, prefer an existing `Caddyfile`, then an existing
+/// `Caddyfile.txt`, then the extensionless `Caddyfile` (so a missing-file error
+/// names the canonical path).
+#[cfg(any(windows, test))]
+fn resolve_caddyfile(dir: &Path) -> PathBuf {
+	let default = dir.join("Caddyfile");
+	if default.is_file() {
+		return default;
+	}
+	let with_txt = dir.join("Caddyfile.txt");
+	if with_txt.is_file() {
+		return with_txt;
+	}
+	default
+}
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+
+	use tempfile::tempdir;
+
+	use super::*;
+
+	#[test]
+	fn prefers_extensionless_caddyfile() {
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("Caddyfile"), b"a").unwrap();
+		fs::write(dir.path().join("Caddyfile.txt"), b"b").unwrap();
+		assert_eq!(resolve_caddyfile(dir.path()), dir.path().join("Caddyfile"));
+	}
+
+	#[test]
+	fn falls_back_to_txt_when_only_txt_exists() {
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("Caddyfile.txt"), b"b").unwrap();
+		assert_eq!(
+			resolve_caddyfile(dir.path()),
+			dir.path().join("Caddyfile.txt")
+		);
+	}
+
+	#[test]
+	fn defaults_to_extensionless_when_neither_exists() {
+		let dir = tempdir().unwrap();
+		assert_eq!(resolve_caddyfile(dir.path()), dir.path().join("Caddyfile"));
+	}
 }


### PR DESCRIPTION
🤖 On Windows the Caddyfile lives under `C:\Caddy`, but a stock install often leaves it as `Caddyfile.txt` (Notepad appends `.txt`, and browser downloads keep the extension) rather than the extensionless `Caddyfile`. `reload_caddy` hardcoded `C:\Caddy\Caddyfile`, so both the admin-API read and the `caddy reload --config` fallback failed:

```
Error: reading config file: open C:\Caddy\Caddyfile: The system cannot find the file specified.
WARN bestool::actions::tamanu::lifecycle: caddy reload exited with exit code: 1
```

Adds `caddy::caddyfile_path()`, which prefers an existing `Caddyfile`, then an existing `Caddyfile.txt`, then falls back to the extensionless name so a missing-file error still names the canonical path. `reload_caddy` uses it for both the admin-API and CLI reload paths. (Config backup already handled both variants.)
