### PR TITLE
Make debs work on Debian 12

### DIFF
--- a/.github/workflows/release-algae.yml
+++ b/.github/workflows/release-algae.yml
@@ -28,14 +28,20 @@ jobs:
             os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
+          # Linux-gnu builds are zigbuilt against glibc 2.35 so the binaries
+          # and debs run on Debian 12 (glibc 2.36) as well as newer distros,
+          # matching the gnu35 convention of our third-party builds.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
+            zigtarget: x86_64-unknown-linux-gnu.2.35
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            zigtarget: aarch64-unknown-linux-gnu.2.35
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+            zigtarget: aarch64-unknown-linux-musl
           - target: x86_64-pc-windows-msvc
             os: windows-2022
 
@@ -80,9 +86,9 @@ jobs:
         with:
           tool: cargo-zigbuild,cargo-auditable
 
-      - if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: cargo zigbuild --profile dist --target ${{ matrix.target }} -p algae-cli
-      - if: matrix.target != 'aarch64-unknown-linux-musl'
+      - if: matrix.zigtarget
+        run: cargo auditable zigbuild --profile dist --target ${{ matrix.zigtarget }} -p algae-cli
+      - if: ${{ !matrix.zigtarget }}
         run: cargo auditable build --profile dist --target ${{ matrix.target }} -p algae-cli
 
       - uses: actions/attest-build-provenance@v4.1.0
@@ -128,6 +134,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
+          Depends: libc6 (>= 2.35)
           Maintainer: BES Developers <support@bes.au>
           Description: Lightweight age profile for user-friendly encryption
           Homepage: https://github.com/beyondessential/bestool

--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -28,14 +28,21 @@ jobs:
             os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
+          # Linux-gnu builds are zigbuilt against glibc 2.35 so the binaries
+          # and debs run on Debian 12 (glibc 2.36) as well as newer distros,
+          # matching the gnu35 convention of our third-party builds.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
+            zigtarget: x86_64-unknown-linux-gnu.2.35
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            zigtarget: aarch64-unknown-linux-gnu.2.35
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+            zigtarget: aarch64-unknown-linux-musl
+            features: iti
           - target: x86_64-pc-windows-msvc
             os: windows-2022
 
@@ -81,11 +88,9 @@ jobs:
         with:
           tool: cargo-zigbuild,cargo-auditable,rsign2
 
-      # zigbuild isn't compatible with auditable
-      # https://github.com/rust-secure-code/cargo-auditable/issues/179
-      - if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: cargo zigbuild --profile dist --target ${{ matrix.target }} -p bestool --features iti
-      - if: matrix.target != 'aarch64-unknown-linux-musl'
+      - if: matrix.zigtarget
+        run: cargo auditable zigbuild --profile dist --target ${{ matrix.zigtarget }} -p bestool ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+      - if: ${{ !matrix.zigtarget }}
         run: cargo auditable build --profile dist --target ${{ matrix.target }} -p bestool
 
       - uses: actions/attest-build-provenance@v4.1.0
@@ -177,7 +182,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
-          Depends: bindfs, btrfs-progs, kopia, sudo
+          Depends: bindfs, btrfs-progs, kopia, libc6 (>= 2.35), sudo
           Recommends: lvm2
           Maintainer: BES Developers <support@bes.au>
           Description: BES Deployment tooling

--- a/.github/workflows/release-psql.yml
+++ b/.github/workflows/release-psql.yml
@@ -28,14 +28,20 @@ jobs:
             os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
+          # Linux-gnu builds are zigbuilt against glibc 2.35 so the binaries
+          # and debs run on Debian 12 (glibc 2.36) as well as newer distros,
+          # matching the gnu35 convention of our third-party builds.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
+            zigtarget: x86_64-unknown-linux-gnu.2.35
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            zigtarget: aarch64-unknown-linux-gnu.2.35
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+            zigtarget: aarch64-unknown-linux-musl
           - target: x86_64-pc-windows-msvc
             os: windows-2022
 
@@ -79,11 +85,9 @@ jobs:
         with:
           tool: cargo-zigbuild,cargo-auditable
 
-      # zigbuild isn't compatible with auditable
-      # https://github.com/rust-secure-code/cargo-auditable/issues/179
-      - if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: cargo zigbuild --profile dist --target ${{ matrix.target }} -p bestool-psql
-      - if: matrix.target != 'aarch64-unknown-linux-musl'
+      - if: matrix.zigtarget
+        run: cargo auditable zigbuild --profile dist --target ${{ matrix.zigtarget }} -p bestool-psql
+      - if: ${{ !matrix.zigtarget }}
         run: cargo auditable build --profile dist --target ${{ matrix.target }} -p bestool-psql
 
       - name: Extract version
@@ -150,6 +154,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
+          Depends: libc6 (>= 2.35)
           Maintainer: BES Developers <support@bes.au>
           Description: psql-inspired client for PostgreSQL (BES Tooling)
           Homepage: https://github.com/beyondessential/bestool

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -204,7 +204,7 @@ pub async fn run_with_shutdown(
 			let _ = signal_tx_term.send(DaemonEvent::Shutdown).await;
 		});
 
-		// Reload on SIGHUP (systemd's notify-reload `ReloadSignal`) or SIGUSR1:
+		// Reload on SIGHUP (sent by the unit's ExecReload) or SIGUSR1:
 		// notify systemd we're reloading, bump the reload channel so tasks
 		// refresh, then notify ready again. The reload work itself is async and
 		// best-effort, so READY is sent once the refresh is dispatched.

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -3,13 +3,14 @@ Description=Tamanu alert daemon
 After=network.target
 
 [Service]
-# notify-reload: the daemon signals readiness (READY=1), status, and shutdown
-# (STOPPING=1) over $NOTIFY_SOCKET, and `systemctl reload` sends SIGHUP (the
-# default ReloadSignal) which the daemon answers with RELOADING=1 / READY=1 —
-# re-registering backup capabilities (picking up /etc/bestool/backups changes)
-# without a restart. Needs systemd >= 253; on older systemd use Type=notify plus
-# `ExecReload=/bin/kill -HUP $MAINPID`.
-Type=notify-reload
+# The daemon signals readiness (READY=1), status, and shutdown (STOPPING=1)
+# over $NOTIFY_SOCKET, and `systemctl reload` sends SIGHUP which the daemon
+# answers with RELOADING=1 / READY=1 — re-registering backup capabilities
+# (picking up /etc/bestool/backups changes) without a restart. Type=notify
+# with an explicit ExecReload rather than Type=notify-reload because deployed
+# hosts run systemd 252 (Debian 12), which doesn't parse notify-reload.
+Type=notify
+ExecReload=/bin/kill -HUP $MAINPID
 # Distinct journal identifier so rsyslog can filter alertd apart from other
 # bestool invocations (which all otherwise log as "bestool").
 SyslogIdentifier=bestool-alertd


### PR DESCRIPTION
🤖 The debs we ship don't work on Debian 12: the binaries are built on ubuntu-24.04 so they require glibc 2.38/2.39 (bookworm has 2.36), and the alertd unit uses `Type=notify-reload` which systemd 252 doesn't parse.

Rather than shipping a second deb (the apt repo is a single flat suite, so apt can't pick between same-name debs by host glibc), this follows the gnu35 convention from third-party-builds: build the linux-gnu targets with `cargo auditable zigbuild` against glibc 2.35, so the one deb works on bookworm and newer. The zigbuild/cargo-auditable incompatibility that previously forced the aarch64-musl special case was fixed in cargo-auditable 0.7.3, so all Linux zigbuilds keep auditable data now. The debs also declare `libc6 (>= 2.35)` so dpkg refuses cleanly on anything older.

The alertd unit switches to `Type=notify` with `ExecReload=/bin/kill -HUP $MAINPID`, which works on systemd 252 and newer; the daemon's readiness/reload notifications are unchanged and work identically under either type.

Verified locally: `cargo auditable zigbuild --profile dist --target x86_64-unknown-linux-gnu.2.35 -p bestool` with zig 0.16.0 (same as CI's `pip install ziglang`) produces a binary whose highest versioned glibc symbol is GLIBC_2.34, with the audit section present.

Same change applied to the bestool-psql and algae release workflows, which build and publish debs the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
