### PR TITLE
feat(canopy): version-aware postgres restore (Windows whole-install, Linux version guard)

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -148,9 +148,7 @@ impl Method {
 				.unwrap_or_else(|| config.path.clone())
 				.parent()
 				.map(Path::to_path_buf),
-			Method::Postgresql(config) => super::postgresql::resolve::resolve_target(config)
-				.ok()
-				.and_then(|r| r.data_dir.parent().map(Path::to_path_buf)),
+			Method::Postgresql(config) => super::postgresql::resolve::restore_staging_parent(config),
 		};
 		parent
 			.unwrap_or_else(std::env::temp_dir)

--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -149,39 +149,61 @@ async fn basebackup_prepared(
 }
 
 /// Restore a postgres cluster from a freshly-restored tree (`staging`): stop the
-/// cluster, swap the data directory into place (keeping the old one as
-/// `<data>.old`), start it via plain crash recovery, and verify.
+/// cluster, swap the restored tree into place (keeping the old one as
+/// `<dest>.old`), start it via plain crash recovery, and verify.
 ///
-/// Refuses to overwrite an existing data directory unless `opts.clobber` is set
-/// (the command sets it from the flag or an interactive confirmation).
+/// A Windows backup carries the whole server install, so the swap replaces the
+/// `PostgreSQL\<version>` directory and the exact matching binaries come with it.
+/// A data-only backup (Linux, legacy Windows) replaces just the data directory,
+/// so the matching server major version must already be installed — checked up
+/// front. The version is taken from the restored `PG_VERSION`, not the target
+/// path, so the systemd unit / service name match the data.
+///
+/// Refuses to overwrite an existing directory unless `opts.clobber` is set (the
+/// command sets it from the flag or an interactive confirmation).
 pub async fn restore(
 	config: &PostgresqlConfig,
 	staging: &Path,
 	opts: &super::method::RestoreOpts,
 ) -> Result<()> {
-	let target = resolve::resolve_target(config)?;
-	let restored = resolve::locate_pgdata(staging)?;
+	let mut target = resolve::resolve_target(config)?;
+	let plan = resolve::plan_restore(staging, &target)?;
+	// PG_VERSION is authoritative for the data's major version — trust it over the
+	// target path so the unit/service and any resetwal binary match the data.
+	target.version = plan.data_major.clone();
 	info!(
 		cluster = %target.cluster,
 		version = %target.version,
-		data_dir = %target.data_dir.display(),
+		dest = %plan.dest.display(),
+		whole_install = plan.whole_install,
 		"restoring postgres cluster",
 	);
 
-	super::method::ensure_not_clobbering(&target.data_dir, opts.clobber)?;
+	super::method::ensure_not_clobbering(&plan.dest, opts.clobber)?;
 
-	// Stop the cluster before swapping the data directory: on Windows an open
-	// handle to the running server's files makes the move fail outright; on Unix
-	// it would corrupt a live cluster. Both this and the swap depend on nothing
-	// else holding the files, so let the operator clear a stubborn holder by hand
-	// and retry — each attempt re-checks, so the stop can't be skipped.
+	// A data-only backup carries no binaries; a physical restore only runs under
+	// its own major version. Fail-and-prompt so the operator can install it and
+	// retry (the recheck runs each attempt). A whole-install backup brings its own.
+	if !plan.whole_install {
+		let major = plan.data_major.clone();
+		crate::interactive::retry("checking the installed postgres version", async || {
+			resolve::ensure_server_version_available(&major)
+		})
+		.await?;
+	}
+
+	// Stop the cluster before swapping: on Windows an open handle to the running
+	// server's files makes the move fail outright; on Unix it would corrupt a live
+	// cluster. Both this and the swap depend on nothing else holding the files, so
+	// let the operator clear a stubborn holder by hand and retry — each attempt
+	// re-checks, so the stop can't be skipped.
 	crate::interactive::retry("stopping the postgres cluster", async || {
 		service::stop(&target, config).await
 	})
 	.await?;
 
-	crate::interactive::retry("moving the data directory into place", async || {
-		super::method::replace_dir(&restored, &target.data_dir).await
+	crate::interactive::retry("moving the restored data into place", async || {
+		super::method::replace_dir(&plan.source, &plan.dest).await
 	})
 	.await?;
 
@@ -201,11 +223,11 @@ pub async fn restore(
 		 otherwise-healthy cluster; only sound for a backup that won't start any \
 		 other way",
 		async || service::start(&target, config).await,
-		async || pg_resetwal(&target.data_dir).await,
+		async || pg_resetwal(&target.data_dir, &target.version).await,
 	)
 	.await?;
 
-	verify(config, &target.data_dir).await;
+	verify(config, &target.data_dir, &target.version).await;
 	info!("restore complete; run migrations / config sync as needed");
 	Ok(())
 }
@@ -224,14 +246,14 @@ async fn fix_ownership(_data_dir: &Path) -> Result<()> {
 	Ok(())
 }
 
-async fn pg_resetwal(data_dir: &Path) -> Result<()> {
-	let mut cmd = pg_command(&postgres_bin("pg_resetwal", data_dir));
+async fn pg_resetwal(data_dir: &Path, major: &str) -> Result<()> {
+	let mut cmd = pg_command(&postgres_bin_versioned("pg_resetwal", major, data_dir));
 	cmd.arg("-f").arg(data_dir);
 	run_checked(cmd, "pg_resetwal").await
 }
 
-async fn verify(config: &PostgresqlConfig, data_dir: &Path) {
-	let mut cmd = pg_command(&postgres_bin("psql", data_dir));
+async fn verify(config: &PostgresqlConfig, data_dir: &Path, major: &str) {
+	let mut cmd = pg_command(&postgres_bin_versioned("psql", major, data_dir));
 	// -w as in `checkpoint`: never block on a terminal password prompt.
 	cmd.args(["-X", "-q", "-w", "-tAc", "SELECT 1"]);
 	apply_connection(&mut cmd, config);
@@ -279,6 +301,29 @@ pub(super) fn postgres_bin(name: &str, data_dir: &Path) -> String {
 	crate::find_postgres::find_postgres_bin(name)
 		.map(|p| p.to_string_lossy().into_owned())
 		.unwrap_or_else(|_| name.to_owned())
+}
+
+/// Locate a postgres binary for a specific major version — for restore, where the
+/// tool must match the restored data, not just any install. On Unix that's the
+/// versioned install dir (`/usr/lib/postgresql/<major>/bin/<name>`), avoiding
+/// [`postgres_bin`]'s highest-version fallback when several majors are installed.
+/// On Windows the versioned bin already sits beside the data dir, so this defers
+/// to [`postgres_bin`].
+fn postgres_bin_versioned(name: &str, major: &str, data_dir: &Path) -> String {
+	#[cfg(unix)]
+	{
+		let candidate = PathBuf::from("/usr/lib/postgresql")
+			.join(major)
+			.join("bin")
+			.join(name);
+		if candidate.is_file() {
+			return candidate.to_string_lossy().into_owned();
+		}
+	}
+	#[cfg(not(unix))]
+	let _ = major;
+
+	postgres_bin(name, data_dir)
 }
 
 /// The EDB-layout binary path beside the data dir (`<data_dir>\..\bin\<name>`).

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -8,7 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
-use miette::{Result, bail};
+use miette::{Context as _, IntoDiagnostic as _, Result, bail};
 
 use crate::actions::canopy::backup::method::PostgresqlConfig;
 
@@ -184,6 +184,148 @@ pub fn locate_pgdata(staging: &Path) -> Result<PathBuf> {
 	)
 }
 
+/// A restore's placement, decided from the restored tree and the target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestorePlan {
+	/// The directory within the staging tree to move into place.
+	pub source: PathBuf,
+	/// Where it's moved to, keeping any existing dir as `<dest>.old`.
+	pub dest: PathBuf,
+	/// The cluster's major version, read from the restored `PG_VERSION`.
+	pub data_major: String,
+	/// Whether the snapshot carries the whole server install (`bin`/`lib` beside
+	/// `data`, as the Windows backup now captures) rather than just the data dir.
+	/// A whole-install restore brings its own matching binaries, so it needs no
+	/// installed-version check.
+	pub whole_install: bool,
+}
+
+/// Decide how to lay a restored tree (`staging`) down for `target`.
+///
+/// A whole-install snapshot (the data dir nested under a tree with a sibling
+/// `bin`) replaces the whole server install directory, bringing its binaries. A
+/// data-only snapshot (the data dir at the tree root) replaces just the cluster
+/// data directory.
+pub fn plan_restore(staging: &Path, target: &ResolvedCluster) -> Result<RestorePlan> {
+	let data = locate_pgdata(staging)?;
+	let data_major = read_pg_version(&data)?;
+
+	// Whole-install only when the data dir is nested inside the restored tree and
+	// its parent (also inside the tree) holds a `bin` directory — never when the
+	// tree root *is* the data dir, where `data.parent()` would be a real host dir.
+	let install_root = if data != staging {
+		data.parent()
+			.filter(|root| root.starts_with(staging) && root.join("bin").is_dir())
+	} else {
+		None
+	};
+	if let Some(install_root) = install_root {
+		let dest = target.data_dir.parent().ok_or_else(|| {
+			miette::miette!(
+				"target data dir {} has no parent install directory to restore into",
+				target.data_dir.display()
+			)
+		})?;
+		return Ok(RestorePlan {
+			source: install_root.to_path_buf(),
+			dest: dest.to_path_buf(),
+			data_major,
+			whole_install: true,
+		});
+	}
+
+	Ok(RestorePlan {
+		source: data,
+		dest: target.data_dir.clone(),
+		data_major,
+		whole_install: false,
+	})
+}
+
+/// The cluster's major version from its `PG_VERSION` file (e.g. `18`, or `9.6`).
+fn read_pg_version(data_dir: &Path) -> Result<String> {
+	let raw = std::fs::read_to_string(data_dir.join("PG_VERSION"))
+		.into_diagnostic()
+		.wrap_err_with(|| format!("reading PG_VERSION in {}", data_dir.display()))?;
+	Ok(raw.trim().to_owned())
+}
+
+/// The base directory server *binaries* live under, per major version:
+/// `/usr/lib/postgresql` on Debian/Ubuntu, `%ProgramFiles%\PostgreSQL` (the same
+/// tree as the data) on Windows.
+fn server_base() -> PathBuf {
+	#[cfg(windows)]
+	{
+		postgres_base()
+	}
+	#[cfg(not(windows))]
+	{
+		PathBuf::from("/usr/lib/postgresql")
+	}
+}
+
+/// The installed server major versions (each a `<version>` dir with a `bin`
+/// subdirectory under [`server_base`]), sorted.
+pub fn installed_server_versions() -> Vec<String> {
+	versions_under(&server_base())
+}
+
+/// The `<version>` dirs (with a `bin` subdirectory) directly under `base`, sorted.
+fn versions_under(base: &Path) -> Vec<String> {
+	let mut out: Vec<String> = std::fs::read_dir(base)
+		.into_iter()
+		.flatten()
+		.flatten()
+		.filter(|entry| entry.path().join("bin").is_dir())
+		.filter_map(|entry| entry.file_name().into_string().ok())
+		.collect();
+	out.sort();
+	out
+}
+
+/// Error unless server binaries for major `wanted` are installed. A data-only
+/// backup doesn't carry binaries, and a physical restore only runs under its own
+/// major version (minor differences are fine), so the matching server must be
+/// present before the restore.
+pub fn ensure_server_version_available(wanted: &str) -> Result<()> {
+	ensure_version_present(wanted, &installed_server_versions())
+}
+
+fn ensure_version_present(wanted: &str, installed: &[String]) -> Result<()> {
+	if installed.iter().any(|version| version == wanted) {
+		return Ok(());
+	}
+	let found = if installed.is_empty() {
+		"none found".to_owned()
+	} else {
+		format!("found {}", installed.join(", "))
+	};
+	bail!(
+		"PostgreSQL {wanted} server binaries are not installed ({found}); a data-only \
+		 backup restores only under its own major version. Install PostgreSQL {wanted} and retry."
+	)
+}
+
+/// The directory a restore stages into: a sibling of what it will replace, on the
+/// same filesystem so the swap is a rename. On Windows that's the `PostgreSQL`
+/// base (so the whole `PostgreSQL\<version>` install can be replaced); elsewhere
+/// the data dir's parent.
+pub fn restore_staging_parent(config: &PostgresqlConfig) -> Option<PathBuf> {
+	let target = resolve_target(config).ok()?;
+	#[cfg(windows)]
+	{
+		target
+			.data_dir
+			.parent()
+			.and_then(Path::parent)
+			.map(Path::to_path_buf)
+	}
+	#[cfg(not(windows))]
+	{
+		target.data_dir.parent().map(Path::to_path_buf)
+	}
+}
+
 fn read_subdirs(dir: &Path) -> Vec<PathBuf> {
 	let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
 		.into_iter()
@@ -326,5 +468,67 @@ mod tests {
 			resolve_in(&config("main", None, Some(data_dir.clone())), tmp.path()).unwrap();
 		assert_eq!(resolved.version, "16");
 		assert_eq!(resolved.data_dir, data_dir);
+	}
+
+	fn target(data_dir: PathBuf) -> ResolvedCluster {
+		ResolvedCluster {
+			version: "18".into(),
+			cluster: "main".into(),
+			data_dir,
+		}
+	}
+
+	#[test]
+	fn plan_restore_data_only_replaces_the_data_dir() {
+		let tmp = tempfile::tempdir().unwrap();
+		// A data-only snapshot: PG_VERSION at the staging root.
+		let staging = tmp.path().join("staging");
+		std::fs::create_dir_all(&staging).unwrap();
+		std::fs::write(staging.join("PG_VERSION"), "18\n").unwrap();
+
+		let data_dir = tmp.path().join("18").join("data");
+		let plan = plan_restore(&staging, &target(data_dir.clone())).unwrap();
+		assert!(!plan.whole_install);
+		assert_eq!(plan.source, staging);
+		assert_eq!(plan.dest, data_dir);
+		assert_eq!(plan.data_major, "18");
+	}
+
+	#[test]
+	fn plan_restore_whole_install_replaces_the_install_root() {
+		let tmp = tempfile::tempdir().unwrap();
+		// A whole-install snapshot: bin/ beside data/PG_VERSION at the staging root.
+		let staging = tmp.path().join("staging");
+		std::fs::create_dir_all(staging.join("bin")).unwrap();
+		let data = staging.join("data");
+		std::fs::create_dir_all(&data).unwrap();
+		std::fs::write(data.join("PG_VERSION"), "18").unwrap();
+
+		let target_data = tmp.path().join("PostgreSQL").join("18").join("data");
+		let plan = plan_restore(&staging, &target(target_data.clone())).unwrap();
+		assert!(plan.whole_install);
+		assert_eq!(plan.source, staging);
+		assert_eq!(plan.dest, target_data.parent().unwrap());
+		assert_eq!(plan.data_major, "18");
+	}
+
+	#[test]
+	fn versions_under_lists_dirs_with_a_bin() {
+		let tmp = tempfile::tempdir().unwrap();
+		std::fs::create_dir_all(tmp.path().join("16").join("bin")).unwrap();
+		std::fs::create_dir_all(tmp.path().join("18").join("bin")).unwrap();
+		// No bin: not a server install.
+		std::fs::create_dir_all(tmp.path().join("junk")).unwrap();
+		assert_eq!(versions_under(tmp.path()), vec!["16".to_owned(), "18".to_owned()]);
+	}
+
+	#[test]
+	fn ensure_version_present_checks_membership() {
+		let installed = vec!["16".to_owned(), "18".to_owned()];
+		assert!(ensure_version_present("18", &installed).is_ok());
+		let err = ensure_version_present("17", &installed).unwrap_err();
+		let msg = format!("{err}");
+		assert!(msg.contains("PostgreSQL 17"));
+		assert!(msg.contains("found 16, 18"));
 	}
 }

--- a/crates/bestool/src/actions/canopy/backup/postgresql/vss.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/vss.rs
@@ -12,7 +12,7 @@
 //! Windows host; the pure helpers (path math, script generation) are unit-tested
 //! here (they operate on strings, so the tests are platform-independent).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use miette::{Context as _, IntoDiagnostic as _, Result, bail};
 use tracing::{info, warn};
@@ -21,6 +21,18 @@ use super::resolve::ResolvedCluster;
 
 /// The VSS writer/alias name used in the diskshadow script.
 const ALIAS: &str = "bestoolpg";
+
+/// The directory the backup captures. On the EDB layout the whole server install
+/// (`…\PostgreSQL\<version>`, carrying `bin`/`lib`/`share` beside `data`) sits one
+/// level above the data dir, so snapshot that instead — a restore then brings the
+/// exact matching binaries and is version-independent. Falls back to the data dir
+/// alone for a non-EDB layout (no sibling `bin`).
+fn backup_root(data_dir: &Path) -> &Path {
+	match data_dir.parent() {
+		Some(parent) if parent.join("bin").is_dir() => parent,
+		_ => data_dir,
+	}
+}
 
 /// Teardown state for a prepared shadow copy, released by [`teardown`].
 #[derive(Debug)]
@@ -85,9 +97,9 @@ fn delete_script(expose_target: &str) -> String {
 /// Take the shadow copy and expose it; returns the kopia source path and the
 /// teardown state. Caller must always pass the result to [`teardown`].
 pub async fn prepare(resolved: &ResolvedCluster, backup_type: &str) -> Result<(PathBuf, Shadow)> {
-	let data_dir = resolved.data_dir.to_string_lossy().into_owned();
-	let volume = volume_of(&data_dir)?.to_owned();
-	let rel = relative_to_volume(&data_dir, &volume).to_owned();
+	let root = backup_root(&resolved.data_dir).to_string_lossy().into_owned();
+	let volume = volume_of(&root)?.to_owned();
+	let rel = relative_to_volume(&root, &volume).to_owned();
 	let expose_target = expose_target_dir(&volume, backup_type);
 	let metadata = std::env::temp_dir().join(format!("bestool-vss-{}.cab", std::process::id()));
 
@@ -183,6 +195,22 @@ mod tests {
 		assert!(script.contains("add volume C: alias bestoolpg"));
 		assert!(script.contains("expose %bestoolpg% \"C:\\shadow\\pg\""));
 		assert!(script.contains("set metadata \"C:\\meta.cab\""));
+	}
+
+	#[test]
+	fn backup_root_is_the_install_dir_on_the_edb_layout() {
+		let tmp = tempfile::tempdir().unwrap();
+		let install = tmp.path().join("18");
+		let data = install.join("data");
+		std::fs::create_dir_all(install.join("bin")).unwrap();
+		std::fs::create_dir_all(&data).unwrap();
+		// With a sibling `bin`, the whole install is captured…
+		assert_eq!(backup_root(&data), install);
+
+		// …without one (non-EDB layout), just the data dir.
+		let bare = tmp.path().join("bare").join("data");
+		std::fs::create_dir_all(&bare).unwrap();
+		assert_eq!(backup_root(&bare), bare);
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 PostgreSQL physical backups (filesystem snapshot / `pg_basebackup`) only restore under their **own major version** — minor differences (18.2 → 18.3) are fine, majors (17 → 18) are not. Today nothing enforces or provides for that, so a cross-major restore just fails confusingly at start. This makes it correct on both platforms.

## Windows — self-contained, version-independent restore

The backup now captures the **whole EDB install directory** (`…\PostgreSQL\<version>` — `bin`, `lib`, `share`, `data`), not just the data dir. The VSS shadow already covers the whole volume; this just moves the exposed/snapshotted subtree up one level to the install root when the EDB layout is present (a sibling `bin`).

Restore then replaces the whole `PostgreSQL\<version>` directory, so the exact matching server binaries come down with the data — the restore no longer depends on any particular version being installed on the target.

- The kopia source path changes, so kopia history restarts once (dedup of data blobs is unaffected).
- **Legacy data-only Windows snapshots still restore** — the layout is detected from the restored tree (whole-install if the data dir is nested under a sibling `bin`, else data-only), and a data-only tree lays down just the data dir as before.

## Linux — installed-version guard

Linux backups are data-only (binaries live in `/usr/lib/postgresql/<major>/`), so before restoring, the required major version — read from the restored `PG_VERSION`, which is authoritative — is checked against what's installed. If it's missing, the restore **fails and prompts to retry** (reusing #662's helper): the operator can install the matching server and continue, and the check re-runs. Non-interactive → hard fail. The same guard covers legacy data-only Windows snapshots.

## Also

- The restore takes the major version from `PG_VERSION` for the systemd unit / Windows service name, rather than trusting the target path.
- It selects the **version-matching** `pg_resetwal`/`psql` binary (`/usr/lib/postgresql/<major>/bin`) instead of the highest installed — a real hazard mid-upgrade with multiple majors present.
- On Windows the restore now stages beside the install root (under the `PostgreSQL` base) so replacing the whole install is an atomic same-volume rename.

## Caveat

Restoring a whole-install Windows snapshot onto a host where that major was **never** installed brings the software but not a registered Windows service, so the start step will fail — and (via #662) prompt the operator to register/start it and retry. Bare-metal service registration is out of scope here.
