### PR TITLE
feat(canopy): send the run id with backup and restore credential requests

### DIFF
--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -281,8 +281,14 @@ pub(super) async fn spawn_proxy(
 	backup_type: String,
 	purpose: BackupPurpose,
 	region: &str,
+	run_id: Uuid,
 ) -> Result<RunningProxy> {
-	let provider = Arc::new(CanopyCredentialProvider::new(client, backup_type, purpose));
+	let provider = Arc::new(CanopyCredentialProvider::new(
+		client,
+		backup_type,
+		purpose,
+		run_id,
+	));
 	let upstream_host = upstream_host_for(region).await;
 	let config = S3ProxyConfig {
 		upstream: format!("https://{upstream_host}"),
@@ -431,12 +437,20 @@ async fn backup_after_start(
 		TargetOutcome::Ready(target) => target,
 	};
 
+	let run_uuid: Uuid = run_id
+		.parse()
+		.into_diagnostic()
+		.wrap_err("backup run_id is not a valid uuid")?;
+
 	// The proxy serves for the whole run; held in scope until reporting is done.
+	// The run id is carried on every credential issuance so Canopy can correlate
+	// the whole session.
 	let proxy = spawn_proxy(
 		client.clone(),
 		backup_type.to_owned(),
 		BackupPurpose::Backup,
 		&target.region,
+		run_uuid,
 	)
 	.await?;
 	let conn = RepoConn {
@@ -476,10 +490,6 @@ async fn backup_after_start(
 	let s3_sent_payload_bytes = Some(to_i64(traffic.sent_payload));
 	let s3_received_raw_bytes = Some(to_i64(traffic.received_raw));
 	let s3_received_payload_bytes = Some(to_i64(traffic.received_payload));
-	let run_uuid: Uuid = run_id
-		.parse()
-		.into_diagnostic()
-		.wrap_err("backup run_id is not a valid uuid")?;
 	let report = match &outcome {
 		Ok(snapshot) => ReportArgs::builder()
 			.run_id(run_uuid)

--- a/crates/bestool/src/actions/canopy/backup/provider.rs
+++ b/crates/bestool/src/actions/canopy/backup/provider.rs
@@ -16,6 +16,7 @@ use bestool_kopia::proxy::{BoxError, CredentialProvider, Credentials};
 use futures::future::BoxFuture;
 use jiff::{Timestamp, ToSpan};
 use tokio::sync::Mutex;
+use uuid::Uuid;
 
 /// Refresh creds this far ahead of their `Expiration`.
 const REFRESH_MARGIN_MINUTES: i64 = 2;
@@ -33,8 +34,14 @@ pub struct CanopyCredentialProvider {
 
 impl CanopyCredentialProvider {
 	/// Build a provider that fetches `(backup_type, purpose)` credentials from
-	/// Canopy.
-	pub fn new(client: Arc<CanopyClient>, backup_type: String, purpose: BackupPurpose) -> Self {
+	/// Canopy, tagged with `run_id` so Canopy can correlate every issuance,
+	/// snapshot, and report of one run.
+	pub fn new(
+		client: Arc<CanopyClient>,
+		backup_type: String,
+		purpose: BackupPurpose,
+		run_id: Uuid,
+	) -> Self {
 		let refresh: Refresher = Arc::new(move || {
 			let client = client.clone();
 			let backup_type = backup_type.clone();
@@ -44,6 +51,7 @@ impl CanopyCredentialProvider {
 						&BackupCredentialsArgs::builder()
 							.type_(backup_type.clone())
 							.purpose(purpose)
+							.run_id(run_id)
 							.build(),
 					)
 					.await

--- a/crates/bestool/src/actions/canopy/kopia.rs
+++ b/crates/bestool/src/actions/canopy/kopia.rs
@@ -91,12 +91,14 @@ pub async fn run(args: KopiaArgs, _ctx: Context) -> Result<()> {
 		}
 	};
 
-	// The proxy serves for the whole command; held in scope to the end.
+	// The proxy serves for the whole command; held in scope to the end. A fresh
+	// run id per invocation lets canopy correlate this session's credential issues.
 	let proxy = spawn_proxy(
 		client.clone(),
 		args.backup_type.clone(),
 		args.purpose.into(),
 		&target.region,
+		uuid::Uuid::new_v4(),
 	)
 	.await?;
 	let config_dir = transient_config_dir()?;

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -94,6 +94,10 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		}
 	};
 
+	// A fresh run id per restore (canopy rejects a repeated one), carried on every
+	// credential issuance so canopy can correlate the whole session.
+	let run_id = Uuid::new_v4();
+
 	// Read-only creds + connection (the restore purpose downscopes server-side).
 	// The proxy serves for the whole restore; held in scope to the end.
 	let proxy = spawn_proxy(
@@ -101,6 +105,7 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		args.backup_type.clone(),
 		BackupPurpose::Restore,
 		&target.region,
+		run_id,
 	)
 	.await?;
 	let config_dir = transient_config_dir()?;
@@ -128,9 +133,6 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 		taken = ?snapshot.end_time.or(snapshot.start_time),
 		"restoring snapshot",
 	);
-
-	// A fresh run id per restore (canopy rejects a repeated one).
-	let run_id = Uuid::new_v4();
 
 	// Perform the restore, capturing the outcome so it can be reported to canopy
 	// whether it succeeds or fails.


### PR DESCRIPTION
🤖 Canopy correlates a whole session — every credential issuance, the snapshot, and the run report — by a single run id, and now wants that id on the credential requests, not just the report.

The S3-proxy credential provider now carries the run id and sends it on every `backup-credentials` call (`BackupCredentialsArgs.run_id`, already present in the OpenAPI schema). It's threaded through `spawn_proxy` from all three call sites:

- **backup** and **restore** pass their existing run id — the same one reported at the end — so issuance and report line up;
- the ad-hoc `kopia` passthrough mints a fresh id per invocation.

For backups the id is parsed to a UUID once up front and reused for both the proxy and the report (removing a duplicate parse). For restores the run id is now minted before the proxy starts.

Builds on Linux + `x86_64-pc-windows-gnu`, clippy clean, provider tests pass.
