### PR TITLE
fix(canopy): select restore snapshot by id alone, not the canopy-type tag

### DIFF
--- a/.workhorse/specs/canopy/backup.md
+++ b/.workhorse/specs/canopy/backup.md
@@ -162,8 +162,10 @@ The superuser connection already carries the replication privilege.
 
 ## Restore
 
-`bestool canopy restore --type <type>` is the operator-facing restore.
-It resolves the definition, fetches restore-purpose (read-only) credentials, connects to the repository, and selects a snapshot — the latest, or one named by id — filtered to this server and this backup type.
+`bestool canopy restore <type> <id>` is the operator-facing restore.
+The backup type selects the definition, method, and credential scope; the snapshot to restore is named explicitly by id.
+It resolves the definition, fetches restore-purpose (read-only) credentials, connects to the repository, and selects the snapshot whose id matches.
+Selection is by id across the whole repository — not scoped to the server issuing the restore — so a replacement host can restore a backup taken by the server it succeeds.
 It restores the snapshot into a staging area on the same filesystem as the target so the final move is atomic, then hands off to the method.
 
 The `postgresql` method's restore is a full automated swap: it stops the cluster, moves the existing data directory aside (kept, not deleted), moves the restored tree into place with the right ownership and permissions, starts the cluster via plain crash recovery, and verifies it accepts connections.

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -120,7 +120,7 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 
 	// Select the snapshot to restore.
 	let snapshots = list_snapshots(&kopia, &s3env).await?;
-	let snapshot = select_snapshot(&snapshots, &args.backup_type, &args.id)?;
+	let snapshot = select_snapshot(&snapshots, &args.id)?;
 	info!(
 		id = %snapshot.id,
 		taken = ?snapshot.end_time.or(snapshot.start_time),
@@ -159,25 +159,49 @@ async fn list_snapshots(kopia: &std::path::Path, s3env: &S3KopiaEnv<'_>) -> Resu
 
 /// Pick the snapshot to restore from the repo's list by id prefix.
 ///
-/// Selection is deliberately not scoped to the local server: a restore is
-/// typically onto a different (rebuilt or replacement) host than the one that
-/// took the backup, so the snapshot's source host is not this server's id.
-fn select_snapshot<'a>(
-	snapshots: &'a [Snapshot],
-	backup_type: &str,
-	id: &str,
-) -> Result<&'a Snapshot> {
-	let mut hits = snapshots.iter().filter(|s| {
-		s.id.starts_with(id)
-			&& s.tags.get("canopy-type").map(String::as_str) == Some(backup_type)
-	});
-	let first = hits
-		.next()
-		.ok_or_else(|| miette!("no '{backup_type}' snapshot matching id '{id}' in the repository"))?;
+/// Selection is by snapshot id alone. It is deliberately not scoped to the
+/// local server — a restore is typically onto a different (rebuilt or
+/// replacement) host, so the snapshot's source host is not this server's id —
+/// nor gated on the `canopy-type` tag: kopia's `snapshot list` does not echo
+/// the tags set at create time, so every listed snapshot deserialises with no
+/// tags and gating on them would reject every snapshot. The backup type still
+/// selects the def, method, and credentials in the caller.
+fn select_snapshot<'a>(snapshots: &'a [Snapshot], id: &str) -> Result<&'a Snapshot> {
+	let mut hits = snapshots.iter().filter(|s| s.id.starts_with(id));
+	let Some(first) = hits.next() else {
+		bail!(
+			"no snapshot matching id '{id}' in the repository{}",
+			available_snapshots_hint(snapshots)
+		);
+	};
 	if hits.next().is_some() {
 		bail!("snapshot id '{id}' is ambiguous; give more characters");
 	}
 	Ok(first)
+}
+
+/// Describe what the connected repository actually holds, appended to the
+/// "no match" error so the operator can see the ids available rather than
+/// guess. Newest first, capped so the message stays readable.
+fn available_snapshots_hint(snapshots: &[Snapshot]) -> String {
+	if snapshots.is_empty() {
+		return "; the repository has no snapshots".to_owned();
+	}
+	const MAX: usize = 20;
+	let mut sorted: Vec<&Snapshot> = snapshots.iter().collect();
+	sorted.sort_by_key(|s| std::cmp::Reverse(s.end_time.or(s.start_time)));
+	let mut out = format!("; {} snapshot(s) available (id, source, taken):", snapshots.len());
+	for s in sorted.iter().take(MAX) {
+		let taken = s
+			.end_time
+			.or(s.start_time)
+			.map_or_else(|| "unknown".to_owned(), |t| t.to_string());
+		out.push_str(&format!("\n  {} {} {taken}", s.id, s.source.host));
+	}
+	if snapshots.len() > MAX {
+		out.push_str(&format!("\n  … and {} more", snapshots.len() - MAX));
+	}
+	out
 }
 
 /// Interactive double-confirmation for a destructive restore. Returns `true`
@@ -214,7 +238,9 @@ mod tests {
 
 	use super::*;
 
-	fn snap(id: &str, host: &str, btype: &str, end: Option<&str>) -> Snapshot {
+	/// A snapshot as kopia's `snapshot list --json` actually emits it: source
+	/// host and id, but no tags (kopia does not echo the create-time tags).
+	fn snap(id: &str, host: &str, end: Option<&str>) -> Snapshot {
 		Snapshot {
 			id: id.into(),
 			source: SnapshotSource {
@@ -225,45 +251,55 @@ mod tests {
 			description: String::new(),
 			start_time: None,
 			end_time: end.map(|t| t.parse().unwrap()),
-			tags: std::collections::BTreeMap::from([("canopy-type".into(), btype.into())]),
+			tags: std::collections::BTreeMap::new(),
 			root_entry: None,
 		}
 	}
 
 	#[test]
 	fn selects_by_id_prefix() {
-		let snaps = vec![snap("abc123", "srv", "tamanu-postgres", None)];
-		let chosen = select_snapshot(&snaps, "tamanu-postgres", "abc").unwrap();
+		let snaps = vec![snap("abc123", "srv", None)];
+		let chosen = select_snapshot(&snaps, "abc").unwrap();
 		assert_eq!(chosen.id, "abc123");
+	}
+
+	#[test]
+	fn selects_when_kopia_omits_tags() {
+		// The regression: kopia's snapshot list returns no tags, so gating on the
+		// canopy-type tag rejected every snapshot. Selection by id must still find
+		// a valid, correct id.
+		let snaps = vec![snap("99f1f3f6e25f483b5196d61d2f28a871", "srv", None)];
+		let chosen = select_snapshot(&snaps, "99f1f3f6e25f483b5196d61d2f28a871").unwrap();
+		assert_eq!(chosen.id, "99f1f3f6e25f483b5196d61d2f28a871");
 	}
 
 	#[test]
 	fn selects_across_hosts() {
 		// A restore onto a different host: the snapshot's source host is not this
 		// server's id, but selection by id must still find it.
-		let snaps = vec![snap("abc123", "other-host", "tamanu-postgres", None)];
-		let chosen = select_snapshot(&snaps, "tamanu-postgres", "abc").unwrap();
+		let snaps = vec![snap("abc123", "other-host", None)];
+		let chosen = select_snapshot(&snaps, "abc").unwrap();
 		assert_eq!(chosen.id, "abc123");
 	}
 
 	#[test]
 	fn errors_on_ambiguous_prefix() {
-		let snaps = vec![
-			snap("abc123", "srv", "tamanu-postgres", None),
-			snap("abc456", "other", "tamanu-postgres", None),
-		];
-		assert!(select_snapshot(&snaps, "tamanu-postgres", "abc").is_err());
+		let snaps = vec![snap("abc123", "srv", None), snap("abc456", "other", None)];
+		assert!(select_snapshot(&snaps, "abc").is_err());
 	}
 
 	#[test]
-	fn errors_when_no_match() {
-		let snaps = vec![snap("abc", "srv", "tamanu-postgres", None)];
-		assert!(select_snapshot(&snaps, "tamanu-postgres", "zzz").is_err());
+	fn errors_when_no_match_lists_available() {
+		let snaps = vec![snap("abc", "srv", Some("2026-01-01T00:00:00Z"))];
+		let err = select_snapshot(&snaps, "zzz").unwrap_err().to_string();
+		assert!(err.contains("no snapshot matching id 'zzz'"));
+		assert!(err.contains("abc"));
 	}
 
 	#[test]
-	fn errors_on_type_mismatch() {
-		let snaps = vec![snap("abc123", "srv", "files", None)];
-		assert!(select_snapshot(&snaps, "tamanu-postgres", "abc").is_err());
+	fn errors_when_repository_empty() {
+		let snaps: Vec<Snapshot> = vec![];
+		let err = select_snapshot(&snaps, "abc").unwrap_err().to_string();
+		assert!(err.contains("no snapshots"));
 	}
 }

--- a/crates/bestool/src/actions/kopia/list.rs
+++ b/crates/bestool/src/actions/kopia/list.rs
@@ -1,6 +1,6 @@
 use bestool_kopia::{
 	Snapshot, build_filter, fetch_snapshots, format_tags, format_taken, human_bytes, parse_tag_kv,
-	short_id,
+	parse_tags, short_id,
 };
 use clap::Parser;
 use comfy_table::{ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
@@ -53,13 +53,12 @@ pub async fn run(args: ListArgs, ctx: Context) -> Result<()> {
 	let kopia = ctx.require::<KopiaArgs>();
 	let bin = kopia_binary(kopia)?;
 
-	let snapshots = fetch_snapshots(&bin)?;
+	let snapshots = fetch_snapshots(&bin, &parse_tags(&args.tags)?)?;
 
 	let filter = build_filter(
 		args.all,
 		args.source_host,
 		current_hostname(),
-		&args.tags,
 		args.path,
 		args.since.as_deref(),
 		args.limit,

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -573,13 +573,15 @@ impl Snapshot {
 	}
 }
 
-/// Filter criteria used by listing/restore/mount.
+/// In-process filter criteria for a snapshot list.
+///
+/// Tag filtering is not here: kopia's `snapshot list` does not echo the
+/// create-time tags, so tags are applied at the source (see
+/// [`fetch_snapshots`]), not against the parsed list.
 #[derive(Debug, Default, Clone)]
 pub struct SnapshotFilter {
 	/// `None` means "any host". `Some(name)` filters source.host == name.
 	pub source_host: Option<String>,
-	/// All entries must match.
-	pub tags: BTreeMap<String, String>,
 	/// Source path must contain this substring (case-insensitive).
 	pub path_substr: Option<String>,
 	/// Snapshot's taken_at must be within this Span from now.
@@ -603,11 +605,6 @@ impl SnapshotFilter {
 					&& s.source.host != *host
 				{
 					return false;
-				}
-				for (k, v) in &self.tags {
-					if s.tags.get(k) != Some(v) {
-						return false;
-					}
 				}
 				if let Some(needle) = &path_substr_lc
 					&& !s.source.path.to_lowercase().contains(needle)
@@ -641,13 +638,22 @@ pub fn parse_tag_kv(s: &str) -> Result<(String, String), String> {
 		.ok_or_else(|| format!("expected KEY:VALUE, got `{s}`"))
 }
 
+/// Parse repeated `--tag KEY:VALUE` flags into a map for [`fetch_snapshots`].
+pub fn parse_tags(tags: &[String]) -> Result<BTreeMap<String, String>> {
+	let mut map = BTreeMap::new();
+	for raw in tags {
+		let (k, v) = parse_tag_kv(raw).map_err(|e| miette!("invalid --tag: {e}"))?;
+		map.insert(k, v);
+	}
+	Ok(map)
+}
+
 /// Build a [`SnapshotFilter`] from CLI-shaped inputs. `all = true` drops any
-/// source-host filter.
+/// source-host filter. Tags are applied at fetch time, not here.
 pub fn build_filter(
 	all: bool,
 	source_host: Option<String>,
 	default_host: Option<String>,
-	tags: &[String],
 	path: Option<String>,
 	since: Option<&str>,
 	limit: Option<usize>,
@@ -658,12 +664,6 @@ pub fn build_filter(
 		source_host.or(default_host)
 	};
 
-	let mut tag_map = BTreeMap::new();
-	for raw in tags {
-		let (k, v) = parse_tag_kv(raw).map_err(|e| miette!("invalid --tag: {e}"))?;
-		tag_map.insert(k, v);
-	}
-
 	let since = since
 		.map(|s| {
 			s.parse::<Span>()
@@ -673,22 +673,35 @@ pub fn build_filter(
 
 	Ok(SnapshotFilter {
 		source_host,
-		tags: tag_map,
 		path_substr: path,
 		since,
 		limit,
 	})
 }
 
-/// Run `kopia snapshot list --json --all` and parse the result.
+/// Build the `kopia snapshot list --json --all` command, filtering by `tags`.
+///
+/// Tags are applied by kopia (`--tags KEY:VALUE`) against the snapshot's
+/// manifest labels: `snapshot list` does not echo the create-time tags in its
+/// output, so filtering on them in-process would match nothing.
+fn snapshot_list_command(bin: &Path, tags: &BTreeMap<String, String>) -> Command {
+	let mut cmd = Command::new(bin);
+	cmd.args(["snapshot", "list", "--json", "--all"]);
+	for (k, v) in tags {
+		cmd.arg("--tags").arg(format!("{k}:{v}"));
+	}
+	cmd.env("KOPIA_CHECK_FOR_UPDATES", "false");
+	cmd
+}
+
+/// Run `kopia snapshot list --json --all` (optionally tag-filtered) and parse
+/// the result.
 ///
 /// `bin` is expected to already be wrapped by [`build_kopia_command`] if
 /// elevation was needed — callers typically run that first and pass the
 /// resulting binary path here.
-pub fn fetch_snapshots(bin: &Path) -> Result<Vec<Snapshot>> {
-	let output = Command::new(bin)
-		.args(["snapshot", "list", "--json", "--all"])
-		.env("KOPIA_CHECK_FOR_UPDATES", "false")
+pub fn fetch_snapshots(bin: &Path, tags: &BTreeMap<String, String>) -> Result<Vec<Snapshot>> {
+	let output = snapshot_list_command(bin, tags)
 		.output()
 		.into_diagnostic()
 		.wrap_err_with(|| format!("invoking {}", bin.display()))?;
@@ -851,12 +864,11 @@ mod cli {
 				);
 			}
 
-			let snapshots = fetch_snapshots(bin)?;
+			let snapshots = fetch_snapshots(bin, &parse_tags(&self.tags)?)?;
 			let filter = build_filter(
 				self.all,
 				self.source_host.clone(),
 				default_host,
-				&self.tags,
 				self.path.clone(),
 				self.since.as_deref(),
 				None,
@@ -883,7 +895,7 @@ mod cli {
 	}
 
 	fn resolve_by_id(bin: &std::path::Path, id_query: &str) -> Result<Snapshot> {
-		let snapshots = fetch_snapshots(bin)?;
+		let snapshots = fetch_snapshots(bin, &BTreeMap::new())?;
 		let matches: Vec<&Snapshot> = snapshots
 			.iter()
 			.filter(|s| s.id.starts_with(id_query))
@@ -1201,23 +1213,32 @@ mod tests {
 	}
 
 	#[test]
-	fn filter_by_tags_requires_all_to_match() {
-		let now = Timestamp::from_second(10_000_000).unwrap();
-		let mut tagged = snapshot("t", "h", "/data", now);
-		tagged.tags.insert("area".into(), "postgres".into());
-		tagged.tags.insert("type".into(), "ext4".into());
-		let snaps = vec![tagged, snapshot("u", "h", "/data", now)];
-
+	fn snapshot_list_command_passes_tags_to_kopia() {
+		// Tags must be filtered by kopia (`--tags KEY:VALUE`), not in-process:
+		// `snapshot list` doesn't echo them, so a parsed snapshot has empty tags.
 		let mut tags = BTreeMap::new();
 		tags.insert("area".into(), "postgres".into());
 		tags.insert("type".into(), "ext4".into());
-		let filter = SnapshotFilter {
-			tags,
-			..Default::default()
-		};
-		let got = filter.apply(&snaps, now);
-		assert_eq!(got.len(), 1);
-		assert_eq!(got[0].id, "t");
+		let cmd = snapshot_list_command(Path::new("kopia"), &tags);
+		let args: Vec<String> = cmd
+			.get_args()
+			.map(|a| a.to_string_lossy().into_owned())
+			.collect();
+		assert!(args.contains(&"--all".to_string()));
+		assert!(
+			args.windows(2)
+				.any(|w| w[0] == "--tags" && w[1] == "area:postgres")
+		);
+		assert!(args.windows(2).any(|w| w[0] == "--tags" && w[1] == "type:ext4"));
+	}
+
+	#[test]
+	fn snapshot_list_command_without_tags_omits_tag_flag() {
+		let cmd = snapshot_list_command(Path::new("kopia"), &BTreeMap::new());
+		assert!(
+			!cmd.get_args()
+				.any(|a| a.to_string_lossy() == "--tags")
+		);
 	}
 
 	#[test]
@@ -1304,23 +1325,14 @@ mod tests {
 
 	#[test]
 	fn build_filter_all_drops_host() {
-		let filter =
-			build_filter(true, None, Some("ignored".into()), &[], None, None, None).unwrap();
+		let filter = build_filter(true, None, Some("ignored".into()), None, None, None).unwrap();
 		assert!(filter.source_host.is_none());
 	}
 
 	#[test]
 	fn build_filter_default_host_used_when_not_overridden() {
-		let filter = build_filter(
-			false,
-			None,
-			Some("default-host".into()),
-			&[],
-			None,
-			None,
-			None,
-		)
-		.unwrap();
+		let filter =
+			build_filter(false, None, Some("default-host".into()), None, None, None).unwrap();
 		assert_eq!(filter.source_host.as_deref(), Some("default-host"));
 	}
 
@@ -1330,7 +1342,6 @@ mod tests {
 			false,
 			Some("explicit".into()),
 			Some("default".into()),
-			&[],
 			None,
 			None,
 			None,
@@ -1341,14 +1352,13 @@ mod tests {
 
 	#[test]
 	fn build_filter_parses_since() {
-		let filter = build_filter(false, None, None, &[], None, Some("24h"), None).unwrap();
+		let filter = build_filter(false, None, None, None, Some("24h"), None).unwrap();
 		assert!(filter.since.is_some());
 	}
 
 	#[test]
 	fn build_filter_rejects_bad_since() {
-		let err =
-			build_filter(false, None, None, &[], None, Some("not-a-duration"), None).unwrap_err();
+		let err = build_filter(false, None, None, None, Some("not-a-duration"), None).unwrap_err();
 		assert!(format!("{err}").contains("--since"));
 	}
 


### PR DESCRIPTION
🤖 Restoring a snapshot by a valid, correct id failed with `no snapshot matching id '<id>' in the repository`, even on the server that took the backup, in the right group, with a live restore credential.

The cause: `select_snapshot` matched on `s.id.starts_with(id) && s.tags.get("canopy-type") == Some(type)`. But kopia's `snapshot list` output does not echo the tags set at snapshot-create time (it stores them as manifest labels), so every listed snapshot deserialises with no tags. The tag half of the condition was therefore always false, and selection rejected every snapshot regardless of the id. The unit tests passed only because they hand-constructed `tags` maps that real kopia output never contains.

This matches by id alone. The backup type still selects the def, method, and credential scope in the caller; it no longer gates snapshot selection. When no id matches, the error now lists the ids the connected repository actually holds (id, source server, taken-at), rather than leaving the operator to guess.

Also updates the restore spec to the current shape (positional `<type> <id>`, id-only selection, not scoped to the issuing server).

## Also: the same bug in the generic snapshot filter

`SnapshotFilter` filtered listings by `.tags` read back from the same tagless `snapshot list` output, so `bestool kopia list --tag` and the `--tag` snapshot picker (restore/mount) matched nothing too. Tag filtering now passes `--tags KEY:VALUE` to kopia, which filters against the manifest labels; the in-process filter no longer carries tags.
