### PR TITLE
feat(canopy): derive bon builders for wire types so additive API fields don't break builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "algae-cli",
  "base64 0.22.1",
  "blake3",
+ "bon",
  "flate2",
  "futures",
  "getrandom 0.4.3",
@@ -1052,6 +1053,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -370,9 +370,11 @@ mod backup {
 			return Ok(());
 		}
 		client
-			.backup_capabilities(&bestool_canopy::schema::BackupCapabilitiesArgs {
-				types: types.clone(),
-			})
+			.backup_capabilities(
+				&bestool_canopy::schema::BackupCapabilitiesArgs::builder()
+					.types(types.clone())
+					.build(),
+			)
 			.await?;
 		info!(?types, "registered backup capabilities with canopy");
 		Ok(())
@@ -537,7 +539,7 @@ mod backup {
 			];
 			for kind in noise {
 				assert!(
-					!is_real_change(&Event::new(kind.clone())),
+					!is_real_change(&Event::new(kind)),
 					"{kind:?} should be ignored as read-noise"
 				);
 			}
@@ -550,7 +552,7 @@ mod backup {
 			];
 			for kind in real {
 				assert!(
-					is_real_change(&Event::new(kind.clone())),
+					is_real_change(&Event::new(kind)),
 					"{kind:?} should trigger re-registration"
 				);
 			}

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -481,32 +481,29 @@ async fn backup_after_start(
 		.into_diagnostic()
 		.wrap_err("backup run_id is not a valid uuid")?;
 	let report = match &outcome {
-		Ok(snapshot) => ReportArgs {
-			run_id: run_uuid,
-			type_: backup_type.to_owned(),
-			purpose: BackupPurpose::Backup,
-			outcome: RunOutcome::Success,
-			error: None,
-			bytes_uploaded: snapshot.bytes_uploaded,
-			snapshot_id: snapshot.id.clone(),
-			s3_sent_raw_bytes,
-			s3_sent_payload_bytes,
-			s3_received_raw_bytes,
-			s3_received_payload_bytes,
-		},
-		Err(err) => ReportArgs {
-			run_id: run_uuid,
-			type_: backup_type.to_owned(),
-			purpose: BackupPurpose::Backup,
-			outcome: RunOutcome::Failure,
-			error: Some(trim_error(err)),
-			bytes_uploaded: None,
-			snapshot_id: None,
-			s3_sent_raw_bytes,
-			s3_sent_payload_bytes,
-			s3_received_raw_bytes,
-			s3_received_payload_bytes,
-		},
+		Ok(snapshot) => ReportArgs::builder()
+			.run_id(run_uuid)
+			.type_(backup_type.to_owned())
+			.purpose(BackupPurpose::Backup)
+			.outcome(RunOutcome::Success)
+			.maybe_bytes_uploaded(snapshot.bytes_uploaded)
+			.maybe_snapshot_id(snapshot.id.clone())
+			.maybe_s3_sent_raw_bytes(s3_sent_raw_bytes)
+			.maybe_s3_sent_payload_bytes(s3_sent_payload_bytes)
+			.maybe_s3_received_raw_bytes(s3_received_raw_bytes)
+			.maybe_s3_received_payload_bytes(s3_received_payload_bytes)
+			.build(),
+		Err(err) => ReportArgs::builder()
+			.run_id(run_uuid)
+			.type_(backup_type.to_owned())
+			.purpose(BackupPurpose::Backup)
+			.outcome(RunOutcome::Failure)
+			.error(trim_error(err))
+			.maybe_s3_sent_raw_bytes(s3_sent_raw_bytes)
+			.maybe_s3_sent_payload_bytes(s3_sent_payload_bytes)
+			.maybe_s3_received_raw_bytes(s3_received_raw_bytes)
+			.maybe_s3_received_payload_bytes(s3_received_payload_bytes)
+			.build(),
 	};
 	client
 		.backup_report(&report)

--- a/crates/bestool/src/actions/canopy/backup/provider.rs
+++ b/crates/bestool/src/actions/canopy/backup/provider.rs
@@ -40,10 +40,12 @@ impl CanopyCredentialProvider {
 			let backup_type = backup_type.clone();
 			Box::pin(async move {
 				client
-					.backup_credentials(&BackupCredentialsArgs {
-						type_: backup_type.clone(),
-						purpose: Some(purpose),
-					})
+					.backup_credentials(
+						&BackupCredentialsArgs::builder()
+							.type_(backup_type.clone())
+							.purpose(purpose)
+							.build(),
+					)
 					.await
 					.map_err(|err| format!("{err}"))
 			})

--- a/crates/bestool/src/actions/canopy/register.rs
+++ b/crates/bestool/src/actions/canopy/register.rs
@@ -319,13 +319,13 @@ async fn begin(
 	let resp = transport
 		.client()
 		.post(url)
-		.json(&BeginArgs {
-			server_id,
-			token: token.to_owned(),
-			spki: transport
-				.carries_spki_in_body()
-				.then(|| spki.to_owned()),
-		})
+		.json(
+			&BeginArgs::builder()
+				.server_id(server_id)
+				.token(token.to_owned())
+				.maybe_spki(transport.carries_spki_in_body().then(|| spki.to_owned()))
+				.build(),
+		)
 		.send()
 		.await
 		.into_diagnostic()
@@ -345,14 +345,14 @@ async fn complete(
 	let resp = transport
 		.client()
 		.post(url)
-		.json(&CompleteArgs {
-			server_id,
-			nonce: nonce.to_owned(),
-			signature: signature.to_owned(),
-			spki: transport
-				.carries_spki_in_body()
-				.then(|| spki.to_owned()),
-		})
+		.json(
+			&CompleteArgs::builder()
+				.server_id(server_id)
+				.nonce(nonce.to_owned())
+				.signature(signature.to_owned())
+				.maybe_spki(transport.carries_spki_in_body().then(|| spki.to_owned()))
+				.build(),
+		)
 		.send()
 		.await
 		.into_diagnostic()

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -140,23 +140,22 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 	// own outcome is what the command returns; a reporting failure is only warned.
 	let traffic = proxy.traffic();
 	let to_i64 = |n: u64| i64::try_from(n).unwrap_or(i64::MAX);
-	let report = ReportArgs {
-		run_id,
-		type_: args.backup_type.clone(),
-		purpose: BackupPurpose::Restore,
-		outcome: if outcome.is_ok() {
+	let report = ReportArgs::builder()
+		.run_id(run_id)
+		.type_(args.backup_type.clone())
+		.purpose(BackupPurpose::Restore)
+		.outcome(if outcome.is_ok() {
 			RunOutcome::Success
 		} else {
 			RunOutcome::Failure
-		},
-		error: outcome.as_ref().err().map(trim_error),
-		bytes_uploaded: None,
-		snapshot_id: Some(snapshot.id.clone()),
-		s3_sent_raw_bytes: Some(to_i64(traffic.sent_raw)),
-		s3_sent_payload_bytes: Some(to_i64(traffic.sent_payload)),
-		s3_received_raw_bytes: Some(to_i64(traffic.received_raw)),
-		s3_received_payload_bytes: Some(to_i64(traffic.received_payload)),
-	};
+		})
+		.maybe_error(outcome.as_ref().err().map(trim_error))
+		.snapshot_id(snapshot.id.clone())
+		.s3_sent_raw_bytes(to_i64(traffic.sent_raw))
+		.s3_sent_payload_bytes(to_i64(traffic.sent_payload))
+		.s3_received_raw_bytes(to_i64(traffic.received_raw))
+		.s3_received_payload_bytes(to_i64(traffic.received_payload))
+		.build();
 	if let Err(err) = client.backup_report(&report).await {
 		warn!("failed to report the restore to canopy: {err}");
 	}

--- a/crates/bestool/src/canopy_contract.rs
+++ b/crates/bestool/src/canopy_contract.rs
@@ -120,15 +120,15 @@ async fn events_request_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/events", "post");
 
-	let event = NewEvent {
-		source: "bestool-contract-test".to_owned(),
-		ref_: "host/alert:target".to_owned(),
-		message: "message".to_owned(),
-		description: Some("description".to_owned()),
-		severity: Some(Severity::Warning),
-		occurred_at: Some("2026-01-01T00:00:00Z".parse().unwrap()),
-		active: Some(true),
-	};
+	let event = NewEvent::builder()
+		.source("bestool-contract-test".to_owned())
+		.ref_("host/alert:target".to_owned())
+		.message("message".to_owned())
+		.description("description".to_owned())
+		.severity(Severity::Warning)
+		.occurred_at("2026-01-01T00:00:00Z".parse().unwrap())
+		.active(true)
+		.build();
 	let instance = serde_json::to_value(&event).unwrap();
 	assert_valid(spec, &request_schema("/events", "post"), &instance);
 
@@ -230,11 +230,11 @@ async fn register_begin_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/servers/register/begin", "post");
 
-	let request = BeginArgs {
-		server_id: "00000000-0000-0000-0000-000000000000".parse().unwrap(),
-		token: "enrollment-token".to_owned(),
-		spki: Some("c3BraQ==".to_owned()),
-	};
+	let request = BeginArgs::builder()
+		.server_id("00000000-0000-0000-0000-000000000000".parse().unwrap())
+		.token("enrollment-token".to_owned())
+		.spki("c3BraQ==".to_owned())
+		.build();
 	let instance = serde_json::to_value(&request).unwrap();
 	assert_valid(
 		spec,
@@ -259,12 +259,11 @@ async fn register_complete_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/servers/register/complete", "post");
 
-	let request = CompleteArgs {
-		server_id: "00000000-0000-0000-0000-000000000000".parse().unwrap(),
-		nonce: "bm9uY2U=".to_owned(),
-		signature: "c2lnbmF0dXJl".to_owned(),
-		spki: None,
-	};
+	let request = CompleteArgs::builder()
+		.server_id("00000000-0000-0000-0000-000000000000".parse().unwrap())
+		.nonce("bm9uY2U=".to_owned())
+		.signature("c2lnbmF0dXJl".to_owned())
+		.build();
 	let instance = serde_json::to_value(&request).unwrap();
 	assert_valid(
 		spec,
@@ -361,7 +360,8 @@ async fn backup_capabilities_request_matches_spec() {
 	assert_operation_exists(spec, "/backup-capabilities", "post");
 
 	let types = vec!["tamanu-postgres".to_owned()];
-	let instance = serde_json::to_value(BackupCapabilitiesArgs { types }).unwrap();
+	let instance =
+		serde_json::to_value(BackupCapabilitiesArgs::builder().types(types).build()).unwrap();
 	assert_valid(
 		spec,
 		&request_schema("/backup-capabilities", "post"),
@@ -375,10 +375,12 @@ async fn backup_credentials_request_and_response_match_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/backup-credentials", "post");
 
-	let instance = serde_json::to_value(BackupCredentialsArgs {
-		type_: "tamanu-postgres".to_owned(),
-		purpose: Some(BackupPurpose::Backup),
-	})
+	let instance = serde_json::to_value(
+		BackupCredentialsArgs::builder()
+			.type_("tamanu-postgres".to_owned())
+			.purpose(BackupPurpose::Backup)
+			.build(),
+	)
 	.unwrap();
 	assert_valid(
 		spec,
@@ -439,22 +441,24 @@ async fn backup_report_request_matches_spec() {
 	let spec = spec().await;
 	assert_operation_exists(spec, "/backup-report", "post");
 
-	let instance = serde_json::to_value(ReportArgs {
-		run_id: "00000000-0000-0000-0000-000000000000".parse().unwrap(),
-		type_: "tamanu-postgres".to_owned(),
-		purpose: BackupPurpose::Backup,
-		outcome: RunOutcome::Success,
-		error: None,
-		bytes_uploaded: Some(12345),
-		snapshot_id: Some("abc123".to_owned()),
-		// Intentionally populated: this gates the PR. bestool already sends these
-		// (canopy ignores unknown fields), but the contract check stays red until
-		// canopy's OpenAPI spec defines the s3 traffic fields — then it goes green.
-		s3_sent_raw_bytes: Some(2_000_000),
-		s3_sent_payload_bytes: Some(1_950_000),
-		s3_received_raw_bytes: Some(4096),
-		s3_received_payload_bytes: Some(0),
-	})
+	// The s3 traffic fields are intentionally populated: this gates the PR.
+	// bestool already sends these (canopy ignores unknown fields), but the
+	// contract check stays red until canopy's OpenAPI spec defines the s3 traffic
+	// fields — then it goes green.
+	let instance = serde_json::to_value(
+		ReportArgs::builder()
+			.run_id("00000000-0000-0000-0000-000000000000".parse().unwrap())
+			.type_("tamanu-postgres".to_owned())
+			.purpose(BackupPurpose::Backup)
+			.outcome(RunOutcome::Success)
+			.bytes_uploaded(12345)
+			.snapshot_id("abc123".to_owned())
+			.s3_sent_raw_bytes(2_000_000)
+			.s3_sent_payload_bytes(1_950_000)
+			.s3_received_raw_bytes(4096)
+			.s3_received_payload_bytes(0)
+			.build(),
+	)
 	.unwrap();
 	assert_valid(spec, &request_schema("/backup-report", "post"), &instance);
 

--- a/crates/canopy/Cargo.toml
+++ b/crates/canopy/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 algae-cli = { version = "1.1.6", path = "../algae-cli" }
 base64 = "0.22.1"
 blake3 = "1.8.5"
+bon = "3.9.3"
 flate2 = "1.0.34"
 futures = { workspace = true, features = ["executor"] }
 getrandom = "0.4.2"

--- a/crates/canopy/build.rs
+++ b/crates/canopy/build.rs
@@ -77,7 +77,9 @@ fn main() {
 		.add_root_schema(root_schema)
 		.expect("generating types from canopy schemas");
 
-	let file = syn::parse2(type_space.to_stream()).expect("parsing generated canopy schema tokens");
+	let mut file: syn::File =
+		syn::parse2(type_space.to_stream()).expect("parsing generated canopy schema tokens");
+	inject_builders(&mut file.items);
 	let mut generated = provenance(&spec_text, source);
 	generated.push_str(&rewrite_types(&prettyplease::unparse(&file)));
 	generated.push_str(&generate_client_methods(&spec));
@@ -336,6 +338,42 @@ fn is_open_schema(spec: &Value, name: &str) -> bool {
 			&& member.get("properties").is_none()
 			&& member.get("$ref").is_none()
 	})
+}
+
+/// Give every generated struct a compile-time-checked builder and mark it
+/// `#[non_exhaustive]`.
+///
+/// canopy's OpenAPI evolves independently of bestool, so a struct built with a
+/// literal breaks the moment canopy adds a field. `#[derive(::bon::Builder)]`
+/// lets construction name only the fields it sets: bon treats an `Option<T>`
+/// field as defaulting to `None`, so an added optional field touches no call
+/// site, and `#[non_exhaustive]` stops literal construction from other crates
+/// so the builder is the only way in.
+///
+/// Only structs with named fields get this: bon can't derive on enums or
+/// tuple/newtype structs, and an empty struct has nothing to build. Recurses
+/// into modules so nested types (e.g. under `error`) are considered, then
+/// skipped when they aren't named-field structs.
+fn inject_builders(items: &mut [syn::Item]) {
+	for item in items {
+		match item {
+			syn::Item::Struct(item) => {
+				if let syn::Fields::Named(fields) = &item.fields
+					&& !fields.named.is_empty()
+				{
+					item.attrs
+						.push(syn::parse_quote!(#[derive(::bon::Builder)]));
+					item.attrs.push(syn::parse_quote!(#[non_exhaustive]));
+				}
+			}
+			syn::Item::Mod(item) => {
+				if let Some((_, items)) = &mut item.content {
+					inject_builders(items);
+				}
+			}
+			_ => {}
+		}
+	}
 }
 
 /// Post-process the generated wire types.

--- a/crates/canopy/tests/schema.rs
+++ b/crates/canopy/tests/schema.rs
@@ -128,15 +128,11 @@ fn backup_target_repo_password_is_redacted() {
 
 #[test]
 fn new_event_omits_optional_fields() {
-	let event = NewEvent {
-		source: "src".to_owned(),
-		ref_: "host/alert:tgt".to_owned(),
-		message: "msg".to_owned(),
-		description: None,
-		severity: None,
-		occurred_at: None,
-		active: None,
-	};
+	let event = NewEvent::builder()
+		.source("src".to_owned())
+		.ref_("host/alert:tgt".to_owned())
+		.message("msg".to_owned())
+		.build();
 	let json = serde_json::to_string(&event).unwrap();
 	assert!(json.contains("\"source\":\"src\""));
 	assert!(json.contains("\"ref\":\"host/alert:tgt\""));
@@ -149,15 +145,15 @@ fn new_event_omits_optional_fields() {
 
 #[test]
 fn new_event_serialises_occurred_at_camel_case_and_severity_lowercase() {
-	let event = NewEvent {
-		source: "src".to_owned(),
-		ref_: "ref".to_owned(),
-		message: "msg".to_owned(),
-		description: Some("desc".to_owned()),
-		severity: Some(Severity::Warning),
-		occurred_at: Some("2025-01-01T00:00:00Z".parse().unwrap()),
-		active: Some(true),
-	};
+	let event = NewEvent::builder()
+		.source("src".to_owned())
+		.ref_("ref".to_owned())
+		.message("msg".to_owned())
+		.description("desc".to_owned())
+		.severity(Severity::Warning)
+		.occurred_at("2025-01-01T00:00:00Z".parse().unwrap())
+		.active(true)
+		.build();
 	let json = serde_json::to_string(&event).unwrap();
 	assert!(json.contains("\"occurredAt\":"));
 	assert!(json.contains("\"severity\":\"warning\""));


### PR DESCRIPTION
🤖 The `bestool-canopy` `schema` module is codegen'd from canopy's live OpenAPI document, and its input/output structs were constructed with struct literals. Because the generated types track canopy as it evolves, canopy adding even one optional field broke every downstream build that constructed an affected struct.

This derives `bon::Builder` on every generated named-field struct and marks them `#[non_exhaustive]`, so construction names only the fields it sets: an added `Option` field defaults to `None` and touches no call site, and literal construction from other crates no longer compiles — keeping the builder the only way in. Every construction site is converted to the builder.

### Why bon rather than typify's native builder

typify's `with_struct_builder` emits a builder that's frozen at codegen time against the pre-rewrite field types. The build script rewrites some fields after generation (chrono → `jiff::Timestamp`, secrets → `Redacted`), so typify's builder would end up type-mismatched against the rewritten struct. bon is a `#[derive]` expanded by rustc after the rewrites, so it sees the final field types.

bon also detects optional members by the last path segment of the type, so typify's fully-qualified `::std::option::Option<T>` is correctly treated as optional — which is what makes added optional fields free.

### Trade-off

bon treats a non-`Option` field as required, so a future field that canopy adds as required-with-a-default (rather than optional) would surface as a compile error at the builder, matching the compile-time-safety intent. Per-field `#[builder(default)]` injection for serde-defaulted fields could soften that later if it comes up.
