### PR TITLE
fix(canopy): grant the postgres service account access to restored data on Windows

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -212,8 +212,12 @@ pub async fn restore(
 	})
 	.await?;
 
-	crate::interactive::retry("fixing data directory ownership", async || {
-		fix_ownership(&target.data_dir).await
+	// The account the server runs as, so its files can be made writable by it
+	// (Windows). Fix the whole restored tree (`dest`): the data dir for a data-only
+	// restore, or the install root — binaries included — for a whole-install one.
+	let service_account = service::service_account(target, config).await;
+	crate::interactive::retry("fixing restored data permissions", async || {
+		fix_ownership(&plan.dest, service_account.as_deref()).await
 	})
 	.await?;
 
@@ -286,17 +290,40 @@ async fn repoint_symlink_if_present(link: &Path, dest: &Path) {
 	}
 }
 
-/// Restore the postgres-owned mode and ownership of the freshly-swapped data
-/// directory. Unix-only: on Windows the directory inherits its parent's ACLs
-/// (the EDB install root), which is what the service account already expects.
+/// Fix up ownership and permissions of the freshly-restored tree (`dest`) so the
+/// postgres server account can read and write it.
+///
+/// On Unix: `chown` to `postgres` and `chmod 0750` — the peer-auth service user.
+///
+/// On Windows: kopia can restore files with an ACL that grants neither the
+/// service account nor Administrators, so the server can't even create
+/// `postmaster.pid` and won't start. Take ownership (the elevated caller always
+/// can), reset each entry to the ACL inherited from the install root, and grant
+/// the server's own account (`account`, e.g. `NT AUTHORITY\NetworkService`) full
+/// control.
 #[cfg(unix)]
-async fn fix_ownership(data_dir: &Path) -> Result<()> {
-	run_status("chown", &["-R", "postgres:postgres", path(data_dir)]).await?;
-	run_status("chmod", &["0750", path(data_dir)]).await
+async fn fix_ownership(dest: &Path, _account: Option<&str>) -> Result<()> {
+	run_status("chown", &["-R", "postgres:postgres", path(dest)]).await?;
+	run_status("chmod", &["0750", path(dest)]).await
 }
 
-#[cfg(not(unix))]
-async fn fix_ownership(_data_dir: &Path) -> Result<()> {
+#[cfg(windows)]
+async fn fix_ownership(dest: &Path, account: Option<&str>) -> Result<()> {
+	let dir = dest.to_string_lossy();
+	// Take ownership so the ACL can be rewritten even when kopia locked it down.
+	run_status("takeown", &["/F", dir.as_ref(), "/R", "/D", "Y"]).await?;
+	// Reset every entry to the ACL inherited from the install root.
+	run_status("icacls", &[dir.as_ref(), "/reset", "/T", "/C", "/Q"]).await?;
+	// Grant the server's own account full control (object + container inherit).
+	if let Some(account) = account {
+		let grant = format!("{account}:(OI)(CI)F");
+		run_status("icacls", &[dir.as_ref(), "/grant", grant.as_str(), "/T", "/C", "/Q"]).await?;
+	}
+	Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+async fn fix_ownership(_dest: &Path, _account: Option<&str>) -> Result<()> {
 	Ok(())
 }
 
@@ -324,7 +351,7 @@ fn path(p: &Path) -> &str {
 	p.to_str().unwrap_or_default()
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 pub(super) async fn run_status(program: &str, args: &[&str]) -> Result<()> {
 	let status = tokio::process::Command::new(program)
 		.args(args)

--- a/crates/bestool/src/actions/canopy/backup/postgresql/service.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/service.rs
@@ -76,6 +76,22 @@ pub async fn quiesce_other_versions(keep_major: &str) {
 	}
 }
 
+/// The account the cluster's service runs as, when it needs granting access to
+/// the restored files (Windows: the EDB service account, e.g.
+/// `NT AUTHORITY\NetworkService`). `None` when there's nothing extra to grant —
+/// off Windows, or when the service runs as LocalSystem (already `SYSTEM`).
+pub async fn service_account(target: &ResolvedCluster, config: &PostgresqlConfig) -> Option<String> {
+	#[cfg(windows)]
+	{
+		win::query_account(&service_name(target, config)).await
+	}
+	#[cfg(not(windows))]
+	{
+		let _ = (target, config);
+		None
+	}
+}
+
 #[cfg(unix)]
 async fn systemctl(verb: &str, target: &ResolvedCluster) -> Result<()> {
 	let unit = format!("postgresql@{}-{}", target.version, target.cluster);
@@ -124,6 +140,29 @@ mod win {
 				StartType::Manual => "demand",
 			}
 		}
+	}
+
+	/// The account the service runs as, per its SCM config. `None` if the service
+	/// is absent/unreadable or runs as LocalSystem (already `SYSTEM`, and a name
+	/// `icacls` doesn't accept). Best-effort — a failure to read it just means no
+	/// extra grant.
+	pub async fn query_account(name: &str) -> Option<String> {
+		let name = name.to_owned();
+		tokio::task::spawn_blocking(move || {
+			let manager =
+				ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT).ok()?;
+			let service = manager.open_service(&name, ServiceAccess::QUERY_CONFIG).ok()?;
+			let account = service.query_config().ok()?.account_name?;
+			let account = account.to_string_lossy().into_owned();
+			if account.eq_ignore_ascii_case("localsystem") {
+				None
+			} else {
+				Some(account)
+			}
+		})
+		.await
+		.ok()
+		.flatten()
 	}
 
 	/// Set a service's start type via `sc config` — the Service Control Manager


### PR DESCRIPTION
🤖 A Windows restore left the data directory unwritable by the postgres server, so it wouldn't start:

```
starting the postgres cluster failed:
  x the postgres service postgresql-x64-14 did not reach Running within 60s
```

and a manual start confirmed it's a permissions problem, not data:

```
pg_ctl -D data start
FATAL:  could not create lock file "postmaster.pid": Permission denied
```

— "Permission denied" *even running elevated as Administrator*.

## Cause

kopia restores the data directory with an ACL that grants neither the postgres service account (`NT AUTHORITY\NetworkService` for EDB) nor Administrators write access. On Unix `fix_ownership` chowns the tree to `postgres`; on Windows it was a **no-op**, so nothing repaired the ACL and the server couldn't create `postmaster.pid`.

## Fix

`fix_ownership` now handles Windows: it takes ownership of the restored tree (the elevated caller always can), resets each entry to the ACL inherited from the install root, then grants the cluster's own service account — read from the service config via the SCM — full control. Applied to the whole restored tree: the data dir for a data-only restore, or the install root (binaries included) for a whole-install one.

Builds on Linux + `x86_64-pc-windows-gnu`, clippy clean, existing postgresql tests pass.

I couldn't exercise this on a Windows host, so the `takeown`/`icacls` sequence is reasoned from the symptoms and cross-compiled, not run live. One known limitation: `takeown /D Y` uses the English affirmative, so it assumes an English-locale server.
