### PR TITLE
fix(canopy): fix Windows restore — service stop, prompt-to-retry, kopia progress

### DIFF
--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -187,7 +187,7 @@ canopy-tags = ["__canopy", "tamanu-config", "bestool-tamanu/canopy-registration"
 # Config-driven backups: registers capabilities with canopy, runs pre/method/post
 # per a backups/*.toml def, drives kopia, reports the outcome. The `postgresql`
 # method needs bestool-postgres (CHECKPOINT/verify) but not Tamanu config.
-canopy-backup = ["__canopy", "bestool-tamanu/canopy-registration", "dep:bestool-kopia", "bestool-kopia/proxy", "dep:bestool-postgres", "dep:axum", "dep:toml", "dep:notify", "dep:fs4"]
+canopy-backup = ["__canopy", "bestool-tamanu/canopy-registration", "dep:bestool-kopia", "bestool-kopia/proxy", "dep:bestool-postgres", "dep:axum", "dep:toml", "dep:notify", "dep:fs4", "dep:windows-service"]
 canopy-restore = ["canopy-backup"]
 __canopy = ["dep:bestool-canopy"] # internal feature to enable the canopy subcommand common code
 

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -645,6 +645,24 @@ async fn snapshot(
 	Ok(parse_snapshot_output(&stdout))
 }
 
+/// Run a kopia command with its stdout/stderr inherited, so kopia's own
+/// progress display reaches the terminal (it stays silent when its output is a
+/// pipe, as [`run_kopia`] leaves it). stdin is detached so kopia can't consume
+/// the caller's prompts. Errors on a non-zero exit; the output the user already
+/// saw stands in for a captured error message.
+pub(super) async fn run_kopia_visible(cmd: std::process::Command, what: &str) -> Result<()> {
+	let status = tokio::process::Command::from(cmd)
+		.stdin(std::process::Stdio::null())
+		.status()
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("spawning kopia {what}"))?;
+	if !status.success() {
+		bail!("kopia {what} failed ({status})");
+	}
+	Ok(())
+}
+
 /// Run a kopia command, returning its stdout on success.
 pub(super) async fn run_kopia(cmd: std::process::Command, what: &str) -> Result<String> {
 	let output = tokio::process::Command::from(cmd)

--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -83,6 +83,15 @@ pub struct PostgresqlConfig {
 	/// Force a snapshot strategy instead of auto-detecting (for testing).
 	#[serde(default)]
 	pub strategy: Option<String>,
+	/// Override the service controlled around a restore. On Windows this is the
+	/// service name (defaults to the EDB installer's `postgresql-x64-<version>`);
+	/// ignored on Unix, where the systemd unit is derived from version + cluster.
+	#[serde(default)]
+	#[cfg_attr(
+		not(windows),
+		expect(dead_code, reason = "only read on Windows; Unix derives the systemd unit")
+	)]
+	pub service_name: Option<String>,
 }
 
 /// A built-in backup method, selected by the def's single method table.

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -10,6 +10,7 @@ pub mod basebackup;
 pub mod btrfs;
 pub mod lvm;
 pub mod resolve;
+mod service;
 pub mod strategy;
 mod sys;
 pub mod vss;
@@ -169,40 +170,58 @@ pub async fn restore(
 
 	super::method::ensure_not_clobbering(&target.data_dir, opts.clobber)?;
 
-	stop_cluster(&target).await;
+	// Stop the cluster before swapping the data directory: on Windows an open
+	// handle to the running server's files makes the move fail outright; on Unix
+	// it would corrupt a live cluster. Both this and the swap depend on nothing
+	// else holding the files, so let the operator clear a stubborn holder by hand
+	// and retry — each attempt re-checks, so the stop can't be skipped.
+	crate::interactive::retry("stopping the postgres cluster", async || {
+		service::stop(&target, config).await
+	})
+	.await?;
 
-	super::method::replace_dir(&restored, &target.data_dir).await?;
-	fix_ownership(&target.data_dir).await?;
+	crate::interactive::retry("moving the data directory into place", async || {
+		super::method::replace_dir(&restored, &target.data_dir).await
+	})
+	.await?;
 
-	if let Err(err) = start_cluster(&target).await {
-		warn!(
-			"cluster did not start cleanly ({err}); resetting WAL as a last resort \
-			 (this may indicate a non-clean backup)"
-		);
-		pg_resetwal(&target.data_dir).await?;
-		start_cluster(&target).await?;
-	}
+	crate::interactive::retry("fixing data directory ownership", async || {
+		fix_ownership(&target.data_dir).await
+	})
+	.await?;
+
+	// A crash-consistent restore normally starts via ordinary crash recovery. If
+	// it won't, resetting the WAL forces a start but is a destructive last resort,
+	// so it's an explicit operator choice rather than automatic.
+	crate::interactive::retry_or_recover(
+		"starting the postgres cluster",
+		"reset the write-ahead log",
+		"force-reset the WAL so the cluster can start without replaying it — \
+		 destructive: can discard recent transactions or corrupt an \
+		 otherwise-healthy cluster; only sound for a backup that won't start any \
+		 other way",
+		async || service::start(&target, config).await,
+		async || pg_resetwal(&target.data_dir).await,
+	)
+	.await?;
 
 	verify(config, &target.data_dir).await;
 	info!("restore complete; run migrations / config sync as needed");
 	Ok(())
 }
 
-async fn stop_cluster(target: &resolve::ResolvedCluster) {
-	let unit = format!("postgresql@{}-{}", target.version, target.cluster);
-	if let Err(err) = run_status("systemctl", &["stop", &unit]).await {
-		warn!("stopping {unit} failed (continuing): {err}");
-	}
-}
-
-async fn start_cluster(target: &resolve::ResolvedCluster) -> Result<()> {
-	let unit = format!("postgresql@{}-{}", target.version, target.cluster);
-	run_status("systemctl", &["start", &unit]).await
-}
-
+/// Restore the postgres-owned mode and ownership of the freshly-swapped data
+/// directory. Unix-only: on Windows the directory inherits its parent's ACLs
+/// (the EDB install root), which is what the service account already expects.
+#[cfg(unix)]
 async fn fix_ownership(data_dir: &Path) -> Result<()> {
 	run_status("chown", &["-R", "postgres:postgres", path(data_dir)]).await?;
 	run_status("chmod", &["0750", path(data_dir)]).await
+}
+
+#[cfg(not(unix))]
+async fn fix_ownership(_data_dir: &Path) -> Result<()> {
+	Ok(())
 }
 
 async fn pg_resetwal(data_dir: &Path) -> Result<()> {
@@ -224,11 +243,13 @@ async fn verify(config: &PostgresqlConfig, data_dir: &Path) {
 	}
 }
 
+#[cfg(unix)]
 fn path(p: &Path) -> &str {
 	p.to_str().unwrap_or_default()
 }
 
-async fn run_status(program: &str, args: &[&str]) -> Result<()> {
+#[cfg(unix)]
+pub(super) async fn run_status(program: &str, args: &[&str]) -> Result<()> {
 	let status = tokio::process::Command::new(program)
 		.args(args)
 		.stdin(std::process::Stdio::null())
@@ -375,6 +396,7 @@ mod tests {
 			port,
 			socket: socket.map(PathBuf::from),
 			strategy: None,
+			service_name: None,
 		}
 	}
 

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -218,6 +218,7 @@ mod tests {
 			port: None,
 			socket: None,
 			strategy: None,
+			service_name: None,
 		}
 	}
 

--- a/crates/bestool/src/actions/canopy/backup/postgresql/service.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/service.rs
@@ -1,0 +1,186 @@
+//! Stop and start the managed postgres server around a restore.
+//!
+//! Unix drives systemd's `postgresql@<version>-<cluster>` unit. Windows drives
+//! the EDB installer's Windows service (`postgresql-x64-<version>` by default,
+//! overridable via the config's `service_name`) through the Service Control
+//! Manager, waiting for it to reach the requested state — otherwise the still
+//! open file handles on the data directory make the swap fail with a sharing
+//! violation.
+
+use miette::Result;
+
+use super::resolve::ResolvedCluster;
+use crate::actions::canopy::backup::method::PostgresqlConfig;
+
+/// Stop the cluster, waiting until it is fully down.
+pub async fn stop(target: &ResolvedCluster, config: &PostgresqlConfig) -> Result<()> {
+	#[cfg(unix)]
+	{
+		let _ = config;
+		systemctl("stop", target).await
+	}
+	#[cfg(windows)]
+	{
+		win::transition(&service_name(target, config), win::Desired::Stopped).await
+	}
+	#[cfg(not(any(unix, windows)))]
+	{
+		let _ = (target, config);
+		Ok(())
+	}
+}
+
+/// Start the cluster, waiting until it is accepting the service's control.
+pub async fn start(target: &ResolvedCluster, config: &PostgresqlConfig) -> Result<()> {
+	#[cfg(unix)]
+	{
+		let _ = config;
+		systemctl("start", target).await
+	}
+	#[cfg(windows)]
+	{
+		win::transition(&service_name(target, config), win::Desired::Running).await
+	}
+	#[cfg(not(any(unix, windows)))]
+	{
+		let _ = (target, config);
+		Ok(())
+	}
+}
+
+#[cfg(unix)]
+async fn systemctl(verb: &str, target: &ResolvedCluster) -> Result<()> {
+	let unit = format!("postgresql@{}-{}", target.version, target.cluster);
+	super::run_status("systemctl", &[verb, &unit]).await
+}
+
+/// The Windows service name: the configured override, else the EDB installer's
+/// default `postgresql-x64-<version>`.
+#[cfg(windows)]
+fn service_name(target: &ResolvedCluster, config: &PostgresqlConfig) -> String {
+	config
+		.service_name
+		.clone()
+		.unwrap_or_else(|| format!("postgresql-x64-{}", target.version))
+}
+
+#[cfg(windows)]
+mod win {
+	use std::time::Duration;
+
+	use miette::{IntoDiagnostic as _, Result, WrapErr as _, bail};
+	use tracing::info;
+	use windows_service::{
+		service::{ServiceAccess, ServiceState},
+		service_manager::{ServiceManager, ServiceManagerAccess},
+	};
+
+	/// The state to drive the service into.
+	#[derive(Clone, Copy)]
+	pub enum Desired {
+		Stopped,
+		Running,
+	}
+
+	/// Drive `name` to `desired`, waiting for the transition to settle. The SCM
+	/// calls block, so run them off the async runtime.
+	pub async fn transition(name: &str, desired: Desired) -> Result<()> {
+		let name = name.to_owned();
+		tokio::task::spawn_blocking(move || transition_blocking(&name, desired))
+			.await
+			.into_diagnostic()
+			.wrap_err("joining service-control task")?
+	}
+
+	fn transition_blocking(name: &str, desired: Desired) -> Result<()> {
+		let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
+			.into_diagnostic()
+			.wrap_err("connecting to the Service Control Manager")?;
+		let service = manager
+			.open_service(
+				name,
+				ServiceAccess::QUERY_STATUS | ServiceAccess::START | ServiceAccess::STOP,
+			)
+			.into_diagnostic()
+			.wrap_err_with(|| format!("opening the postgres service {name:?}"))?;
+
+		let current = service.query_status().into_diagnostic()?.current_state;
+		match desired {
+			Desired::Stopped => {
+				if current == ServiceState::Stopped {
+					return Ok(());
+				}
+				service
+					.stop()
+					.into_diagnostic()
+					.wrap_err_with(|| format!("stopping the postgres service {name}"))?;
+				wait_for(&service, ServiceState::Stopped, name)?;
+				info!("stopped the postgres service {name}");
+			}
+			Desired::Running => {
+				if current == ServiceState::Running {
+					return Ok(());
+				}
+				service
+					.start::<&str>(&[])
+					.into_diagnostic()
+					.wrap_err_with(|| format!("starting the postgres service {name}"))?;
+				wait_for(&service, ServiceState::Running, name)?;
+				info!("started the postgres service {name}");
+			}
+		}
+		Ok(())
+	}
+
+	/// Poll the service until it reaches `want`. SCM transitions aren't atomic;
+	/// give a stop or start up to a minute to complete.
+	fn wait_for(
+		service: &windows_service::service::Service,
+		want: ServiceState,
+		name: &str,
+	) -> Result<()> {
+		for _ in 0..120 {
+			if service.query_status().into_diagnostic()?.current_state == want {
+				return Ok(());
+			}
+			std::thread::sleep(Duration::from_millis(500));
+		}
+		bail!("the postgres service {name} did not reach {want:?} within 60s");
+	}
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+	use super::*;
+
+	fn cluster(version: &str) -> ResolvedCluster {
+		ResolvedCluster {
+			data_dir: format!(r"C:\Program Files\PostgreSQL\{version}\data").into(),
+			version: version.to_owned(),
+			cluster: "main".to_owned(),
+		}
+	}
+
+	fn config(service_name: Option<&str>) -> PostgresqlConfig {
+		PostgresqlConfig {
+			cluster: "main".into(),
+			data_dir: None,
+			version: None,
+			connection_url: None,
+			port: None,
+			socket: None,
+			strategy: None,
+			service_name: service_name.map(str::to_owned),
+		}
+	}
+
+	#[test]
+	fn defaults_to_the_edb_service_name() {
+		assert_eq!(service_name(&cluster("18"), &config(None)), "postgresql-x64-18");
+	}
+
+	#[test]
+	fn the_override_wins() {
+		assert_eq!(service_name(&cluster("18"), &config(Some("pg-custom"))), "pg-custom");
+	}
+}

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -22,7 +22,7 @@ use tracing::info;
 
 use super::backup::{
 	base_url_of, build_client, config, connect_repo, load_registration, method::RestoreOpts,
-	run_kopia, spawn_proxy,
+	run_kopia, run_kopia_visible, spawn_proxy,
 };
 use crate::actions::Context;
 
@@ -136,8 +136,11 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 	}
 	let mut restore_cmd = build_kopia_command_with_s3(&kopia, &s3env, RunAs::CurrentUser)
 		.map_err(|e| miette!("{e}"))?;
+	// Force kopia's progress display (a large restore is otherwise a silent wait)
+	// and run it against the inherited terminal so it's actually visible.
+	restore_cmd.arg("--progress");
 	args_snapshot_restore(&mut restore_cmd, &snapshot.id, &staging);
-	run_kopia(restore_cmd, "snapshot restore").await?;
+	run_kopia_visible(restore_cmd, "snapshot restore").await?;
 
 	let clobber = args.clobber || confirm_clobber_interactively(&args.backup_type)?;
 	let opts = RestoreOpts {

--- a/crates/bestool/src/interactive.rs
+++ b/crates/bestool/src/interactive.rs
@@ -1,0 +1,230 @@
+//! Interactive retry for operations that depend on external state an operator
+//! can fix by hand: a running service holding a file open, wrong permissions, a
+//! busy device.
+//!
+//! On failure the error is shown and the operator is asked what to do. The
+//! operation is re-run on each retry, so the underlying condition is genuinely
+//! re-checked — declining to fix it just fails again, rather than letting the
+//! caller skip the step. With no terminal to prompt on (a daemon, a redirected
+//! stdin), the first failure is returned unchanged.
+
+use std::io::{IsTerminal as _, Write as _};
+
+use miette::{Context as _, IntoDiagnostic as _, Report, Result};
+use tracing::warn;
+
+/// Run `op`, prompting the operator to fix-and-retry or abort on failure. `what`
+/// names the operation for the error and prompt (e.g. "stopping the postgres
+/// cluster"). See the module docs for the non-interactive behaviour.
+pub async fn retry<T, F>(what: &str, mut op: F) -> Result<T>
+where
+	F: AsyncFnMut() -> Result<T>,
+{
+	loop {
+		let err = match op().await {
+			Ok(value) => return Ok(value),
+			Err(err) => err,
+		};
+
+		if !std::io::stdin().is_terminal() {
+			return Err(err);
+		}
+		warn!("{what} failed: {err}");
+
+		match prompt(what, &err, &[RETRY, ABORT], 'r')? {
+			Some('r') => continue,
+			_ => return Err(err),
+		}
+	}
+}
+
+/// Run `op`, and on failure offer the operator a third option beyond retry and
+/// abort: run `recover` (a recovery action, e.g. resetting the WAL) and then
+/// retry. `recover_label`/`recover_detail` name and explain that action in the
+/// prompt. Each retry re-runs `op`; a failing `recover` aborts. Non-interactive
+/// behaviour is as [`retry`]: the first failure is returned unchanged (the
+/// recovery action is never taken without an explicit choice).
+pub async fn retry_or_recover<T, Op, Rec>(
+	what: &str,
+	recover_label: &str,
+	recover_detail: &str,
+	mut op: Op,
+	mut recover: Rec,
+) -> Result<T>
+where
+	Op: AsyncFnMut() -> Result<T>,
+	Rec: AsyncFnMut() -> Result<()>,
+{
+	loop {
+		let err = match op().await {
+			Ok(value) => return Ok(value),
+			Err(err) => err,
+		};
+
+		if !std::io::stdin().is_terminal() {
+			return Err(err);
+		}
+		warn!("{what} failed: {err}");
+
+		let recover_choice = Choice {
+			key: 'w',
+			label: recover_label,
+			detail: recover_detail,
+		};
+		match prompt(what, &err, &[RETRY, recover_choice, ABORT], 'r')? {
+			Some('r') => continue,
+			Some('w') => {
+				recover().await?;
+				continue;
+			}
+			_ => return Err(err),
+		}
+	}
+}
+
+/// One selectable option at a recovery prompt.
+struct Choice<'a> {
+	/// The key the operator presses to pick it.
+	key: char,
+	/// A short name.
+	label: &'a str,
+	/// A one-line explanation of what it does.
+	detail: &'a str,
+}
+
+const RETRY: Choice<'static> = Choice {
+	key: 'r',
+	label: "retry",
+	detail: "try again — e.g. after clearing the problem by hand",
+};
+
+const ABORT: Choice<'static> = Choice {
+	key: 'a',
+	label: "abort",
+	detail: "give up and return the error",
+};
+
+/// Render the failure and `choices`, then read the operator's pick, returning
+/// the chosen key (lowercased). An empty line picks `default`; end-of-input
+/// (Ctrl-D) or an unreadable stdin gives `None` (the caller aborts). Re-prompts
+/// on an unrecognised key.
+fn prompt(what: &str, err: &Report, choices: &[Choice<'_>], default: char) -> Result<Option<char>> {
+	eprintln!("\n{what} failed:\n{err:?}\n");
+	for choice in choices {
+		let marker = if choice.key == default {
+			" (default)"
+		} else {
+			""
+		};
+		eprintln!(
+			"  [{}] {}{} — {}",
+			choice.key, choice.label, marker, choice.detail
+		);
+	}
+	let keys = choices
+		.iter()
+		.map(|choice| {
+			if choice.key == default {
+				choice.key.to_ascii_uppercase()
+			} else {
+				choice.key
+			}
+			.to_string()
+		})
+		.collect::<Vec<_>>()
+		.join("/");
+
+	loop {
+		eprint!("Choose [{keys}]: ");
+		std::io::stderr().flush().ok();
+
+		let mut answer = String::new();
+		let read = std::io::stdin()
+			.read_line(&mut answer)
+			.into_diagnostic()
+			.wrap_err("reading choice")?;
+		if read == 0 {
+			return Ok(None); // end of input: nothing more to answer with
+		}
+		let answer = answer.trim();
+		if answer.is_empty() {
+			return Ok(Some(default));
+		}
+		let key = answer.chars().next().unwrap().to_ascii_lowercase();
+		if choices.iter().any(|choice| choice.key == key) {
+			return Ok(Some(key));
+		}
+		eprintln!("'{answer}' is not one of the options.");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::atomic::{AtomicU32, Ordering};
+
+	use miette::miette;
+
+	use super::*;
+
+	/// A success on the first attempt never prompts, so it works without a TTY.
+	#[tokio::test]
+	async fn returns_immediately_on_success() {
+		let calls = AtomicU32::new(0);
+		let out: u32 = retry("noop", async || {
+			calls.fetch_add(1, Ordering::SeqCst);
+			Ok(7)
+		})
+		.await
+		.unwrap();
+		assert_eq!(out, 7);
+		assert_eq!(calls.load(Ordering::SeqCst), 1);
+	}
+
+	/// The recovery action is never taken when the op succeeds.
+	#[tokio::test]
+	async fn recover_variant_returns_on_first_success() {
+		let recovered = AtomicU32::new(0);
+		let out: u32 = retry_or_recover(
+			"noop",
+			"recover",
+			"do the thing",
+			async || Ok(9),
+			async || {
+				recovered.fetch_add(1, Ordering::SeqCst);
+				Ok(())
+			},
+		)
+		.await
+		.unwrap();
+		assert_eq!(out, 9);
+		assert_eq!(recovered.load(Ordering::SeqCst), 0);
+	}
+
+	/// Without a terminal a failure is returned after a single attempt (no loop,
+	/// no recovery), matching the documented non-interactive behaviour.
+	#[tokio::test]
+	async fn fails_hard_without_a_terminal() {
+		if std::io::stdin().is_terminal() {
+			return; // can't exercise the non-interactive path with a real TTY attached
+		}
+		let calls = AtomicU32::new(0);
+		let recovered = AtomicU32::new(0);
+		let result: Result<()> = retry_or_recover(
+			"always fails",
+			"recover",
+			"do the thing",
+			async || {
+				calls.fetch_add(1, Ordering::SeqCst);
+				Err(miette!("boom"))
+			},
+			async || {
+				recovered.fetch_add(1, Ordering::SeqCst);
+				Ok(())
+			},
+		)
+		.await;
+		assert!(result.is_err());
+		assert_eq!(calls.load(Ordering::SeqCst), 1);
+		assert_eq!(recovered.load(Ordering::SeqCst), 0);
+	}
+}

--- a/crates/bestool/src/lib.rs
+++ b/crates/bestool/src/lib.rs
@@ -16,6 +16,8 @@ mod canopy_contract;
 pub(crate) mod download;
 pub mod find_postgres;
 pub(crate) mod http;
+#[cfg(feature = "canopy-restore")]
+pub(crate) mod interactive;
 
 #[cfg(doc)]
 pub mod __help {


### PR DESCRIPTION
🤖 Restoring a `postgresql` backup on Windows failed at the data-directory swap:

```
WARN stopping postgresql@18-main failed (continuing): spawning systemctl
Error: moving C:\Program Files\PostgreSQL\18\data aside to C:\Program Files\PostgreSQL\18\data.old
  The process cannot access the file because it is being used by another process. (os error 32)
```

The restore stopped the cluster with `systemctl`, which doesn't exist on Windows. The stop silently no-op'd, the server kept running and holding the data directory, and the move-aside then failed with a sharing violation.

## Windows service control

`postgresql` restore no longer shells out to `systemctl` directly. A new per-platform `service` module handles stop/start:

- **Unix** drives the `postgresql@<version>-<cluster>` systemd unit (unchanged).
- **Windows** drives the EDB installer's Windows service through the Service Control Manager and **waits** for it to reach Stopped/Running before returning — that wait is what releases the file handles before the swap.

The service name defaults to the EDB convention `postgresql-x64-<version>`, overridable with a new `service_name` field on the `[postgresql]` config for non-standard installs. The Unix-only `chown`/`chmod` ownership fix is now skipped on Windows (the swapped directory inherits the install root's ACLs).

## Fail-and-prompt-to-retry

Every step that depends on external state now fails-and-prompts on an interactive terminal instead of aborting outright. The operator can clear a stubborn holder — stop the server by hand, close a file, fix permissions — and retry; each attempt re-runs the operation, so the condition is genuinely re-checked and the step can't be skipped by declining to fix it. Wrapped steps: stopping the cluster, swapping the data directory, fixing ownership, and starting the cluster.

Starting gets a third choice — **reset the write-ahead log** — with an explanation of the risk. This is the previous automatic WAL reset, now surfaced as a deliberate destructive last resort rather than something that happens silently.

With no terminal to prompt on (a daemon, redirected stdin) the first failure is returned unchanged, and the WAL is never reset without an explicit choice. **Behaviour change:** a scripted, non-interactive restore that previously auto-reset the WAL on a start failure now fails instead.

The retry helpers live in a generic `crate::interactive` module for reuse elsewhere.

## Visible restore progress

The kopia restore download ran with no visible progress — a long, silent wait. It was spawned with piped output, and kopia only draws its progress display against a terminal, so it stayed silent. It now runs with inherited stdio and a forced `--progress` (global flag, matching the backup path), so kopia's own progress display is visible. stdin is detached so kopia can't swallow the confirmation prompts.
