### PR TITLE
feat(alertd): apply canopy effective-severity ceilings to healthchecks

### DIFF
--- a/crates/alertd/src/doctor/check.rs
+++ b/crates/alertd/src/doctor/check.rs
@@ -1,3 +1,4 @@
+use bestool_canopy::schema::CheckSeverity;
 use serde_json::{Map, Value, json};
 
 /// Outcome of a single healthcheck.
@@ -43,6 +44,35 @@ impl CheckStatus {
 	/// Whether this status is a skip — useful for rendering and accounting.
 	pub fn is_skip(&self) -> bool {
 		matches!(self, CheckStatus::Skip(_))
+	}
+
+	/// Apply canopy's effective-severity ceiling to this status.
+	///
+	/// The severity canopy reports for a check is a *ceiling*, never a floor: a
+	/// computed status is only ever lowered towards it, never raised. So a check
+	/// that passes still passes even when its ceiling is `warn`, and a `warn`
+	/// finding is never promoted to a `fail` just because the ceiling allows it.
+	///
+	/// The ceiling only bites on the two states that would otherwise alert:
+	/// * `fail` ceiling — leaves everything as computed.
+	/// * `warn` ceiling — a computed [`Fail`](Self::Fail) drops to
+	///   [`Warning`](Self::Warning), keeping its reason.
+	/// * `skip` ceiling — the check is silenced for this server, so a computed
+	///   [`Warning`](Self::Warning) or [`Fail`](Self::Fail) drops to
+	///   [`Skip`](Self::Skip), keeping its reason.
+	///
+	/// [`Broken`](Self::Broken) is left untouched: it reports that the check
+	/// itself errored (bad SQL, a missing column), which is a fault in our own
+	/// diagnostics rather than a severity finding about the system, and shouldn't
+	/// be silenced by an operator muting the check's *result*.
+	pub fn cap_to(self, ceiling: CheckSeverity) -> Self {
+		match (ceiling, self) {
+			(CheckSeverity::Skip, CheckStatus::Warning(reason) | CheckStatus::Fail(reason)) => {
+				CheckStatus::Skip(reason)
+			}
+			(CheckSeverity::Warn, CheckStatus::Fail(reason)) => CheckStatus::Warning(reason),
+			(_, status) => status,
+		}
 	}
 
 	/// The explanatory reason carried by every non-pass status, if any.
@@ -368,6 +398,56 @@ mod tests {
 		let skip = Check::skip("x", "n/a", "central-only");
 		assert_eq!(skip.to_wire()["result"], "skipped");
 		assert_eq!(skip.to_wire()["reason"], "central-only");
+	}
+
+	#[test]
+	fn cap_to_never_raises_severity() {
+		// A pass stays a pass regardless of the ceiling.
+		assert!(matches!(
+			CheckStatus::Pass.cap_to(CheckSeverity::Warn),
+			CheckStatus::Pass
+		));
+		assert!(matches!(
+			CheckStatus::Pass.cap_to(CheckSeverity::Fail),
+			CheckStatus::Pass
+		));
+		// A warning is not promoted to a failure by a fail ceiling.
+		assert!(matches!(
+			CheckStatus::Warning("w".into()).cap_to(CheckSeverity::Fail),
+			CheckStatus::Warning(_)
+		));
+	}
+
+	#[test]
+	fn cap_to_lowers_to_the_ceiling() {
+		// fail capped at warn becomes a warning, keeping its reason.
+		match CheckStatus::Fail("disk full".into()).cap_to(CheckSeverity::Warn) {
+			CheckStatus::Warning(r) => assert_eq!(r, "disk full"),
+			other => panic!("expected Warning, got {other:?}"),
+		}
+		// warn and fail capped at skip are silenced, keeping their reason.
+		match CheckStatus::Warning("noisy".into()).cap_to(CheckSeverity::Skip) {
+			CheckStatus::Skip(r) => assert_eq!(r, "noisy"),
+			other => panic!("expected Skip, got {other:?}"),
+		}
+		match CheckStatus::Fail("noisy".into()).cap_to(CheckSeverity::Skip) {
+			CheckStatus::Skip(r) => assert_eq!(r, "noisy"),
+			other => panic!("expected Skip, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn cap_to_leaves_broken_and_skip_untouched() {
+		// Broken is a fault in the check itself, not a severity finding, so an
+		// operator silencing the check's result must not hide it.
+		assert!(matches!(
+			CheckStatus::Broken("bad sql".into()).cap_to(CheckSeverity::Skip),
+			CheckStatus::Broken(_)
+		));
+		assert!(matches!(
+			CheckStatus::Skip("n/a".into()).cap_to(CheckSeverity::Fail),
+			CheckStatus::Skip(_)
+		));
 	}
 
 	#[test]

--- a/crates/alertd/src/doctor/sweep.rs
+++ b/crates/alertd/src/doctor/sweep.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
+use bestool_canopy::schema::CheckSeverity;
 use futures::stream::{FuturesUnordered, StreamExt};
 use miette::{IntoDiagnostic, Result, miette};
 use node_semver::Version;
@@ -14,6 +15,23 @@ use crate::doctor::{
 	progress::{DoctorEvent, ProgressSender},
 	server_info::{self, ServerFacts},
 };
+
+/// Ceiling applied to a check that canopy's severity map doesn't mention.
+///
+/// A check absent from the map is one canopy doesn't yet know about (it's newer
+/// than the deployment), which canopy's own contract classifies as `warn` until
+/// it catches up. Matching that here keeps a local sweep's verdict in step with
+/// what canopy would show.
+const ABSENT_CHECK_SEVERITY: CheckSeverity = CheckSeverity::Warn;
+
+/// The ceiling to apply to the check named `name`, honouring the absent-check
+/// default ([`ABSENT_CHECK_SEVERITY`]).
+pub fn severity_ceiling(severities: &HashMap<String, CheckSeverity>, name: &str) -> CheckSeverity {
+	severities
+		.get(name)
+		.copied()
+		.unwrap_or(ABSENT_CHECK_SEVERITY)
+}
 
 /// The Tamanu deployment a sweep runs against, when the host has one.
 #[derive(Clone)]
@@ -68,6 +86,7 @@ pub fn resolve_sweep_tamanu(install: Option<(Version, PathBuf)>) -> Result<Optio
 	}
 }
 
+#[derive(Clone)]
 pub struct SweepResult {
 	pub server_id: Option<String>,
 	pub results: Vec<(Check, bool)>,
@@ -77,6 +96,33 @@ pub struct SweepResult {
 	/// callers (e.g. the daemon plugin) can cache it across ticks instead of
 	/// re-querying every minute.
 	pub pg_version: Option<String>,
+}
+
+impl SweepResult {
+	/// Lower each check's status to canopy's effective-severity ceiling, then
+	/// re-derive the overall result and the wire `health[]` array to match.
+	///
+	/// This is a display-time transform for local consumers (the `doctor` CLI):
+	/// the payload posted to canopy is always the raw one, since canopy is the
+	/// source of truth for severities and applies the mapping itself. See
+	/// [`CheckStatus::cap_to`](crate::doctor::check::CheckStatus::cap_to) for the
+	/// ceiling semantics and [`severity_ceiling`] for the absent-check default.
+	pub fn apply_severities(&mut self, severities: &HashMap<String, CheckSeverity>) {
+		for (check, _) in &mut self.results {
+			let ceiling = severity_ceiling(severities, check.name);
+			check.status = check.status.clone().cap_to(ceiling);
+		}
+		self.overall = OverallResult::from_checks(
+			&self
+				.results
+				.iter()
+				.map(|(c, _)| c.clone())
+				.collect::<Vec<_>>(),
+		);
+		if let Value::Object(obj) = &mut self.payload {
+			obj.insert("health".into(), Value::Array(health_array(&self.results)));
+		}
+	}
 }
 
 pub async fn perform_sweep(
@@ -327,15 +373,18 @@ fn build_payload(info: &Value, results: &[(Check, bool)]) -> Value {
 		}
 	}
 
-	let health: Vec<Value> = results
+	payload.insert("health".into(), Value::Array(health_array(results)));
+
+	Value::Object(payload)
+}
+
+/// The `health[]` wire array: one entry per on-wire check, in the given order.
+fn health_array(results: &[(Check, bool)]) -> Vec<Value> {
+	results
 		.iter()
 		.filter(|(_, on_wire)| *on_wire)
 		.map(|(c, _)| c.to_wire())
-		.collect();
-
-	payload.insert("health".into(), Value::Array(health));
-
-	Value::Object(payload)
+		.collect()
 }
 
 #[cfg(test)]
@@ -471,6 +520,73 @@ mod tests {
 			.map(|v| v["check"].as_str().unwrap())
 			.collect();
 		assert_eq!(names, vec!["on"]);
+	}
+
+	#[test]
+	fn apply_severities_caps_results_overall_and_wire() {
+		let results = vec![pass("keep_pass"), fail("noisy"), fail("real")];
+		let payload = build_payload(&Value::Object(Default::default()), &results);
+		let mut sweep = SweepResult {
+			server_id: None,
+			results,
+			overall: OverallResult::Failing,
+			payload,
+			pg_version: None,
+		};
+
+		let mut severities = HashMap::new();
+		severities.insert("noisy".to_string(), CheckSeverity::Skip);
+		severities.insert("real".to_string(), CheckSeverity::Fail);
+		// `keep_pass` is absent from the map: it defaults to warn, but a pass is
+		// never raised, so it stays passing.
+		sweep.apply_severities(&severities);
+
+		let status_of = |name: &str| {
+			sweep
+				.results
+				.iter()
+				.find(|(c, _)| c.name == name)
+				.map(|(c, _)| c.status.wire_result())
+				.unwrap()
+		};
+		assert_eq!(status_of("keep_pass"), "passed");
+		assert_eq!(status_of("noisy"), "skipped");
+		assert_eq!(status_of("real"), "failed");
+
+		// Overall is re-derived from the capped statuses: the only fatal check
+		// left is `real`, so we're still failing; silence `real` too and it drops.
+		assert_eq!(sweep.overall, OverallResult::Failing);
+
+		// The wire health array tracks the capped statuses.
+		let wire_result = |name: &str| {
+			sweep.payload["health"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.find(|c| c["check"] == name)
+				.unwrap()["result"]
+				.clone()
+		};
+		assert_eq!(wire_result("noisy"), "skipped");
+		assert_eq!(wire_result("real"), "failed");
+	}
+
+	#[test]
+	fn apply_severities_absent_check_defaults_to_warn() {
+		// A check canopy hasn't heard of yet is capped at warn, so a computed
+		// failure is shown as a warning rather than promoted or left fatal.
+		let results = vec![fail("brand_new")];
+		let payload = build_payload(&Value::Object(Default::default()), &results);
+		let mut sweep = SweepResult {
+			server_id: None,
+			results,
+			overall: OverallResult::Failing,
+			payload,
+			pg_version: None,
+		};
+		sweep.apply_severities(&HashMap::new());
+		assert_eq!(sweep.results[0].0.status.wire_result(), "warning");
+		assert_eq!(sweep.overall, OverallResult::Degraded);
 	}
 
 	#[test]

--- a/crates/alertd/src/doctor/task.rs
+++ b/crates/alertd/src/doctor/task.rs
@@ -1,5 +1,6 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use bestool_canopy::schema::CheckSeverity;
 use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
 use jiff::Timestamp;
 use miette::{Result, miette};
@@ -7,7 +8,7 @@ use serde_json::{Value, json};
 use tokio::sync::{Mutex, mpsc};
 use tracing::warn;
 
-use crate::doctor::{self, progress::DoctorEvent};
+use crate::doctor::{self, check::Check, progress::DoctorEvent};
 use crate::tasks::TaskEndpointHandler;
 use crate::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
 
@@ -19,6 +20,22 @@ const DOCTOR_INTERVAL: Duration = Duration::from_secs(60);
 /// run the in-process backup driver. Fire-and-forget: the callback spawns its
 /// own work and guards against overlapping runs.
 pub type BackupDispatch = Arc<dyn Fn(Vec<String>) + Send + Sync>;
+
+/// Apply the effective-severity ceiling to a single streamed check, if a
+/// mapping is available (a no-op otherwise). Mirrors
+/// [`doctor::SweepResult::apply_severities`] for the one-check streaming case.
+fn cap_check(check: Check, severities: Option<&HashMap<String, CheckSeverity>>) -> Check {
+	match severities {
+		Some(map) => {
+			let ceiling = doctor::sweep::severity_ceiling(map, check.name);
+			Check {
+				status: check.status.cap_to(ceiling),
+				..check
+			}
+		}
+		None => check,
+	}
+}
 
 /// Periodic doctor sweep, plus on-demand `latest` / `recompute` HTTP endpoints.
 ///
@@ -42,6 +59,12 @@ struct DoctorTaskInner {
 	/// HTTP endpoint so `bestool tamanu doctor` can read what the daemon
 	/// already computed instead of re-running the checks itself.
 	latest: Mutex<Option<LatestSweep>>,
+	/// Effective-severity ceilings canopy last returned on a status push, keyed
+	/// by check name. `None` until the first successful push. Applied to the
+	/// sweeps this daemon serves locally (`latest` / `recompute`) so operators
+	/// see the same severities the CLI and canopy show; the payload posted to
+	/// canopy stays raw. See [`doctor::SweepResult::apply_severities`].
+	check_severities: Mutex<Option<HashMap<String, CheckSeverity>>>,
 	/// Runs the backup driver for the types canopy asks for via `backup_now`.
 	/// `None` when backups aren't compiled in.
 	backup_dispatch: Option<BackupDispatch>,
@@ -50,8 +73,9 @@ struct DoctorTaskInner {
 #[derive(Clone)]
 struct LatestSweep {
 	computed_at: Timestamp,
-	payload: Value,
-	server_id: Option<String>,
+	/// The raw sweep result, kept typed so the `latest` endpoint can apply the
+	/// current severity ceilings on read rather than baking them in at sweep time.
+	sweep: doctor::SweepResult,
 }
 
 impl DoctorTask {
@@ -62,6 +86,7 @@ impl DoctorTask {
 				tamanu,
 				pg_version_cache: Mutex::new(None),
 				latest: Mutex::new(None),
+				check_severities: Mutex::new(None),
 				backup_dispatch: None,
 			}),
 		}
@@ -107,12 +132,25 @@ impl DoctorTaskInner {
 
 		let latest = LatestSweep {
 			computed_at: Timestamp::now(),
-			payload: sweep.payload.clone(),
-			server_id: sweep.server_id.clone(),
+			sweep: sweep.clone(),
 		};
 		*self.latest.lock().await = Some(latest);
 
 		Ok(sweep)
+	}
+
+	/// Snapshot the severity ceilings canopy last returned, if any.
+	async fn severities_snapshot(&self) -> Option<HashMap<String, CheckSeverity>> {
+		self.check_severities.lock().await.clone()
+	}
+
+	/// Apply the current severity ceilings to a sweep, if we have any. A no-op
+	/// (leaving the raw sweep) until canopy has returned a mapping.
+	async fn capped(&self, mut sweep: doctor::SweepResult) -> doctor::SweepResult {
+		if let Some(severities) = self.severities_snapshot().await {
+			sweep.apply_severities(&severities);
+		}
+		sweep
 	}
 
 	async fn tick(self: &Arc<Self>, ctx: &TaskContext) -> Result<()> {
@@ -128,11 +166,17 @@ impl DoctorTaskInner {
 			return Ok(());
 		};
 
-		let backup_now = canopy
+		let response = canopy
 			.status(&server_id, &sweep.payload)
 			.await
-			.map_err(|err| miette!("posting doctor status to canopy: {err}"))?
-			.backup_now;
+			.map_err(|err| miette!("posting doctor status to canopy: {err}"))?;
+
+		// Cache the effective-severity ceilings for the sweeps we serve locally.
+		// The payload we just posted stays raw: canopy is the source of truth and
+		// maps severities itself.
+		*self.check_severities.lock().await = Some(response.check_severities);
+
+		let backup_now = response.backup_now;
 
 		if !backup_now.is_empty() {
 			match &self.backup_dispatch {
@@ -152,11 +196,14 @@ impl DoctorTaskInner {
 	async fn endpoint_latest(self: Arc<Self>) -> TaskEndpointResponse {
 		let snapshot = self.latest.lock().await.clone();
 		match snapshot {
-			Some(s) => TaskEndpointResponse::Json(json!({
-				"computedAt": s.computed_at.to_string(),
-				"serverId": s.server_id,
-				"payload": s.payload,
-			})),
+			Some(s) => {
+				let sweep = self.capped(s.sweep).await;
+				TaskEndpointResponse::Json(json!({
+					"computedAt": s.computed_at.to_string(),
+					"serverId": sweep.server_id,
+					"payload": sweep.payload,
+				}))
+			}
 			None => TaskEndpointResponse::Error {
 				status: 503,
 				message: "no doctor sweep cached yet (daemon may have just started)".into(),
@@ -170,12 +217,18 @@ impl DoctorTaskInner {
 		let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<DoctorEvent>();
 		let (out_tx, out_rx) = mpsc::unbounded_channel::<Value>();
 
+		// Snapshot the ceilings once so the streamed per-check events and the
+		// final payload are capped consistently, matching what `latest` serves.
+		let severities = self.severities_snapshot().await;
+
 		let task_self = self.clone();
 		tokio::spawn(async move {
 			let progress_forward_tx = out_tx.clone();
+			let stream_severities = severities.clone();
 			let forwarder = tokio::spawn(async move {
 				while let Some(event) = progress_rx.recv().await {
 					let DoctorEvent::Completed(check) = event;
+					let check = cap_check(check, stream_severities.as_ref());
 					let _ = progress_forward_tx.send(json!({
 						"event": "check",
 						"check": check.to_streaming_json(),
@@ -184,7 +237,10 @@ impl DoctorTaskInner {
 			});
 
 			match task_self.run_sweep(&ctx, Some(progress_tx)).await {
-				Ok(sweep) => {
+				Ok(mut sweep) => {
+					if let Some(severities) = &severities {
+						sweep.apply_severities(severities);
+					}
 					// Make sure all `Completed` events arrived before we emit
 					// `done` — perform_sweep drops the sender on return, which
 					// closes the forwarder loop above.
@@ -253,5 +309,39 @@ impl BackgroundTask for DoctorTask {
 				handler: recompute_handler,
 			},
 		]
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::doctor::check::CheckStatus;
+
+	#[test]
+	fn cap_check_applies_ceiling_when_present() {
+		let mut severities = HashMap::new();
+		severities.insert("disk_free".to_string(), CheckSeverity::Warn);
+		let check = Check::fail("disk_free", "1% free", "out of space");
+		let capped = cap_check(check, Some(&severities));
+		match capped.status {
+			CheckStatus::Warning(r) => assert_eq!(r, "out of space"),
+			other => panic!("expected Warning, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn cap_check_absent_check_defaults_to_warn() {
+		// No entry for this check: canopy's default ceiling is warn, so a fail
+		// streams as a warning.
+		let check = Check::fail("brand_new", "bad", "reason");
+		let capped = cap_check(check, Some(&HashMap::new()));
+		assert!(matches!(capped.status, CheckStatus::Warning(_)));
+	}
+
+	#[test]
+	fn cap_check_no_mapping_is_a_noop() {
+		let check = Check::fail("disk_free", "1% free", "out of space");
+		let capped = cap_check(check, None);
+		assert!(matches!(capped.status, CheckStatus::Fail(_)));
 	}
 }

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -1,5 +1,10 @@
-use std::io::{IsTerminal as _, Write};
+use std::{
+	collections::HashMap,
+	io::{IsTerminal as _, Write},
+	time::Duration,
+};
 
+use bestool_canopy::schema::CheckSeverity;
 use clap::Parser;
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use serde_json::Value;
@@ -147,6 +152,11 @@ async fn run_local_sweep(
 	let selected_names = selected_names(&args.only, &args.skip)?;
 	let (progress, tui_handle) = setup_progress(live_tty, &selected_names, SweepSource::Local);
 
+	// Fetch canopy's effective-severity ceilings concurrently with the checks.
+	// Soft-fail throughout (see `fetch_check_severities`): the mapping only ever
+	// lowers a verdict, so its absence just leaves the raw sweep.
+	let severities_handle = tokio::spawn(fetch_check_severities());
+
 	let sweep_args_only = args.only.clone();
 	let sweep_args_skip = args.skip.clone();
 	let sweep_handle = tokio::spawn(async move {
@@ -166,6 +176,7 @@ async fn run_local_sweep(
 		let outcome = handle.await.into_diagnostic()??;
 		if outcome.interrupted {
 			sweep_handle.abort();
+			severities_handle.abort();
 			let mut synthetic = synthetic_sweep(outcome.results);
 			synthetic.payload = serde_json::Value::Object(Default::default());
 			return Ok(SweepOutcome {
@@ -178,8 +189,49 @@ async fn run_local_sweep(
 		false
 	};
 
-	let sweep = sweep_handle.await.into_diagnostic()??;
+	let mut sweep = sweep_handle.await.into_diagnostic()??;
+	// Apply the mapping once it's back (the checks may well have finished first).
+	if let Some(severities) = severities_handle.await.ok().flatten() {
+		sweep.apply_severities(&severities);
+	}
 	Ok(SweepOutcome { sweep, interrupted })
+}
+
+/// Best-effort fetch of canopy's effective-severity ceilings for this server.
+///
+/// Every failure path — no registration, no auth path to canopy, no resolvable
+/// server id, a timeout, or any request/parse error — resolves to `None` ("no
+/// mapping") rather than an error, so a doctor run never fails or stalls on
+/// canopy being unreachable. Bounded by an overall timeout for the same reason.
+async fn fetch_check_severities() -> Option<HashMap<String, CheckSeverity>> {
+	tokio::time::timeout(Duration::from_secs(10), async {
+		let reg = bestool_canopy::registration::load().await.ok().flatten()?;
+		let device_key = reg.device_key.as_deref()?;
+		let base_url = reg
+			.api_url
+			.as_deref()
+			.unwrap_or(bestool_canopy::DEFAULT_CANOPY_URL)
+			.parse()
+			.ok()?;
+		let tailscale_url = bestool_canopy::TAILSCALE_URL.parse().ok()?;
+		let client = bestool_canopy::CanopyClient::with_urls(
+			base_url,
+			tailscale_url,
+			Some(device_key),
+			crate::http::client_builder,
+		)
+		.await
+		.ok()??;
+
+		let server_id = bestool_tamanu::server_info::get_or_create_server_id()
+			.await
+			.ok()?;
+		let value = client.status_check_severities(&server_id).await.ok()?;
+		serde_json::from_value(value).ok()
+	})
+	.await
+	.ok()
+	.flatten()
 }
 
 /// Drive a fresh sweep on the daemon and stream the per-check results back.

--- a/crates/bestool/src/canopy_contract.rs
+++ b/crates/bestool/src/canopy_contract.rs
@@ -16,8 +16,8 @@ use std::collections::BTreeMap;
 
 use bestool_canopy::schema::{
 	BackupCapabilitiesArgs, BackupCredentialsArgs, BackupPurpose, BackupTarget, BeginArgs,
-	BeginResponse, CompleteArgs, CompleteResponse, CredentialProcessOutput, NewEvent, ReportArgs,
-	RunOutcome, Severity,
+	BeginResponse, CheckSeverity, CompleteArgs, CompleteResponse, CredentialProcessOutput,
+	NewEvent, ReportArgs, RunOutcome, Severity,
 };
 use serde_json::{Value, json};
 use tokio::sync::OnceCell;
@@ -501,4 +501,74 @@ async fn status_response_carries_backup_now() {
 		Some(&json!("string")),
 		"backup_now items are no longer strings: {backup_now:#}",
 	);
+}
+
+#[tokio::test]
+#[ignore = "live canopy contract test; run by the dedicated CI job"]
+async fn status_response_carries_check_severities() {
+	// alertd caches `check_severities` off the status response to cap local
+	// verdicts; confirm canopy still serves it as a map of CheckSeverity.
+	let spec = spec().await;
+	let schema = resolve(spec, &response_schema("/status/{server_id}", "post"));
+	let check_severities = schema
+		.pointer("/properties/check_severities")
+		.or_else(|| {
+			schema
+				.get("allOf")?
+				.as_array()?
+				.iter()
+				.find_map(|member| member.pointer("/properties/check_severities"))
+		})
+		.unwrap_or_else(|| panic!("status response has no check_severities: {schema:#}"));
+	assert_eq!(
+		check_severities.pointer("/type"),
+		Some(&json!("object")),
+		"check_severities is no longer an object map: {check_severities:#}",
+	);
+}
+
+#[tokio::test]
+#[ignore = "live canopy contract test; run by the dedicated CI job"]
+async fn check_severities_endpoint_matches_spec() {
+	// The no-daemon doctor run fetches ceilings from this standalone endpoint.
+	let spec = spec().await;
+	assert_operation_exists(spec, "/status/{server_id}/check-severities", "get");
+
+	// Every value in the map is a CheckSeverity; confirm bestool's generated
+	// enum still round-trips the spec's vocabulary in both directions.
+	let spec_levels: Vec<String> = resolve(spec, "/components/schemas/CheckSeverity")
+		.get("enum")
+		.and_then(Value::as_array)
+		.expect("CheckSeverity schema has an enum")
+		.iter()
+		.map(|v| {
+			v.as_str()
+				.expect("CheckSeverity enum values are strings")
+				.to_owned()
+		})
+		.collect();
+
+	// Exhaustive match: adding a variant breaks this and forces the list update.
+	use CheckSeverity::*;
+	const ALL: &[CheckSeverity] = &[Skip, Warn, Fail];
+	for severity in ALL {
+		match severity {
+			Skip | Warn | Fail => {}
+		}
+	}
+
+	for level in &spec_levels {
+		assert!(
+			serde_json::from_value::<CheckSeverity>(json!(level)).is_ok(),
+			"canopy CheckSeverity {level:?} does not deserialise into bestool's enum",
+		);
+	}
+	for severity in ALL {
+		let ours = serde_json::to_value(severity).unwrap();
+		let ours = ours.as_str().unwrap().to_owned();
+		assert!(
+			spec_levels.contains(&ours),
+			"bestool CheckSeverity {ours:?} is not accepted by canopy (spec has {spec_levels:?})",
+		);
+	}
 }


### PR DESCRIPTION
🤖 Applies canopy's effective-severity mapping as a **ceiling** on healthcheck verdicts, so a local sweep shows the same severity an operator sees in canopy.

Canopy now exposes, per server, how a failure of each healthcheck is classified: `skip` (silenced), `warn`, or `fail`. It's served at `GET /status/{server_id}/check-severities` and also rides along every status-push response as `check_severities`. Checks absent from the map default to `warn` (canopy's own contract).

## Semantics

The mapping is a ceiling, never a floor — it only ever lowers a computed verdict:

- a passing check stays passing regardless of the ceiling;
- a warning is never promoted to a failure;
- a `warn` ceiling caps a computed Fail down to Warning;
- a `skip` ceiling silences a computed Warning/Fail (→ Skip), keeping its reason.

`Broken` is left untouched: it reports a fault in our own diagnostics (bad SQL, a missing column) rather than a severity finding about the system, so muting a check's result shouldn't hide it.

## Where it applies

- **Daemon**: caches `check_severities` from each status-push response and applies it to the sweeps it serves locally (`/tasks/doctor/latest` and the `recompute` stream). The payload posted to canopy stays raw — canopy is the source of truth and maps severities itself.
- **No-daemon run**: fetches the standalone endpoint concurrently with running the checks, then applies the mapping before final output. Soft-fails throughout (no registration, no auth path, no server id, a timeout, or any request/parse error all mean "no mapping"), bounded by an overall timeout, so a doctor run never fails or stalls on canopy being unreachable.

## Tests

- Unit coverage for the ceiling primitive, the absent-check default, the overall/wire rebuild, and the streaming path.
- Two live contract tests: the standalone endpoint exists and its `CheckSeverity` vocabulary round-trips, and the status response still carries `check_severities`.
