### PR TITLE
fix(canopy): create the temp base dir before staging a transient kopia config

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -595,9 +595,7 @@ async fn snapshot(
 	let kopia = find_kopia_binary(None).ok_or_else(|| miette!("could not find the kopia binary"))?;
 
 	// A transient kopia config so the bucket/password never persist on the device.
-	let config_dir = tempfile::tempdir()
-		.into_diagnostic()
-		.wrap_err("creating transient kopia config dir")?;
+	let config_dir = transient_config_dir()?;
 	let config_path = config_dir.path().join("repository.config");
 
 	// When kopia runs as the kopia user (not us), it writes and reads this config
@@ -643,6 +641,21 @@ async fn snapshot(
 		run_kopia(create, "snapshot create").await?
 	};
 	Ok(parse_snapshot_output(&stdout))
+}
+
+/// Create a transient directory for a throwaway kopia config (so the bucket and
+/// password never persist on the device), ensuring the base temp dir exists
+/// first. On Windows `%TEMP%` is often a per-session subdirectory
+/// (`…\Temp\<session>`) that may not exist yet, and `tempfile` doesn't create the
+/// parent — so create it here, or the tempdir fails with "path not found".
+pub(super) fn transient_config_dir() -> Result<tempfile::TempDir> {
+	let base = std::env::temp_dir();
+	std::fs::create_dir_all(&base)
+		.into_diagnostic()
+		.wrap_err_with(|| format!("creating temp dir {}", base.display()))?;
+	tempfile::tempdir_in(&base)
+		.into_diagnostic()
+		.wrap_err("creating transient kopia config dir")
 }
 
 /// Run a kopia command with its stdout/stderr inherited, so kopia's own

--- a/crates/bestool/src/actions/canopy/kopia.rs
+++ b/crates/bestool/src/actions/canopy/kopia.rs
@@ -16,7 +16,9 @@ use bestool_kopia::{
 use clap::{Parser, ValueEnum};
 use miette::{Context as _, IntoDiagnostic as _, Result, bail, miette};
 
-use super::backup::{base_url_of, build_client, connect_repo, load_registration, spawn_proxy};
+use super::backup::{
+	base_url_of, build_client, connect_repo, load_registration, spawn_proxy, transient_config_dir,
+};
 use crate::actions::Context;
 
 /// Run a kopia command against Canopy's repository.
@@ -97,9 +99,7 @@ pub async fn run(args: KopiaArgs, _ctx: Context) -> Result<()> {
 		&target.region,
 	)
 	.await?;
-	let config_dir = tempfile::tempdir()
-		.into_diagnostic()
-		.wrap_err("creating transient kopia config dir")?;
+	let config_dir = transient_config_dir()?;
 	let config_path = config_dir.path().join("repository.config");
 	let s3env = S3KopiaEnv {
 		password: &target.repo_password.0,

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -22,7 +22,7 @@ use tracing::info;
 
 use super::backup::{
 	base_url_of, build_client, config, connect_repo, load_registration, method::RestoreOpts,
-	run_kopia, run_kopia_visible, spawn_proxy,
+	run_kopia, run_kopia_visible, spawn_proxy, transient_config_dir,
 };
 use crate::actions::Context;
 
@@ -99,9 +99,7 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		&target.region,
 	)
 	.await?;
-	let config_dir = tempfile::tempdir()
-		.into_diagnostic()
-		.wrap_err("creating transient kopia config dir")?;
+	let config_dir = transient_config_dir()?;
 	let config_path = config_dir.path().join("repository.config");
 	let s3env = S3KopiaEnv {
 		password: &target.repo_password.0,


### PR DESCRIPTION
🤖 Restoring on Windows failed before it started:

```
Error:   x creating transient kopia config dir
  `-> The system cannot find the path specified. (os error 3) at path
      "C:\Users\ADMINI~1\AppData\Local\Temp\2\.tmpNmDxIP"
```

The canopy kopia commands (backup, restore, and the `kopia` passthrough) stage a throwaway kopia repository config inside a tempdir, so the bucket and password never persist on the device. They created it with `tempfile::tempdir()`, which places the dir inside `%TEMP%` but does **not** create intermediate parents.

On Windows `%TEMP%` is often a per-session subdirectory — here `…\Temp\2` (the `2` is the session id) — which doesn't always exist yet. So the tempdir creation failed with "path not found". Creating the `2` folder by hand (as you did) worked around it.

The fix: `create_dir_all` the base temp dir first, then stage inside it (`tempdir_in`). Factored into one `transient_config_dir()` helper and used at all three call sites.
