### PR TITLE
Ship Linux releases as static musl builds

### DIFF
--- a/.github/workflows/release-algae.yml
+++ b/.github/workflows/release-algae.yml
@@ -28,20 +28,14 @@ jobs:
             os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
-          # Linux-gnu builds are zigbuilt against glibc 2.35 so the binaries
-          # and debs run on Debian 12 (glibc 2.36) as well as newer distros,
-          # matching the gnu35 convention of our third-party builds.
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-24.04
-            zigtarget: x86_64-unknown-linux-gnu.2.35
+          # Linux releases are static musl binaries, so one build per arch
+          # runs on any distro and glibc era.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-            zigtarget: aarch64-unknown-linux-gnu.2.35
+            gnutarget: x86_64-unknown-linux-gnu
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
-            zigtarget: aarch64-unknown-linux-musl
+            gnutarget: aarch64-unknown-linux-gnu
           - target: x86_64-pc-windows-msvc
             os: windows-2022
 
@@ -71,8 +65,6 @@ jobs:
         run: |
           echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> "$GITHUB_ENV"
 
-      - if: runner.os == 'Linux'
-        run: pip install ziglang
       - if: contains(matrix.target, 'musl')
         run: sudo apt-get update && sudo apt-get install -y musl musl-dev musl-tools
 
@@ -84,12 +76,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.82.2
         with:
-          tool: cargo-zigbuild,cargo-auditable
+          tool: cargo-auditable
 
-      - if: matrix.zigtarget
-        run: cargo auditable zigbuild --profile dist --target ${{ matrix.zigtarget }} -p algae-cli
-      - if: ${{ !matrix.zigtarget }}
-        run: cargo auditable build --profile dist --target ${{ matrix.target }} -p algae-cli
+      - run: cargo auditable build --profile dist --target ${{ matrix.target }} -p algae-cli
 
       - uses: actions/attest-build-provenance@v4.1.0
         if: runner.os != 'Windows'
@@ -108,15 +97,15 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Package DEB
-        if: contains(matrix.target, 'linux-gnu')
+        if: contains(matrix.target, 'linux-musl')
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"
           target="${{ matrix.target }}"
           arch=""
-          if [[ "$target" == "x86_64-unknown-linux-gnu" ]]; then
+          if [[ "$target" == "x86_64-unknown-linux-musl" ]]; then
             arch="amd64"
-          elif [[ "$target" == "aarch64-unknown-linux-gnu" ]]; then
+          elif [[ "$target" == "aarch64-unknown-linux-musl" ]]; then
             arch="arm64"
           fi
 
@@ -134,7 +123,6 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
-          Depends: libc6 (>= 2.35)
           Maintainer: BES Developers <support@bes.au>
           Description: Lightweight age profile for user-friendly encryption
           Homepage: https://github.com/beyondessential/bestool
@@ -172,6 +160,12 @@ jobs:
             aws s3 cp "$src" "$dest" --no-progress
           fi
 
+          # Also publish under the gnu target path so consumers of the old
+          # gnu builds keep working while they move to the musl paths.
+          if [[ -n "${{ matrix.gnutarget }}" ]]; then
+            aws s3 cp "$src" "s3://bes-ops-tools/algae/${version}/${{ matrix.gnutarget }}/" --no-progress
+          fi
+
           for deb in algae-*.deb; do
             [[ -f "$deb" ]] || continue
             aws s3 cp "$deb" "s3://bes-ops-tools/algae/${version}/" --no-progress
@@ -190,10 +184,14 @@ jobs:
             aws s3 cp "$src" "$dest" --no-progress
           fi
 
+          if [[ -n "${{ matrix.gnutarget }}" ]]; then
+            aws s3 cp "$src" "s3://bes-ops-tools/algae/latest/${{ matrix.gnutarget }}/" --no-progress
+          fi
+
           aws cloudfront create-invalidation --distribution-id=EDAG0UBS1MN74 --paths '/algae/latest/*'
 
       - name: Upload version file
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"

--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -28,21 +28,18 @@ jobs:
             os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
-          # Linux-gnu builds are zigbuilt against glibc 2.35 so the binaries
-          # and debs run on Debian 12 (glibc 2.36) as well as newer distros,
-          # matching the gnu35 convention of our third-party builds.
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-24.04
-            zigtarget: x86_64-unknown-linux-gnu.2.35
+          # Linux releases are static musl binaries with the iti features
+          # included, so one build per arch runs on any distro and glibc era.
+          # gnutarget: the linux-gnu target path the artifacts are also
+          # uploaded under, so consumers of the old gnu builds (deployed
+          # binaries self-updating, pinned URLs) keep working while the fleet
+          # rolls over to musl; remove once that's done.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-            zigtarget: aarch64-unknown-linux-gnu.2.35
+            gnutarget: x86_64-unknown-linux-gnu
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
-            zigtarget: aarch64-unknown-linux-musl
-            features: iti
+            gnutarget: aarch64-unknown-linux-gnu
           - target: x86_64-pc-windows-msvc
             os: windows-2022
 
@@ -73,8 +70,6 @@ jobs:
         run: |
           echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> "$GITHUB_ENV"
 
-      - if: runner.os == 'Linux'
-        run: pip install ziglang
       - if: contains(matrix.target, 'musl')
         run: sudo apt-get update && sudo apt-get install -y musl musl-dev musl-tools
 
@@ -86,11 +81,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.82.2
         with:
-          tool: cargo-zigbuild,cargo-auditable,rsign2
+          tool: cargo-auditable,rsign2
 
-      - if: matrix.zigtarget
-        run: cargo auditable zigbuild --profile dist --target ${{ matrix.zigtarget }} -p bestool ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
-      - if: ${{ !matrix.zigtarget }}
+      - if: runner.os == 'Linux'
+        run: cargo auditable build --profile dist --target ${{ matrix.target }} -p bestool --features iti
+      - if: runner.os != 'Linux'
         run: cargo auditable build --profile dist --target ${{ matrix.target }} -p bestool
 
       - uses: actions/attest-build-provenance@v4.1.0
@@ -110,15 +105,15 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Package DEB
-        if: contains(matrix.target, 'linux-gnu')
+        if: contains(matrix.target, 'linux-musl')
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"
           target="${{ matrix.target }}"
           arch=""
-          if [[ "$target" == "x86_64-unknown-linux-gnu" ]]; then
+          if [[ "$target" == "x86_64-unknown-linux-musl" ]]; then
             arch="amd64"
-          elif [[ "$target" == "aarch64-unknown-linux-gnu" ]]; then
+          elif [[ "$target" == "aarch64-unknown-linux-musl" ]]; then
             arch="arm64"
           fi
 
@@ -182,7 +177,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
-          Depends: bindfs, btrfs-progs, kopia, libc6 (>= 2.35), sudo
+          Depends: bindfs, btrfs-progs, kopia, sudo
           Recommends: lvm2
           Maintainer: BES Developers <support@bes.au>
           Description: BES Deployment tooling
@@ -291,6 +286,13 @@ jobs:
           aws s3 cp "$src.tar.zst" "$dest" --no-progress
           aws s3 cp "$src.tar.zst.minisig" "$dest" --no-progress
 
+          if [[ -n "${{ matrix.gnutarget }}" ]]; then
+            gnudest="s3://bes-ops-tools/bestool/${version}/${{ matrix.gnutarget }}/"
+            aws s3 cp "$src" "$gnudest" --no-progress
+            aws s3 cp "$src.tar.zst" "$gnudest" --no-progress
+            aws s3 cp "$src.tar.zst.minisig" "$gnudest" --no-progress
+          fi
+
           for deb in bestool-*.deb; do
             [[ -f "$deb" ]] || continue
             aws s3 cp "$deb" "s3://bes-ops-tools/bestool/${version}/" --no-progress
@@ -310,6 +312,13 @@ jobs:
           aws s3 cp "$src.tar.zst" "$dest" --no-progress
           aws s3 cp "$src.tar.zst.minisig" "$dest" --no-progress
 
+          if [[ -n "${{ matrix.gnutarget }}" ]]; then
+            gnudest="s3://bes-ops-tools/bestool/latest/${{ matrix.gnutarget }}/"
+            aws s3 cp "$src" "$gnudest" --no-progress
+            aws s3 cp "$src.tar.zst" "$gnudest" --no-progress
+            aws s3 cp "$src.tar.zst.minisig" "$gnudest" --no-progress
+          fi
+
           aws cloudfront create-invalidation --distribution-id=EDAG0UBS1MN74 --paths '/bestool/latest/*'
 
       - name: Upload version file
@@ -328,7 +337,7 @@ jobs:
         run: |
           src="target/${{ matrix.target }}/dist/bestool"
           dest="s3://bes-ops-tools/bestool/gha"
-          if [[ ${{ matrix.target }} == "x86_64-unknown-linux-gnu" ]]; then
+          if [[ ${{ matrix.target }} == "x86_64-unknown-linux-musl" ]]; then
             dest="$dest/Linux-X64"
           elif [[ ${{ matrix.target }} == "x86_64-apple-darwin" ]]; then
             dest="$dest/macOS-X64"

--- a/.github/workflows/release-psql.yml
+++ b/.github/workflows/release-psql.yml
@@ -28,20 +28,12 @@ jobs:
             os: macos-15
           - target: aarch64-apple-darwin
             os: macos-15
-          # Linux-gnu builds are zigbuilt against glibc 2.35 so the binaries
-          # and debs run on Debian 12 (glibc 2.36) as well as newer distros,
-          # matching the gnu35 convention of our third-party builds.
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-24.04
-            zigtarget: x86_64-unknown-linux-gnu.2.35
+          # Linux releases are static musl binaries, so one build per arch
+          # runs on any distro and glibc era.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-            zigtarget: aarch64-unknown-linux-gnu.2.35
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
-            zigtarget: aarch64-unknown-linux-musl
           - target: x86_64-pc-windows-msvc
             os: windows-2022
 
@@ -70,8 +62,6 @@ jobs:
         run: |
           echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> "$GITHUB_ENV"
 
-      - if: runner.os == 'Linux'
-        run: pip install ziglang
       - if: contains(matrix.target, 'musl')
         run: sudo apt-get update && sudo apt-get install -y musl musl-dev musl-tools
 
@@ -83,12 +73,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2.82.2
         with:
-          tool: cargo-zigbuild,cargo-auditable
+          tool: cargo-auditable
 
-      - if: matrix.zigtarget
-        run: cargo auditable zigbuild --profile dist --target ${{ matrix.zigtarget }} -p bestool-psql
-      - if: ${{ !matrix.zigtarget }}
-        run: cargo auditable build --profile dist --target ${{ matrix.target }} -p bestool-psql
+      - run: cargo auditable build --profile dist --target ${{ matrix.target }} -p bestool-psql
 
       - name: Extract version
         id: version
@@ -126,15 +113,15 @@ jobs:
           subject-path: ${{ steps.package.outputs.asset }}
 
       - name: Package DEB
-        if: contains(matrix.target, 'linux-gnu')
+        if: contains(matrix.target, 'linux-musl')
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"
           target="${{ matrix.target }}"
           arch=""
-          if [[ "$target" == "x86_64-unknown-linux-gnu" ]]; then
+          if [[ "$target" == "x86_64-unknown-linux-musl" ]]; then
             arch="amd64"
-          elif [[ "$target" == "aarch64-unknown-linux-gnu" ]]; then
+          elif [[ "$target" == "aarch64-unknown-linux-musl" ]]; then
             arch="arm64"
           fi
 
@@ -154,7 +141,6 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: $arch
-          Depends: libc6 (>= 2.35)
           Maintainer: BES Developers <support@bes.au>
           Description: psql-inspired client for PostgreSQL (BES Tooling)
           Homepage: https://github.com/beyondessential/bestool
@@ -164,7 +150,7 @@ jobs:
           dpkg-deb --build --root-owner-group "$deb_dir" "bestool-psql-${target}-${version}.deb"
 
       - uses: actions/attest-build-provenance@v4.1.0
-        if: contains(matrix.target, 'linux-gnu')
+        if: contains(matrix.target, 'linux-musl')
         with:
           subject-path: "bestool-psql-${{ matrix.target }}-${{ steps.version.outputs.version }}.deb"
 
@@ -178,7 +164,7 @@ jobs:
           retention-days: 7
 
       - name: Configure AWS Credentials
-        if: contains(matrix.target, 'linux-gnu')
+        if: contains(matrix.target, 'linux-musl')
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
           aws-region: ap-southeast-2
@@ -186,7 +172,7 @@ jobs:
           role-session-name: GHA@BEStool-psql=Build
 
       - name: Upload DEB to S3
-        if: contains(matrix.target, 'linux-gnu')
+        if: contains(matrix.target, 'linux-musl')
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"
@@ -196,7 +182,7 @@ jobs:
           aws s3 cp "$deb" "s3://bes-ops-tools/bestool-psql/latest/bestool-psql-${target}.deb" --no-progress
 
       - name: Upload version file
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"
@@ -204,7 +190,7 @@ jobs:
           aws s3 cp latest-version.txt s3://bes-ops-tools/bestool-psql/latest-version.txt --no-progress
 
       - name: Invalidate CloudFront
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         shell: bash
         run: |
           version="${{ steps.version.outputs.version }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,7 +585,6 @@ dependencies = [
  "clap_complete",
  "comfy-table",
  "crossterm",
- "ctrlc",
  "detect-targets",
  "dirs",
  "duct",
@@ -628,8 +640,8 @@ dependencies = [
  "windows-env",
  "windows-service",
  "windows_exe_info",
+ "zeromq",
  "zip 8.6.0",
- "zmq",
 ]
 
 [[package]]
@@ -950,7 +962,7 @@ dependencies = [
  "serde",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "target-lexicon 0.13.5",
+ "target-lexicon",
  "url",
  "zeroize",
 ]
@@ -1246,16 +1258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
- "target-lexicon 0.12.16",
 ]
 
 [[package]]
@@ -1659,19 +1661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,17 +2050,6 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
-]
-
-[[package]]
-name = "dircpy"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
-dependencies = [
- "jwalk",
- "log",
- "walkdir",
 ]
 
 [[package]]
@@ -3816,16 +3794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5318,7 +5286,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6238,6 +6206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,6 +6227,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "3.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7800bc2c7e91b26aeae70c2ab6eaa653efc133104b7756e674c99304adff3fdb"
+dependencies = [
+ "saa",
+ "sdd",
 ]
 
 [[package]]
@@ -6318,6 +6302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sdd"
+version = "4.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1836bad8bdc9c6d665b63202da3d9c6d60ed1e597cae63620e21ebf89a3595a9"
+dependencies = [
+ "saa",
 ]
 
 [[package]]
@@ -6476,15 +6469,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7024,19 +7008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml 0.8.23",
- "version-compare",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7047,12 +7018,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"
@@ -7408,38 +7373,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7453,27 +7397,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
@@ -7671,7 +7602,7 @@ dependencies = [
  "serde",
  "shlex 1.3.0",
  "snapbox",
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -8124,12 +8055,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-compare"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -8977,15 +8902,6 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -9243,13 +9159,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeromq-src"
-version = "0.2.6+4.3.4"
+name = "zeromq"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc120b771270365d5ed0dfb4baf1005f2243ae1ae83703265cb3504070f4160b"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
 dependencies = [
- "cc",
- "dircpy",
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "regex",
+ "scc",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
 ]
 
 [[package]]
@@ -9324,28 +9254,6 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zmq"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3091dd571fb84a9b3e5e5c6a807d186c411c812c8618786c3c30e5349234e7"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "zmq-sys",
-]
-
-[[package]]
-name = "zmq-sys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8351dc72494b4d7f5652a681c33634063bbad58046c1689e75270908fdc864"
-dependencies = [
- "libc",
- "system-deps",
- "zeromq-src",
-]
 
 [[package]]
 name = "zopfli"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ See `bestool <subcommand> --help` for extensive help.
 | Platform | Variant | Download |
 | -------- | ------- | -------- |
 | Windows | x86 | [bestool.exe](https://tools.ops.tamanu.io/bestool/latest/x86_64-pc-windows-msvc/bestool.exe) |
-| Linux | x86 | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-gnu/bestool) |
-| Linux | x86 static | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-musl/bestool) |
+| Linux | x86 | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-unknown-linux-musl/bestool) |
 | Linux | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/latest/aarch64-unknown-linux-musl/bestool) |
 | Mac | Intel | [bestool](https://tools.ops.tamanu.io/bestool/latest/x86_64-apple-darwin/bestool) |
 | Mac | ARM64 | [bestool](https://tools.ops.tamanu.io/bestool/latest/aarch64-apple-darwin/bestool) |

--- a/crates/bestool/Cargo.toml
+++ b/crates/bestool/Cargo.toml
@@ -35,7 +35,6 @@ clap_complete = { version = "4.6.3", optional = true }
 clap-markdown = "0.1.5"
 comfy-table = { version = "7.2.0", optional = true }
 crossterm = { version = "0.29.0", optional = true }
-ctrlc = { version = "3.5.0", optional = true }
 detect-targets = { version = "0.1.84", optional = true }
 dirs = { version = "6.0.0", optional = true }
 duct = { version = "1.1.0", optional = true }
@@ -83,8 +82,8 @@ toml = { version = "1", optional = true }
 tracing = { workspace = true }
 uuid = { version = "1.23.2", features = ["v4"] }
 walkdir = { version = "2.5.0", optional = true }
+zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "tcp-transport"], optional = true }
 zip = { version = "8.6.0", optional = true, default-features = false, features = ["time"] }
-zmq = { version = "0.10.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 tauri-winrt-notification = { version = "0.7.2", optional = true }
@@ -206,9 +205,9 @@ iti = [ # enable all iti subcommands
 ]
 iti-battery = ["__iti", "dep:rppal"]
 iti-improv-wifi = ["__iti", "dep:improv-wifi", "dep:rppal"]
-iti-lcd = ["__iti", "dep:ctrlc", "dep:embedded-graphics", "dep:rpi-st7789v2-driver"]
+iti-lcd = ["__iti", "dep:embedded-graphics", "dep:rpi-st7789v2-driver"]
 iti-temperature = ["__iti", "dep:duct"]
-__iti = ["dep:zmq"] # internal feature to enable the iti subcommand common code
+__iti = ["dep:zeromq"] # internal feature to enable the iti subcommand common code
 
 ## Legacy noop features to avoid breaking builds
 tamanu-upgrade = []

--- a/crates/bestool/USAGE.md
+++ b/crates/bestool/USAGE.md
@@ -1064,7 +1064,7 @@ This is useful for debugging or testing the display server, or for interacting w
 
 The message can be provided either as the first argument, or over stdin.
 
-The message will be validated by the client to avoid sending malformed messages to the server. The command will block until the message can be sent to the display server, then wait for a reply and print it if non-empty.
+The message will be validated by the client to avoid sending malformed messages to the server. The command sends the message to the display server, then waits for a reply and prints it if non-empty.
 
 **Usage:** `bestool iti lcd send [MESSAGE]`
 
@@ -1078,7 +1078,7 @@ The message will be validated by the client to avoid sending malformed messages 
 
 Set all pixels to a single color.
 
-The command will block until the message can be sent to the display server, then wait for a reply and print it if non-empty.
+The command sends the message to the display server, then waits for a reply and prints it if non-empty.
 
 **Usage:** `bestool iti lcd clear [RED] [GREEN] [BLUE]`
 
@@ -1104,7 +1104,7 @@ This wakes the display, turns on the backlight, and shows the current screen con
 
 The LCD must then rest for 120ms before any further commands can be sent.
 
-The command will block until the message can be sent to the display server, then wait for a reply and print it if non-empty.
+The command sends the message to the display server, then waits for a reply and prints it if non-empty.
 
 **Usage:** `bestool iti lcd on`
 
@@ -1118,7 +1118,7 @@ This turns off the backlight and puts the display to sleep, which uses less powe
 
 The LCD must then rest for 5ms before any further commands can be sent.
 
-The command will block until the message can be sent to the display server, then wait for a reply and print it if non-empty.
+The command sends the message to the display server, then waits for a reply and prints it if non-empty.
 
 **Usage:** `bestool iti lcd off`
 

--- a/crates/bestool/src/actions/iti/battery.rs
+++ b/crates/bestool/src/actions/iti/battery.rs
@@ -304,7 +304,7 @@ pub async fn once(args: &BatteryArgs, rolling: Option<&mut VecDeque<f64>>) -> Re
 			},
 		);
 
-		send(&args.zmq_socket, Screen::Layout(items))?;
+		send(&args.zmq_socket, Screen::Layout(items)).await?;
 	}
 
 	Ok(capacity)

--- a/crates/bestool/src/actions/iti/lcd.rs
+++ b/crates/bestool/src/actions/iti/lcd.rs
@@ -1,17 +1,11 @@
-use std::{
-	io::Read,
-	ops::ControlFlow,
-	sync::{
-		atomic::{AtomicBool, Ordering},
-		Arc,
-	},
-};
+use std::io::Read;
 
 use clap::{Parser, Subcommand};
 use embedded_graphics::Drawable;
 use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use rpi_st7789v2_driver::{DriverArgs, Driver};
 use tracing::{error, info, instrument, trace};
+use zeromq::{Socket as _, SocketRecv as _, SocketSend as _, ZmqMessage};
 
 use crate::actions::Context;
 
@@ -94,8 +88,8 @@ pub enum LcdAction {
 	/// The message can be provided either as the first argument, or over stdin.
 	///
 	/// The message will be validated by the client to avoid sending malformed messages to the
-	/// server. The command will block until the message can be sent to the display server, then
-	/// wait for a reply and print it if non-empty.
+	/// server. The command sends the message to the display server, then waits for a reply and
+	/// prints it if non-empty.
 	Send {
 		/// JSON message to send.
 		message: Option<String>,
@@ -103,8 +97,8 @@ pub enum LcdAction {
 
 	/// Set all pixels to a single color.
 	///
-	/// The command will block until the message can be sent to the display server, then wait for a
-	/// reply and print it if non-empty.
+	/// The command sends the message to the display server, then waits for a reply and prints it
+	/// if non-empty.
 	Clear {
 		/// Red value for the background color.
 		#[arg(default_value = "0")]
@@ -125,8 +119,8 @@ pub enum LcdAction {
 	///
 	/// The LCD must then rest for 120ms before any further commands can be sent.
 	///
-	/// The command will block until the message can be sent to the display server, then wait for a
-	/// reply and print it if non-empty.
+	/// The command sends the message to the display server, then waits for a reply and prints it
+	/// if non-empty.
 	On,
 
 	/// Turn the display off.
@@ -135,15 +129,15 @@ pub enum LcdAction {
 	///
 	/// The LCD must then rest for 5ms before any further commands can be sent.
 	///
-	/// The command will block until the message can be sent to the display server, then wait for a
-	/// reply and print it if non-empty.
+	/// The command sends the message to the display server, then waits for a reply and prints it
+	/// if non-empty.
 	Off,
 }
 
 pub async fn run(args: LcdArgs, _ctx: Context) -> Result<()> {
 	use LcdAction::*;
 	match args.action.clone() {
-		Serve => serve(args),
+		Serve => serve(args).await,
 		Send { message } => {
 			let screen = serde_json::from_str(&message.unwrap_or_else(|| {
 				let mut buf = String::new();
@@ -152,36 +146,22 @@ pub async fn run(args: LcdArgs, _ctx: Context) -> Result<()> {
 			}))
 			.into_diagnostic()
 			.wrap_err("json: from_str")?;
-			send(&args.zmq_socket, screen)
+			send(&args.zmq_socket, screen).await
 		}
-		Clear { red, green, blue } => send(&args.zmq_socket, json::Screen::Clear([red, green, blue])),
-		On => send(&args.zmq_socket, json::Screen::Light(true)),
-		Off => send(&args.zmq_socket, json::Screen::Light(false)),
+		Clear { red, green, blue } => {
+			send(&args.zmq_socket, json::Screen::Clear([red, green, blue])).await
+		}
+		On => send(&args.zmq_socket, json::Screen::Light(true)).await,
+		Off => send(&args.zmq_socket, json::Screen::Light(false)).await,
 	}
 }
 
 #[instrument(level = "debug", skip(args))]
-pub fn serve(args: LcdArgs) -> Result<()> {
-	let running = Arc::new(AtomicBool::new(true));
-	let r = running.clone();
-
-	ctrlc::set_handler(move || {
-		r.store(false, Ordering::SeqCst);
-	})
-	.into_diagnostic()
-	.wrap_err("ctrlc: set_handler")?;
-
-	let z = zmq::Context::new();
-	let socket = z
-		.socket(zmq::REP)
-		.into_diagnostic()
-		.wrap_err("zmq: socket(REP)")?;
-	socket
-		.set_ipv6(true)
-		.into_diagnostic()
-		.wrap_err("zmq: set_ipv6")?;
+pub async fn serve(args: LcdArgs) -> Result<()> {
+	let mut socket = zeromq::RepSocket::new();
 	socket
 		.bind(&args.zmq_socket)
+		.await
 		.into_diagnostic()
 		.wrap_err(format!("zmq: bind({})", args.zmq_socket))?;
 	info!(
@@ -194,14 +174,28 @@ pub fn serve(args: LcdArgs) -> Result<()> {
 	lcd.probe_buffer_length()?;
 
 	loop {
-		match loop_inner(running.clone(), &socket, &mut lcd) {
-			Ok(ControlFlow::Continue(_)) => continue,
-			Ok(ControlFlow::Break(_)) => break,
-			Err(err) => {
-				let err = format!("{err:?}");
-				error!("{err}");
-				socket.send(&err, 0).ok();
-				continue;
+		tokio::select! {
+			_ = tokio::signal::ctrl_c() => {
+				info!("ctrl-c received, exiting");
+				break;
+			}
+			request = socket.recv() => {
+				let request = request.into_diagnostic().wrap_err("zmq: recv")?;
+				// REP sockets must reply to every request: answer errors with
+				// their text and successes with an empty message.
+				let reply = match handle(request, &mut lcd) {
+					Ok(()) => ZmqMessage::from(""),
+					Err(err) => {
+						let err = format!("{err:?}");
+						error!("{err}");
+						ZmqMessage::from(err)
+					}
+				};
+				socket
+					.send(reply)
+					.await
+					.into_diagnostic()
+					.wrap_err("zmq: send")?;
 			}
 		}
 	}
@@ -209,31 +203,11 @@ pub fn serve(args: LcdArgs) -> Result<()> {
 	Ok(())
 }
 
-#[instrument(level = "trace", skip(socket, lcd))]
-fn loop_inner(
-	running: Arc<AtomicBool>,
-	socket: &zmq::Socket,
-	lcd: &mut Driver,
-) -> Result<ControlFlow<()>> {
-	let mut polls = [socket.as_poll_item(zmq::POLLIN)];
-	let polled = zmq::poll(&mut polls, 1000)
-		.into_diagnostic()
-		.wrap_err("zmq: poll")?;
-	if !running.load(Ordering::SeqCst) {
-		info!("ctrl-c received, exiting");
-		return Ok(ControlFlow::Break(()));
-	}
-	if polled == 0 || !polls[0].is_readable() {
-		trace!("zmq: no messages (poll timed out)");
-		return Ok(ControlFlow::Continue(()));
-	}
+#[instrument(level = "trace", skip(request, lcd))]
+fn handle(request: ZmqMessage, lcd: &mut Driver) -> Result<()> {
+	let bytes = request.get(0).ok_or_else(|| miette!("zmq: empty message"))?;
 
-	let bytes = socket
-		.recv_bytes(0)
-		.into_diagnostic()
-		.wrap_err("zmq: recv")?;
-
-	let screen: json::Screen = serde_json::from_slice(&bytes)
+	let screen: json::Screen = serde_json::from_slice(bytes)
 		.into_diagnostic()
 		.wrap_err("json: parse")?;
 
@@ -259,27 +233,15 @@ fn loop_inner(
 		}
 	}
 
-	socket
-		.send(zmq::Message::new(), 0)
-		.into_diagnostic()
-		.wrap_err("zmq: send")?;
-
-	Ok(ControlFlow::Continue(()))
+	Ok(())
 }
 
 #[instrument(level = "debug")]
-pub fn send(addr: &str, screen: json::Screen) -> Result<()> {
-	let z = zmq::Context::new();
-	let socket = z
-		.socket(zmq::REQ)
-		.into_diagnostic()
-		.wrap_err("zmq: socket(REQ)")?;
-	socket
-		.set_ipv6(true)
-		.into_diagnostic()
-		.wrap_err("zmq: set_ipv6")?;
+pub async fn send(addr: &str, screen: json::Screen) -> Result<()> {
+	let mut socket = zeromq::ReqSocket::new();
 	socket
 		.connect(addr)
+		.await
 		.into_diagnostic()
 		.wrap_err(format!("zmq: connect({})", addr))?;
 
@@ -287,19 +249,41 @@ pub fn send(addr: &str, screen: json::Screen) -> Result<()> {
 		.into_diagnostic()
 		.wrap_err("json: to_vec")?;
 	socket
-		.send(&bytes, 0)
+		.send(bytes.into())
+		.await
 		.into_diagnostic()
 		.wrap_err("zmq: send")?;
 
-	let reply = socket
-		.recv_string(0)
-		.into_diagnostic()
-		.wrap_err("zmq: recv")?
-		.map_err(|bytes| miette!("reply is not valid utf-8, received {} bytes", bytes.len()))
-		.wrap_err("zmq: recv_string")?;
+	let reply = socket.recv().await.into_diagnostic().wrap_err("zmq: recv")?;
+	let reply: String = reply
+		.try_into()
+		.map_err(|err| miette!("zmq: reply is not valid utf-8: {err}"))?;
 	if !reply.is_empty() {
 		println!("{reply}");
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn send_roundtrip() {
+		let mut server = zeromq::RepSocket::new();
+		let endpoint = server.bind("tcp://127.0.0.1:0").await.unwrap();
+
+		let server_task = tokio::spawn(async move {
+			let request = server.recv().await.unwrap();
+			let screen: json::Screen = serde_json::from_slice(request.get(0).unwrap()).unwrap();
+			assert!(matches!(screen, json::Screen::Light(true)));
+			server.send(ZmqMessage::from("")).await.unwrap();
+		});
+
+		send(&endpoint.to_string(), json::Screen::Light(true))
+			.await
+			.unwrap();
+		server_task.await.unwrap();
+	}
 }

--- a/crates/bestool/src/actions/iti/sparks.rs
+++ b/crates/bestool/src/actions/iti/sparks.rs
@@ -76,11 +76,12 @@ pub async fn run(args: SparksArgs, _ctx: Context) -> Result<()> {
 			&args,
 			cpu.iter().rev().copied(),
 			mem.iter().rev().copied(),
-		)?;
+		)
+		.await?;
 	}
 }
 
-pub fn render(
+pub async fn render(
 	args: &SparksArgs,
 	cpu: impl ExactSizeIterator<Item = f32>,
 	mem: impl ExactSizeIterator<Item = f32>,
@@ -144,7 +145,7 @@ pub fn render(
 		FG_MEM,
 	));
 
-	send(zmq_socket, Screen::Layout(items))?;
+	send(zmq_socket, Screen::Layout(items)).await?;
 
 	Ok(())
 }

--- a/crates/bestool/src/actions/iti/temperature.rs
+++ b/crates/bestool/src/actions/iti/temperature.rs
@@ -101,7 +101,8 @@ pub async fn once(args: &TemperatureArgs) -> Result<()> {
 					..Default::default()
 				},
 			]),
-		)?;
+		)
+		.await?;
 	}
 
 	Ok(())

--- a/crates/bestool/src/actions/self_update.rs
+++ b/crates/bestool/src/actions/self_update.rs
@@ -197,11 +197,10 @@ pub(crate) async fn perform_update(
 	let client = client().await?;
 
 	let detected_targets = get_desired_targets(target.map(|t| vec![t]));
-	let detected_targets = detected_targets.get().await;
-	let target = detected_targets
-		.first()
-		.cloned()
-		.unwrap_or_else(|| TARGET.into());
+	let mut candidates = detected_targets.get().await.to_vec();
+	if candidates.is_empty() {
+		candidates.push(TARGET.into());
+	}
 
 	let dir = temp_dir.unwrap_or_else(std::env::temp_dir);
 	let filename = format!(
@@ -211,12 +210,32 @@ pub(crate) async fn perform_update(
 	let dest = dir.join(&filename);
 	let _ = tokio::fs::remove_file(&dest).await;
 
+	// Try each detected target in order until one has artifacts: on a glibc
+	// host detection lists the gnu triple before musl, and Linux releases are
+	// musl-only, so the gnu candidate can 404.
 	let host = DownloadSource::Tools.host();
-	let archive_path = format!("/bestool/{resolved}/{target}/{filename}.tar.zst");
-	let archive_url = host.join(&archive_path).into_diagnostic()?;
+	let mut signature = None;
+	let mut archive_url = None;
+	for target in &candidates {
+		let archive_path = format!("/bestool/{resolved}/{target}/{filename}.tar.zst");
+		let url = host.join(&archive_path).into_diagnostic()?;
+		match fetch_release_signature(&client, &url).await {
+			Ok(sig) => {
+				signature = Some(sig);
+				archive_url = Some(url);
+				break;
+			}
+			Err(err) => info!(%target, "no release artifact for target: {err}"),
+		}
+	}
+	let (Some(signature), Some(archive_url)) = (signature, archive_url) else {
+		return Err(miette!(
+			"no release artifact found for {resolved} (tried targets: {})",
+			candidates.join(", ")
+		));
+	};
 
 	info!(url = %archive_url, "downloading and verifying release");
-	let signature = fetch_release_signature(&client, &archive_url).await?;
 	let mut verifier = ReleaseVerifier::new(signature);
 	Download::new_with_data_verifier(client, archive_url, &mut verifier)
 		.and_extract(PkgFmt::Tzstd, &dir)


### PR DESCRIPTION
🤖 Follow-on from #685: instead of building gnu binaries against an older glibc, the Linux releases (bestool, bestool-psql, algae) become static musl binaries and the debs package those. One build per arch runs on any distro and glibc era, and zig leaves the pipeline entirely — builds are plain `cargo auditable build` natively on each runner arch.

The bestool Linux builds now include the iti features, so the Pi deployment uses the same artifact as everything else. That required replacing the `zmq` crate: its vendored libzmq is C++, and there is no musl C++ compiler in apt (which is what zig was covering for). The iti modules now use the pure-Rust `zeromq` crate — same ZMTP wire protocol, so it interoperates with libzmq peers. One behaviour change: the lcd client commands fail fast when the display server is down, instead of blocking until it appears.

Self-update now walks the detected targets until one has a signed artifact, instead of only fetching the first: detection on a glibc host lists the gnu triple (which no longer has artifacts) before musl.

Transitional measure, to remove once the fleet has rolled over: the musl binaries and signatures are also uploaded under the linux-gnu S3 paths (versioned and latest) so deployed gnu binaries self-update into musl builds and pinned URLs keep resolving. Debs are untouched by this — they aren't used for self-update, and apt indexes by package name, not target triple.

Verified locally: `cargo auditable build --profile dist --target x86_64-unknown-linux-musl -p bestool --features iti` with only musl-gcc (no zig) produces a static binary with the audit section present, iti subcommands available, and the new REQ/REP round-trip covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
