### PR TITLE
fix(canopy): restore into the snapshot's own postgres version and manage the service

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -166,11 +166,11 @@ pub async fn restore(
 	staging: &Path,
 	opts: &super::method::RestoreOpts,
 ) -> Result<()> {
-	let mut target = resolve::resolve_target(config)?;
-	let plan = resolve::plan_restore(staging, &target)?;
-	// PG_VERSION is authoritative for the data's major version — trust it over the
-	// target path so the unit/service and any resetwal binary match the data.
-	target.version = plan.data_major.clone();
+	// The plan targets the snapshot's *own* major version (from PG_VERSION), so the
+	// destination, the service stopped/started, and the binaries all match the data
+	// being restored — even when a different major is the currently-installed cluster.
+	let plan = resolve::plan_restore(staging, config)?;
+	let target = &plan.target;
 	info!(
 		cluster = %target.cluster,
 		version = %target.version,
@@ -198,9 +198,14 @@ pub async fn restore(
 	// let the operator clear a stubborn holder by hand and retry — each attempt
 	// re-checks, so the stop can't be skipped.
 	crate::interactive::retry("stopping the postgres cluster", async || {
-		service::stop(&target, config).await
+		service::stop(target, config).await
 	})
 	.await?;
+
+	// Quiesce the other installed postgres versions' services (stop + set to manual
+	// start) so a differently-versioned server can't hold the port or auto-restart
+	// over the cluster we're restoring. Best-effort.
+	service::quiesce_other_versions(&target.version).await;
 
 	crate::interactive::retry("moving the restored data into place", async || {
 		super::method::replace_dir(&plan.source, &plan.dest).await
@@ -222,14 +227,63 @@ pub async fn restore(
 		 destructive: can discard recent transactions or corrupt an \
 		 otherwise-healthy cluster; only sound for a backup that won't start any \
 		 other way",
-		async || service::start(&target, config).await,
+		async || service::start(target, config).await,
 		async || pg_resetwal(&target.data_dir, &target.version).await,
 	)
 	.await?;
 
+	// The BES Linux layout indirects the active cluster through
+	// `/var/lib/postgresql/current` and `/etc/postgresql/current`; point them at the
+	// restored version so `current`-based consumers follow it (a no-op for a
+	// same-major restore, where they already resolve here by path).
+	repoint_current_symlinks(target).await;
+
 	verify(config, &target.data_dir, &target.version).await;
 	info!("restore complete; run migrations / config sync as needed");
 	Ok(())
+}
+
+/// Repoint the BES `current` symlinks at the restored version, so consumers that
+/// resolve the cluster through `/var/lib/postgresql/current` (the data dir) and
+/// `/etc/postgresql/current` (the version config) follow a restore that changes
+/// the active major. Only ever *repoints an existing* symlink (never imposes the
+/// convention on a host that doesn't use it), and only points `/etc` at a config
+/// directory that exists. Best-effort; Unix-only.
+#[cfg(unix)]
+async fn repoint_current_symlinks(target: &resolve::ResolvedCluster) {
+	repoint_symlink_if_present(&resolve::postgres_base().join("current"), &target.data_dir).await;
+
+	let etc_version = PathBuf::from("/etc/postgresql").join(&target.version);
+	if etc_version.is_dir() {
+		repoint_symlink_if_present(Path::new("/etc/postgresql/current"), &etc_version).await;
+	}
+}
+
+#[cfg(not(unix))]
+async fn repoint_current_symlinks(_target: &resolve::ResolvedCluster) {}
+
+/// Atomically repoint `link` at `dest`, but only when `link` already exists and is
+/// a symlink. Best-effort: a failure is warned, not fatal.
+#[cfg(unix)]
+async fn repoint_symlink_if_present(link: &Path, dest: &Path) {
+	match tokio::fs::symlink_metadata(link).await {
+		Ok(meta) if meta.file_type().is_symlink() => {}
+		_ => return, // absent, or not a symlink: the convention isn't in play here
+	}
+	// Stage a new symlink beside it and rename over the old one, so the swap is
+	// atomic (no window where `link` is missing).
+	let staged = link.with_extension("bestool-current");
+	let _ = tokio::fs::remove_file(&staged).await;
+	if let Err(err) = tokio::fs::symlink(dest, &staged).await {
+		warn!("could not stage symlink {} -> {}: {err}", staged.display(), dest.display());
+		return;
+	}
+	if let Err(err) = tokio::fs::rename(&staged, link).await {
+		warn!("could not repoint {} -> {}: {err}", link.display(), dest.display());
+		let _ = tokio::fs::remove_file(&staged).await;
+	} else {
+		info!("repointed {} -> {}", link.display(), dest.display());
+	}
 }
 
 /// Restore the postgres-owned mode and ownership of the freshly-swapped data
@@ -408,6 +462,36 @@ async fn checkpoint(config: &PostgresqlConfig, data_dir: &Path) {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn repoint_symlink_updates_an_existing_symlink() {
+		let tmp = tempfile::tempdir().unwrap();
+		let old = tmp.path().join("18");
+		let new = tmp.path().join("17");
+		std::fs::create_dir_all(&old).unwrap();
+		std::fs::create_dir_all(&new).unwrap();
+		let link = tmp.path().join("current");
+		std::os::unix::fs::symlink(&old, &link).unwrap();
+
+		repoint_symlink_if_present(&link, &new).await;
+		assert_eq!(std::fs::read_link(&link).unwrap(), new);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn repoint_symlink_leaves_a_non_symlink_alone() {
+		let tmp = tempfile::tempdir().unwrap();
+		// A real directory at the link path must not be touched.
+		let real = tmp.path().join("current");
+		std::fs::create_dir_all(&real).unwrap();
+		let dest = tmp.path().join("target");
+		std::fs::create_dir_all(&dest).unwrap();
+
+		repoint_symlink_if_present(&real, &dest).await;
+		assert!(real.is_dir());
+		assert!(!std::fs::symlink_metadata(&real).unwrap().file_type().is_symlink());
+	}
 
 	#[test]
 	fn bin_beside_data_dir_is_sibling_of_data() {

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -184,7 +184,7 @@ pub fn locate_pgdata(staging: &Path) -> Result<PathBuf> {
 	)
 }
 
-/// A restore's placement, decided from the restored tree and the target.
+/// A restore's placement, decided from the restored tree and the config.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RestorePlan {
 	/// The directory within the staging tree to move into place.
@@ -198,17 +198,31 @@ pub struct RestorePlan {
 	/// A whole-install restore brings its own matching binaries, so it needs no
 	/// installed-version check.
 	pub whole_install: bool,
+	/// The target resolved to the snapshot's own major version — the destination,
+	/// service, and binaries all match the data being restored.
+	pub target: ResolvedCluster,
 }
 
-/// Decide how to lay a restored tree (`staging`) down for `target`.
+/// Decide how to lay a restored tree (`staging`) down for `config`.
+///
+/// The target is resolved to the snapshot's *own* major version (from its
+/// `PG_VERSION`), not the currently-installed cluster: a physical backup only
+/// runs under its own major, so restoring a v17 backup targets the v17 install
+/// (`…\17\data` / `/var/lib/postgresql/17/<cluster>`) and its service — keeping
+/// the destination, the service stopped/started, and the binaries consistent.
 ///
 /// A whole-install snapshot (the data dir nested under a tree with a sibling
 /// `bin`) replaces the whole server install directory, bringing its binaries. A
 /// data-only snapshot (the data dir at the tree root) replaces just the cluster
 /// data directory.
-pub fn plan_restore(staging: &Path, target: &ResolvedCluster) -> Result<RestorePlan> {
+pub fn plan_restore(staging: &Path, config: &PostgresqlConfig) -> Result<RestorePlan> {
+	plan_restore_in(staging, config, &postgres_base())
+}
+
+fn plan_restore_in(staging: &Path, config: &PostgresqlConfig, base: &Path) -> Result<RestorePlan> {
 	let data = locate_pgdata(staging)?;
 	let data_major = read_pg_version(&data)?;
+	let target = resolve_target_for_version(config, &data_major, base);
 
 	// Whole-install only when the data dir is nested inside the restored tree and
 	// its parent (also inside the tree) holds a `bin` directory — never when the
@@ -231,6 +245,7 @@ pub fn plan_restore(staging: &Path, target: &ResolvedCluster) -> Result<RestoreP
 			dest: dest.to_path_buf(),
 			data_major,
 			whole_install: true,
+			target,
 		});
 	}
 
@@ -239,7 +254,26 @@ pub fn plan_restore(staging: &Path, target: &ResolvedCluster) -> Result<RestoreP
 		dest: target.data_dir.clone(),
 		data_major,
 		whole_install: false,
+		target,
 	})
+}
+
+/// Resolve the restore target pinned to `major` (the snapshot's own version). An
+/// explicit `data_dir` override still wins; otherwise the path is
+/// `<base>/<major>/<cluster-subdir>`.
+fn resolve_target_for_version(config: &PostgresqlConfig, major: &str, base: &Path) -> ResolvedCluster {
+	if let Some(data_dir) = &config.data_dir {
+		return ResolvedCluster {
+			version: major.to_owned(),
+			cluster: config.cluster.clone(),
+			data_dir: data_dir.clone(),
+		};
+	}
+	ResolvedCluster {
+		version: major.to_owned(),
+		cluster: config.cluster.clone(),
+		data_dir: base.join(major).join(cluster_subdir(config)),
+	}
 }
 
 /// The cluster's major version from its `PG_VERSION` file (e.g. `18`, or `9.6`).
@@ -470,28 +504,24 @@ mod tests {
 		assert_eq!(resolved.data_dir, data_dir);
 	}
 
-	fn target(data_dir: PathBuf) -> ResolvedCluster {
-		ResolvedCluster {
-			version: "18".into(),
-			cluster: "main".into(),
-			data_dir,
-		}
-	}
-
 	#[test]
-	fn plan_restore_data_only_replaces_the_data_dir() {
+	fn plan_restore_data_only_targets_the_snapshots_own_version() {
 		let tmp = tempfile::tempdir().unwrap();
 		// A data-only snapshot: PG_VERSION at the staging root.
 		let staging = tmp.path().join("staging");
 		std::fs::create_dir_all(&staging).unwrap();
-		std::fs::write(staging.join("PG_VERSION"), "18\n").unwrap();
+		std::fs::write(staging.join("PG_VERSION"), "17\n").unwrap();
 
-		let data_dir = tmp.path().join("18").join("data");
-		let plan = plan_restore(&staging, &target(data_dir.clone())).unwrap();
+		let cfg = config("main", None, None);
+		let leaf = cluster_subdir(&cfg);
+		let plan = plan_restore_in(&staging, &cfg, tmp.path()).unwrap();
 		assert!(!plan.whole_install);
+		assert_eq!(plan.data_major, "17");
+		// Destination and target track the data's own major (17), not any other
+		// installed version.
+		assert_eq!(plan.target.version, "17");
+		assert_eq!(plan.dest, tmp.path().join("17").join(leaf));
 		assert_eq!(plan.source, staging);
-		assert_eq!(plan.dest, data_dir);
-		assert_eq!(plan.data_major, "18");
 	}
 
 	#[test]
@@ -504,12 +534,14 @@ mod tests {
 		std::fs::create_dir_all(&data).unwrap();
 		std::fs::write(data.join("PG_VERSION"), "18").unwrap();
 
-		let target_data = tmp.path().join("PostgreSQL").join("18").join("data");
-		let plan = plan_restore(&staging, &target(target_data.clone())).unwrap();
+		let cfg = config("main", None, None);
+		let plan = plan_restore_in(&staging, &cfg, tmp.path()).unwrap();
 		assert!(plan.whole_install);
-		assert_eq!(plan.source, staging);
-		assert_eq!(plan.dest, target_data.parent().unwrap());
 		assert_eq!(plan.data_major, "18");
+		assert_eq!(plan.source, staging);
+		// The whole install replaces `<base>/18` (the install root).
+		assert_eq!(plan.dest, tmp.path().join("18"));
+		assert_eq!(plan.target.version, "18");
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/canopy/backup/postgresql/service.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/service.rs
@@ -39,12 +39,40 @@ pub async fn start(target: &ResolvedCluster, config: &PostgresqlConfig) -> Resul
 	}
 	#[cfg(windows)]
 	{
-		win::transition(&service_name(target, config), win::Desired::Running).await
+		let name = service_name(target, config);
+		// A versioned EDB service for a cluster that isn't the live one is often left
+		// Disabled, which blocks starting it outright. Enable it (Automatic) first so
+		// the restored cluster comes up and stays up across reboots.
+		win::set_start_type(&name, win::StartType::Automatic).await?;
+		win::transition(&name, win::Desired::Running).await
 	}
 	#[cfg(not(any(unix, windows)))]
 	{
 		let _ = (target, config);
 		Ok(())
+	}
+}
+
+/// Stop, and set to manual start, the postgres services for every *other* installed
+/// major version — so a differently-versioned server can't hold the port or
+/// auto-restart over the cluster being restored. Best-effort. Windows-only: Debian
+/// clusters listen on distinct ports, so they don't contend.
+pub async fn quiesce_other_versions(keep_major: &str) {
+	#[cfg(windows)]
+	{
+		for version in super::resolve::installed_server_versions() {
+			if version == keep_major {
+				continue;
+			}
+			let name = format!("postgresql-x64-{version}");
+			if let Err(err) = win::stop_and_set_manual(&name).await {
+				tracing::warn!("could not quiesce the postgres service {name}: {err}");
+			}
+		}
+	}
+	#[cfg(not(windows))]
+	{
+		let _ = keep_major;
 	}
 }
 
@@ -66,7 +94,7 @@ fn service_name(target: &ResolvedCluster, config: &PostgresqlConfig) -> String {
 
 #[cfg(windows)]
 mod win {
-	use std::time::Duration;
+	use std::{process::Stdio, time::Duration};
 
 	use miette::{IntoDiagnostic as _, Result, WrapErr as _, bail};
 	use tracing::info;
@@ -80,6 +108,50 @@ mod win {
 	pub enum Desired {
 		Stopped,
 		Running,
+	}
+
+	/// A service's start type, as `sc config start=` expects it.
+	#[derive(Clone, Copy)]
+	pub enum StartType {
+		Automatic,
+		Manual,
+	}
+
+	impl StartType {
+		fn sc_value(self) -> &'static str {
+			match self {
+				StartType::Automatic => "auto",
+				StartType::Manual => "demand",
+			}
+		}
+	}
+
+	/// Set a service's start type via `sc config` — the Service Control Manager
+	/// crate can only rewrite the *whole* config (clobbering the binary path), so
+	/// `sc` is the safe way to change just the start type.
+	pub async fn set_start_type(name: &str, start: StartType) -> Result<()> {
+		let mode = start.sc_value();
+		// `sc config <name> start= <mode>` — the space after `start=` is required.
+		let output = tokio::process::Command::new("sc")
+			.args(["config", name, "start=", mode])
+			.stdin(Stdio::null())
+			.output()
+			.await
+			.into_diagnostic()
+			.wrap_err_with(|| format!("running sc config for {name}"))?;
+		if !output.status.success() {
+			bail!(
+				"sc config {name} start= {mode} failed: {}",
+				String::from_utf8_lossy(&output.stdout).trim()
+			);
+		}
+		Ok(())
+	}
+
+	/// Stop the service (if present/running) and set it to manual start.
+	pub async fn stop_and_set_manual(name: &str) -> Result<()> {
+		let _ = transition(name, Desired::Stopped).await; // best-effort; may be absent/stopped
+		set_start_type(name, StartType::Manual).await
 	}
 
 	/// Drive `name` to `desired`, waiting for the transition to settle. The SCM


### PR DESCRIPTION
🤖 A live restore surfaced that a postgres restore wasn't self-consistent when the snapshot's major version differed from the host's currently-resolved cluster. Log from the field:

```
restoring postgres cluster cluster=main version=17 dest=C:\Program Files\PostgreSQL\18\data whole_install=false
WARN moving the restored data into place failed: … data.old
  The process cannot access the file because it is being used by another process. (os error 32)
…
starting the postgres cluster failed: starting the postgres service postgresql-x64-17
  The service cannot be started, either because it is disabled … (os error 1058)
```

The snapshot's data is **PG 17**, but the target resolved to the **PG 18** install (`…\18\data`). The service version was set to the data's major (17) while the destination stayed at 18 — incoherent. So:

- The **wrong service was stopped** — bestool stopped `postgresql-x64-17`, but `…\18\data` was held open by the running `postgresql-x64-18`, so the move hit a sharing violation.
- The **start failed** — it tried to start `postgresql-x64-17`, which was Disabled.

## Fixes

**Target the snapshot's own major version.** The restore now resolves the destination, the service it stops/starts, and the binaries it runs all to the snapshot's own major (read from `PG_VERSION`) — e.g. a v17 backup targets `…\17\data` / `/var/lib/postgresql/17/<cluster>` and the v17 service — instead of the currently-installed cluster. A physical backup only runs under its own major, so this is the only self-consistent placement, and it makes bestool stop/start the *right* service.

**Enable the target service before starting (Windows).** A versioned EDB service for a cluster that isn't the live one is often left Disabled, which blocks starting it (os error 1058). bestool now sets it to Automatic first (via `sc config`, since the SCM crate can only rewrite the whole config and would clobber the binary path).

**Quiesce other versions' services (Windows).** The other installed majors' services are stopped and set to manual start, so a differently-versioned server can't hold the port or auto-restart over the cluster being restored. Best-effort; Debian clusters use distinct ports so this is Windows-only.

