### PR TITLE
fix(alertd): make billing_tags check see canopy tags

### DIFF
--- a/crates/alertd/src/doctor/task.rs
+++ b/crates/alertd/src/doctor/task.rs
@@ -176,6 +176,14 @@ impl DoctorTaskInner {
 		// maps severities itself.
 		*self.check_severities.lock().await = Some(response.check_severities);
 
+		// Refresh the on-disk tags cache from the effective tags canopy echoes
+		// back. Checks that read tags (e.g. billing_tags) and offline `canopy
+		// tags` consult this cache; without this the daemon would never update it.
+		let tags = response.tags.0.into_iter().collect();
+		if let Err(err) = bestool_tamanu::server_info::save_cached_tags(&tags) {
+			warn!(%err, "could not refresh tags cache from status response");
+		}
+
 		let backup_now = response.backup_now;
 
 		if !backup_now.is_empty() {

--- a/crates/bestool/src/actions/canopy/tags.rs
+++ b/crates/bestool/src/actions/canopy/tags.rs
@@ -86,11 +86,7 @@ pub async fn run(args: TagsArgs, ctx: Context) -> Result<()> {
 	} else {
 		match fetch_online().await {
 			Ok(tags) => {
-				let cache = TagsCache {
-					tags: tags.clone(),
-					fetched_at: Some(jiff::Timestamp::now()),
-				};
-				if let Err(err) = save_cache(&cache_path, &cache) {
+				if let Err(err) = bestool_tamanu::server_info::save_cached_tags(&tags) {
 					warn!(%err, path = %cache_path.display(), "could not save tags cache");
 				}
 				let _ = config; // suppress unused; kept so we hold the load_config side effects
@@ -221,27 +217,6 @@ fn load_cache(path: &Path) -> Result<Option<TagsCache>> {
 	}
 }
 
-fn save_cache(path: &Path, cache: &TagsCache) -> Result<()> {
-	if let Some(parent) = path.parent()
-		&& !parent.exists()
-	{
-		std::fs::create_dir_all(parent)
-			.into_diagnostic()
-			.wrap_err_with(|| format!("creating tags cache dir {}", parent.display()))?;
-	}
-	let json = serde_json::to_vec_pretty(cache)
-		.into_diagnostic()
-		.wrap_err("serialising tags cache")?;
-	let tmp = path.with_extension("json.tmp");
-	std::fs::write(&tmp, &json)
-		.into_diagnostic()
-		.wrap_err_with(|| format!("writing tags cache tempfile at {}", tmp.display()))?;
-	std::fs::rename(&tmp, path)
-		.into_diagnostic()
-		.wrap_err_with(|| format!("renaming tags cache into place at {}", path.display()))?;
-	Ok(())
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -249,14 +224,11 @@ mod tests {
 	fn write_cache(path: &Path, tag: &str) {
 		let mut tags = BTreeMap::new();
 		tags.insert("role".to_owned(), tag.to_owned());
-		save_cache(
-			path,
-			&TagsCache {
-				tags,
-				fetched_at: None,
-			},
-		)
-		.unwrap();
+		let cache = TagsCache {
+			tags,
+			fetched_at: None,
+		};
+		std::fs::write(path, serde_json::to_vec(&cache).unwrap()).unwrap();
 	}
 
 	#[test]

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -58,17 +58,31 @@ pub fn standard_tags_path() -> PathBuf {
 	}
 }
 
-/// Load the cached canopy tags written by `bestool tamanu tags`.
+/// Load the cached canopy tags written by `bestool canopy tags`.
 ///
-/// Reads [`standard_tags_path`] and returns the `tags` map. The cache is a
+/// The cache lives alongside the canopy registration
+/// ([`bestool_canopy::registration::default_tags_path`]); [`standard_tags_path`]
+/// is consulted as a fallback for hosts that predate the move. Returns the
+/// `tags` map from the first path that yields one. The cache is a
 /// `{ "tags": { .. }, "fetched_at": .. }` object; only the `tags` field is read
 /// here, so the timestamp and any future fields are ignored. Returns `None`
-/// when the cache is absent or unparseable.
+/// when neither path holds a readable cache.
 ///
 /// Used by callers that need the tags without a canopy round-trip — e.g. the
 /// doctor reconciling `billing.*` tags against the instance's IMDS tags.
 pub fn load_cached_tags() -> Option<BTreeMap<String, String>> {
-	load_cached_tags_at(&standard_tags_path())
+	let paths: Vec<PathBuf> = [
+		#[cfg(feature = "canopy-registration")]
+		bestool_canopy::registration::default_tags_path(),
+		standard_tags_path(),
+	]
+	.into();
+	load_cached_tags_from(&paths)
+}
+
+/// Return the tags from the first path that yields a readable cache.
+fn load_cached_tags_from(paths: &[PathBuf]) -> Option<BTreeMap<String, String>> {
+	paths.iter().find_map(|path| load_cached_tags_at(path))
 }
 
 fn load_cached_tags_at(path: &Path) -> Option<BTreeMap<String, String>> {
@@ -491,6 +505,43 @@ mod tests {
 			Some("acme")
 		);
 		assert_eq!(tags.get("role").map(String::as_str), Some("central"));
+	}
+
+	#[test]
+	fn load_cached_tags_from_prefers_first_present_path() {
+		let dir = tempfile::tempdir().unwrap();
+		let primary = dir.path().join("primary.json");
+		let legacy = dir.path().join("legacy.json");
+		std::fs::write(&primary, r#"{"tags":{"billing.customer":"primary"}}"#).unwrap();
+		std::fs::write(&legacy, r#"{"tags":{"billing.customer":"legacy"}}"#).unwrap();
+
+		let tags = load_cached_tags_from(&[primary, legacy]).expect("should load");
+		assert_eq!(
+			tags.get("billing.customer").map(String::as_str),
+			Some("primary"),
+		);
+	}
+
+	#[test]
+	fn load_cached_tags_from_falls_back_when_first_absent() {
+		let dir = tempfile::tempdir().unwrap();
+		let primary = dir.path().join("missing.json");
+		let legacy = dir.path().join("legacy.json");
+		std::fs::write(&legacy, r#"{"tags":{"billing.customer":"legacy"}}"#).unwrap();
+
+		let tags = load_cached_tags_from(&[primary, legacy]).expect("should fall back");
+		assert_eq!(
+			tags.get("billing.customer").map(String::as_str),
+			Some("legacy"),
+		);
+	}
+
+	#[test]
+	fn load_cached_tags_from_none_when_all_absent() {
+		let dir = tempfile::tempdir().unwrap();
+		let a = dir.path().join("a.json");
+		let b = dir.path().join("b.json");
+		assert!(load_cached_tags_from(&[a, b]).is_none());
 	}
 
 	#[test]

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -111,6 +111,48 @@ fn load_cached_tags_at(path: &Path) -> Option<BTreeMap<String, String>> {
 	)
 }
 
+/// Persist canopy tags to the on-disk cache alongside the registration.
+///
+/// Writes the `{ "tags": .., "fetched_at": .. }` shape [`load_cached_tags`]
+/// reads, to [`bestool_canopy::registration::default_tags_path`], stamped with
+/// the current time and swapped into place atomically. The parent directory is
+/// created if absent.
+///
+/// Callers that have just obtained fresh tags from canopy use this to refresh
+/// the cache: `bestool canopy tags` on an online fetch, and the alertd doctor,
+/// whose status push echoes the server's effective tags back on every tick.
+#[cfg(feature = "canopy-registration")]
+pub fn save_cached_tags(tags: &BTreeMap<String, String>) -> Result<()> {
+	save_cached_tags_at(&bestool_canopy::registration::default_tags_path(), tags)
+}
+
+#[cfg(feature = "canopy-registration")]
+fn save_cached_tags_at(path: &Path, tags: &BTreeMap<String, String>) -> Result<()> {
+	if let Some(parent) = path.parent()
+		&& !parent.exists()
+	{
+		std::fs::create_dir_all(parent)
+			.into_diagnostic()
+			.wrap_err_with(|| format!("creating tags cache dir {}", parent.display()))?;
+	}
+
+	let payload = serde_json::json!({
+		"tags": tags,
+		"fetched_at": jiff::Timestamp::now(),
+	});
+	let json = serde_json::to_vec_pretty(&payload)
+		.into_diagnostic()
+		.wrap_err("serialising tags cache")?;
+
+	let tmp = path.with_extension("json.tmp");
+	std::fs::write(&tmp, &json)
+		.into_diagnostic()
+		.wrap_err_with(|| format!("writing tags cache tempfile at {}", tmp.display()))?;
+	std::fs::rename(&tmp, path)
+		.into_diagnostic()
+		.wrap_err_with(|| format!("renaming tags cache into place at {}", path.display()))
+}
+
 /// Resolve the `metaServerId` for this Tamanu server.
 ///
 /// Resolution order:
@@ -542,6 +584,20 @@ mod tests {
 		let a = dir.path().join("a.json");
 		let b = dir.path().join("b.json");
 		assert!(load_cached_tags_from(&[a, b]).is_none());
+	}
+
+	#[cfg(feature = "canopy-registration")]
+	#[test]
+	fn save_cached_tags_at_roundtrips_through_load() {
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("sub").join("tags.json");
+		let mut tags = BTreeMap::new();
+		tags.insert("billing.customer".to_owned(), "acme".to_owned());
+		tags.insert("canopy:kind".to_owned(), "central".to_owned());
+
+		save_cached_tags_at(&path, &tags).expect("should write (and create parent dir)");
+		let loaded = load_cached_tags_at(&path).expect("should read back");
+		assert_eq!(loaded, tags);
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 The `billing_tags` doctor check skipped with "no billing tags in canopy" on hosts that plainly carry `billing.*` tags. Two independent gaps:

**Reads the wrong path.** `bestool canopy tags` writes its cache alongside the canopy registration (`/etc/bestool/tags.json`), but `load_cached_tags()` read only the legacy `/etc/tamanu/tags.json`. On any host on the current path the doctor saw an empty cache. It now prefers the registration path and keeps the legacy path as a fallback.

**Never refreshed by alertd.** The cache was only ever written by a manual `bestool canopy tags` run; the daemon read it but never updated it, so the check ran against whatever was last left on disk (often nothing). Canopy's status-push response echoes the server's effective tags on every tick, so alertd now persists them to the cache after each push. The cache write is factored into `server_info::save_cached_tags`, and both alertd and `bestool canopy tags` go through it.

End to end: alertd refreshes the cache each tick from canopy's own effective tags, and `billing_tags` reads that same file — so it reconciles against IMDS instead of skipping.
