### PR TITLE
feat(alertd): reconcile canopy billing tags against IMDS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,5 @@
 ## LLM Rules to follow
 - Use jj/jujutsu locally when available and enabled for the repo.
-- For tests, set the env var `DATABASE_URL=postgresql://localhost/tamanu_meta`.
 - NEVER hardcode database credentials. Always use the environment variable or existing client.
 - When adding or changing features, or when fixing bugs, add tests whenever possible.
 - Never write documentation files or readmes.
@@ -14,7 +13,6 @@
 - Prefer using small dependencies instead of reimplementing the wheel. Ask the user to pick a dependency if there is no obvious choice.
 - Imports: merge them and group them by std, then third-party/workspace, then local (crate, super, self).
 - Ask the user instead of making an assumption if there's a major detail missing from instructions that could affect code quality or implementation design.
-- For tests, set the env var `DATABASE_URL=postgresql://localhost/tamanu_meta`. ENSURE YOU DO THIS INSTEAD OF SKIPPING DATABASE TESTS.
 - When writing parsers, unless very trivial, implement them using winnow or chumsky.
 - Use the newer `foo.rs` / `foo/sub.rs` style of modules.
 - `use` statements always go before `mod` statements.

--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -15,6 +15,7 @@ use super::check::Check;
 
 pub mod util;
 
+pub mod billing_tags;
 pub mod btrfs;
 pub mod caddy_certs;
 pub mod caddy_version;
@@ -278,6 +279,7 @@ pub fn all() -> Vec<CheckEntry> {
 		// Reports the host's LAN and best-guess WAN addresses as status facts
 		// (off the wire; carried in the top-level payload, like the timezone).
 		entry!("ips", ips, host, off_wire),
+		entry!("billing_tags", billing_tags, host),
 		// Tamanu-level: the config-derived FHIR expectation degrades to Unknown
 		// without config (see `services::expected`); the rest is DB/host-derived.
 		entry!("tamanu_service", tamanu_service),

--- a/crates/alertd/src/doctor/checks/billing_tags.rs
+++ b/crates/alertd/src/doctor/checks/billing_tags.rs
@@ -1,0 +1,245 @@
+//! Reconcile canopy `billing.*` tags against the instance's IMDS tags.
+//!
+//! Billing attribution starts from the cloud provider's own instance tags, so
+//! when canopy carries `billing.*` tags they must be reflected on the instance
+//! itself. This check compares the two:
+//!   * a `billing.*` tag in canopy that's absent from IMDS → warning (the
+//!     instance isn't tagged for billing yet);
+//!   * a `billing.*` tag whose IMDS value disagrees with canopy → failure
+//!     (the instance is attributed to the wrong thing).
+//!
+//! The check only applies when both sides are present: it skips when canopy
+//! carries no `billing.*` tags, and when IMDS tags aren't available (not on
+//! EC2, or instance metadata tags disabled).
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use bestool_tamanu::server_info::load_cached_tags;
+
+use super::SweepContext;
+use crate::doctor::{check::Check, server_info::fetch_imds_tags};
+
+const CHECK_NAME: &str = "billing_tags";
+const BILLING_PREFIX: &str = "billing.";
+
+pub async fn run(_ctx: SweepContext) -> Check {
+	let canopy_tags = load_cached_tags().unwrap_or_default();
+	if !canopy_tags.keys().any(|k| is_billing(k)) {
+		return Check::skip(
+			CHECK_NAME,
+			"no billing tags in canopy",
+			"canopy tags carry no billing.* entries to reconcile against IMDS",
+		);
+	}
+
+	let imds_tags = match fetch_imds_tags().await {
+		Some(tags) => tags,
+		None => {
+			return Check::skip(
+				CHECK_NAME,
+				"no IMDS tags",
+				"instance metadata tags unavailable (not on EC2, or IMDS tags disabled)",
+			);
+		}
+	};
+
+	let recon = reconcile(&canopy_tags, &imds_tags);
+	recon.into_check()
+}
+
+fn is_billing(key: &str) -> bool {
+	key.starts_with(BILLING_PREFIX)
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Reconciliation {
+	/// Billing keys present in canopy but absent from IMDS.
+	missing: Vec<String>,
+	/// Billing keys present in both, but with differing values.
+	mismatched: Vec<Mismatch>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Mismatch {
+	key: String,
+	canopy: String,
+	imds: String,
+}
+
+/// Compare the `billing.*` subset of `canopy` against `imds`.
+///
+/// Canopy is the source of truth for which billing tags should exist; IMDS is
+/// where they must be reflected. Only keys present in canopy are considered —
+/// billing-looking IMDS tags with no canopy counterpart are ignored, since
+/// canopy governs the expected set.
+fn reconcile(canopy: &BTreeMap<String, String>, imds: &BTreeMap<String, String>) -> Reconciliation {
+	let mut recon = Reconciliation::default();
+	for (key, canopy_value) in canopy.iter().filter(|(k, _)| is_billing(k)) {
+		match imds.get(key) {
+			None => recon.missing.push(key.clone()),
+			Some(imds_value) if imds_value != canopy_value => recon.mismatched.push(Mismatch {
+				key: key.clone(),
+				canopy: canopy_value.clone(),
+				imds: imds_value.clone(),
+			}),
+			Some(_) => {}
+		}
+	}
+	recon
+}
+
+impl Reconciliation {
+	fn into_check(self) -> Check {
+		let missing_detail = Value::Array(
+			self.missing
+				.iter()
+				.cloned()
+				.map(Value::String)
+				.collect::<Vec<_>>(),
+		);
+		let mismatched_detail = Value::Array(
+			self.mismatched
+				.iter()
+				.map(|m| {
+					serde_json::json!({
+						"key": m.key,
+						"canopy": m.canopy,
+						"imds": m.imds,
+					})
+				})
+				.collect::<Vec<_>>(),
+		);
+
+		let check = if !self.mismatched.is_empty() {
+			let mut reasons: Vec<String> = self
+				.mismatched
+				.iter()
+				.map(|m| format!("{} (canopy={}, imds={})", m.key, m.canopy, m.imds))
+				.collect();
+			if !self.missing.is_empty() {
+				reasons.push(format!("missing from IMDS: {}", self.missing.join(", ")));
+			}
+			Check::fail(
+				CHECK_NAME,
+				format!("{} billing tag(s) mismatched", self.mismatched.len()),
+				format!(
+					"IMDS billing tags disagree with canopy: {}",
+					reasons.join("; ")
+				),
+			)
+		} else if !self.missing.is_empty() {
+			Check::warning(
+				CHECK_NAME,
+				format!("{} billing tag(s) missing from IMDS", self.missing.len()),
+				format!(
+					"canopy billing tags not present on the instance: {}",
+					self.missing.join(", ")
+				),
+			)
+		} else {
+			Check::pass(CHECK_NAME, "IMDS billing tags match canopy")
+		};
+
+		check
+			.with_detail("missing", missing_detail)
+			.with_detail("mismatched", mismatched_detail)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+		pairs
+			.iter()
+			.map(|(k, v)| (k.to_string(), v.to_string()))
+			.collect()
+	}
+
+	#[test]
+	fn all_present_and_matching_is_clean() {
+		let canopy = map(&[("billing.customer", "acme"), ("role", "central")]);
+		let imds = map(&[("billing.customer", "acme"), ("Name", "host-1")]);
+		let recon = reconcile(&canopy, &imds);
+		assert_eq!(recon, Reconciliation::default());
+	}
+
+	#[test]
+	fn missing_billing_tag_is_reported() {
+		let canopy = map(&[("billing.customer", "acme"), ("billing.project", "p1")]);
+		let imds = map(&[("billing.customer", "acme")]);
+		let recon = reconcile(&canopy, &imds);
+		assert_eq!(recon.missing, vec!["billing.project".to_string()]);
+		assert!(recon.mismatched.is_empty());
+	}
+
+	#[test]
+	fn mismatched_billing_tag_is_reported() {
+		let canopy = map(&[("billing.customer", "acme")]);
+		let imds = map(&[("billing.customer", "globex")]);
+		let recon = reconcile(&canopy, &imds);
+		assert!(recon.missing.is_empty());
+		assert_eq!(
+			recon.mismatched,
+			vec![Mismatch {
+				key: "billing.customer".to_string(),
+				canopy: "acme".to_string(),
+				imds: "globex".to_string(),
+			}]
+		);
+	}
+
+	#[test]
+	fn non_billing_tags_are_ignored() {
+		let canopy = map(&[("role", "central"), ("fleet", "prod")]);
+		let imds = map(&[("role", "facility")]);
+		let recon = reconcile(&canopy, &imds);
+		assert_eq!(recon, Reconciliation::default());
+	}
+
+	#[test]
+	fn extra_imds_billing_tags_are_ignored() {
+		let canopy = map(&[("billing.customer", "acme")]);
+		let imds = map(&[("billing.customer", "acme"), ("billing.extra", "x")]);
+		let recon = reconcile(&canopy, &imds);
+		assert_eq!(recon, Reconciliation::default());
+	}
+
+	#[test]
+	fn mismatch_takes_precedence_over_missing_as_failure() {
+		let canopy = map(&[("billing.customer", "acme"), ("billing.project", "p1")]);
+		let imds = map(&[("billing.customer", "globex")]);
+		let recon = reconcile(&canopy, &imds);
+		let check = recon.into_check();
+		assert!(matches!(
+			check.status,
+			crate::doctor::check::CheckStatus::Fail(_)
+		));
+	}
+
+	#[test]
+	fn missing_only_is_a_warning() {
+		let canopy = map(&[("billing.project", "p1")]);
+		let imds = map(&[("billing.customer", "acme")]);
+		let recon = reconcile(&canopy, &imds);
+		let check = recon.into_check();
+		assert!(matches!(
+			check.status,
+			crate::doctor::check::CheckStatus::Warning(_)
+		));
+	}
+
+	#[test]
+	fn clean_is_a_pass() {
+		let canopy = map(&[("billing.customer", "acme")]);
+		let imds = map(&[("billing.customer", "acme")]);
+		let check = reconcile(&canopy, &imds).into_check();
+		assert!(matches!(
+			check.status,
+			crate::doctor::check::CheckStatus::Pass
+		));
+	}
+}

--- a/crates/alertd/src/doctor/server_info.rs
+++ b/crates/alertd/src/doctor/server_info.rs
@@ -195,7 +195,7 @@ pub async fn gather(bestool_version: &str, tamanu_version: &str, facts: ServerFa
 /// when not on EC2, when the token endpoint is unreachable, or when instance
 /// metadata tags aren't enabled for the instance — this is best-effort host
 /// context and never fails the sweep.
-async fn fetch_imds_tags() -> Option<BTreeMap<String, String>> {
+pub(crate) async fn fetch_imds_tags() -> Option<BTreeMap<String, String>> {
 	let client = reqwest::Client::builder()
 		.timeout(IMDS_TIMEOUT)
 		.connect_timeout(IMDS_TIMEOUT)

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -94,7 +94,7 @@ Didn't expect this much output? Use the short '-h' flag to get short help.
 * `alertd` — Run the healthcheck daemon
 * `audit-psql` — Export audit database entries as JSON
 * `caddy` — Manage Caddy
-* `canopy` — Interact with Canopy (the Tamanu meta-monitoring service)
+* `canopy` — Interact with Canopy
 * `crypto` — Cryptographic operations
 * `file` — File utilities
 * `iti` — Tamanu Iti subcommands
@@ -320,7 +320,7 @@ Download caddy
 
 ## `bestool canopy`
 
-Interact with Canopy (the Tamanu meta-monitoring service)
+Interact with Canopy
 
 **Usage:** `bestool canopy <COMMAND>`
 

--- a/crates/bestool/src/actions/canopy.rs
+++ b/crates/bestool/src/actions/canopy.rs
@@ -13,7 +13,7 @@ use miette::Result;
 
 use super::Context;
 
-/// Interact with Canopy (the Tamanu meta-monitoring service).
+/// Interact with Canopy.
 #[derive(Debug, Clone, Parser)]
 pub struct CanopyArgs {
 	/// Canopy subcommand

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -3,7 +3,10 @@
 //! Used by `canopy register`, `alertd`, and `doctor`. Kept here so each
 //! subcommand pulls from one place rather than reaching into a sibling's module.
 
-use std::path::{Path, PathBuf};
+use std::{
+	collections::BTreeMap,
+	path::{Path, PathBuf},
+};
 
 use miette::{IntoDiagnostic, Result};
 use tracing::{debug, info, warn};
@@ -55,6 +58,45 @@ pub fn standard_tags_path() -> PathBuf {
 	} else {
 		PathBuf::from("/etc/tamanu/tags.json")
 	}
+}
+
+/// Load the cached canopy tags written by `bestool tamanu tags`.
+///
+/// Reads [`standard_tags_path`] and returns the `tags` map. The cache is a
+/// `{ "tags": { .. }, "fetched_at": .. }` object; only the `tags` field is read
+/// here, so the timestamp and any future fields are ignored. Returns `None`
+/// when the cache is absent or unparseable.
+///
+/// Used by callers that need the tags without a canopy round-trip — e.g. the
+/// doctor reconciling `billing.*` tags against the instance's IMDS tags.
+pub fn load_cached_tags() -> Option<BTreeMap<String, String>> {
+	load_cached_tags_at(&standard_tags_path())
+}
+
+fn load_cached_tags_at(path: &Path) -> Option<BTreeMap<String, String>> {
+	let bytes = match std::fs::read(path) {
+		Ok(bytes) => bytes,
+		Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+		Err(err) => {
+			debug!(path = %path.display(), %err, "could not read tags cache");
+			return None;
+		}
+	};
+
+	let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+		Ok(value) => value,
+		Err(err) => {
+			debug!(path = %path.display(), %err, "could not parse tags cache");
+			return None;
+		}
+	};
+
+	let obj = value.get("tags")?.as_object()?;
+	Some(
+		obj.iter()
+			.filter_map(|(key, value)| Some((key.clone(), value.as_str()?.to_string())))
+			.collect(),
+	)
 }
 
 /// Resolve the `metaServerId` for this Tamanu server.
@@ -724,6 +766,45 @@ mod tests {
 		// behaviour didn't lose data.
 		write_device_key_file(&path, "NEW").unwrap();
 		assert_eq!(std::fs::read_to_string(&path).unwrap(), "NEW");
+	}
+
+	#[test]
+	fn load_cached_tags_reads_tags_object() {
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("tags.json");
+		std::fs::write(
+			&path,
+			r#"{"tags":{"billing.customer":"acme","role":"central"},"fetched_at":"2026-01-01T00:00:00Z"}"#,
+		)
+		.unwrap();
+		let tags = load_cached_tags_at(&path).expect("should load");
+		assert_eq!(
+			tags.get("billing.customer").map(String::as_str),
+			Some("acme")
+		);
+		assert_eq!(tags.get("role").map(String::as_str), Some("central"));
+	}
+
+	#[test]
+	fn load_cached_tags_none_for_missing_file() {
+		let dir = tempfile::tempdir().unwrap();
+		assert!(load_cached_tags_at(&dir.path().join("nope.json")).is_none());
+	}
+
+	#[test]
+	fn load_cached_tags_none_for_garbage() {
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("tags.json");
+		std::fs::write(&path, "not json").unwrap();
+		assert!(load_cached_tags_at(&path).is_none());
+	}
+
+	#[test]
+	fn load_cached_tags_empty_when_no_tags_field() {
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("tags.json");
+		std::fs::write(&path, r#"{"fetched_at":null}"#).unwrap();
+		assert!(load_cached_tags_at(&path).is_none());
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Adds a `billing_tags` doctor healthcheck that reconciles canopy's `billing.*` tags against the instance's IMDS tags, so billing attribution on the instance stays in sync with canopy.

When canopy carries `billing.*` tags **and** IMDS tags are available:
- **WARN** if a `billing.*` tag from canopy is missing from IMDS (the instance isn't tagged for billing yet).
- **FAIL** if a `billing.*` tag's IMDS value disagrees with canopy (the instance is attributed to the wrong thing). A mismatch outranks a missing tag.
- **PASS** when every canopy billing tag is present on IMDS with a matching value.
- **SKIP** when canopy has no `billing.*` tags, or the host isn't on EC2 / IMDS tags are disabled.

Canopy is treated as the source of truth for the expected set: IMDS billing tags with no canopy counterpart are ignored.

Supporting changes:
- `bestool_tamanu::server_info::load_cached_tags` reads the tags cache (`{ "tags": {...} }`) written by `bestool tamanu tags`, without a canopy round-trip.
- `fetch_imds_tags` (from the IMDS PR) is exposed to the checks.

The reconciliation logic and cache loader are unit-tested.

---
Stacked on #649 — review/merge that first; this diff is only the new check.
