### PR TITLE
fix(alertd): surface real postgres error in db_connect check

### DIFF
--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -390,7 +390,7 @@ pub mod test_support {
 mod tests {
 	use serde_json::Value;
 
-	use super::{SweepContext, all, query_error_check, test_support::central_ctx};
+	use super::{SweepContext, all, fmt_db_error, query_error_check, test_support::central_ctx};
 	use crate::doctor::check::CheckStatus;
 
 	fn no_tamanu_ctx() -> SweepContext {
@@ -532,5 +532,21 @@ mod tests {
 		let check = query_error_check("x", &err);
 		assert!(check.status.is_fatal());
 		assert_eq!(check.to_wire()["result"], Value::from("failed"));
+	}
+
+	#[tokio::test]
+	async fn fmt_db_error_surfaces_the_real_message() {
+		// A genuine DbError (as opposed to an IO/connect failure) must not
+		// collapse to tokio_postgres::Error's unhelpful top-level Display
+		// ("db error") — that's the whole reason this helper exists.
+		let Some(err) = query_err("SELECT 1/0").await else {
+			return;
+		};
+		let formatted = fmt_db_error(&err);
+		assert_ne!(formatted, "db error");
+		assert!(
+			formatted.contains("division by zero"),
+			"expected the real postgres message, got {formatted:?}"
+		);
 	}
 }

--- a/crates/alertd/src/doctor/checks/db_connect.rs
+++ b/crates/alertd/src/doctor/checks/db_connect.rs
@@ -85,4 +85,44 @@ mod tests {
 			check.status
 		);
 	}
+
+	/// A reachable postgres that actively rejects the connection (here, a
+	/// nonexistent database name) produces a real `DbError`, not an IO
+	/// failure. The reported reason must be that error's actual message, not
+	/// `tokio_postgres::Error`'s generic top-level Display for `Kind::Db`
+	/// ("db error") — which is what `fmt_db_error` exists to avoid. Skips if
+	/// there's no local test postgres, mirroring the other DB-backed tests in
+	/// this crate.
+	#[tokio::test]
+	async fn rejected_connection_surfaces_real_reason() {
+		if crate::doctor::checks::test_support::central_ctx()
+			.await
+			.is_none()
+		{
+			return;
+		}
+
+		let config: TamanuConfig = serde_json::from_value(serde_json::json!({
+			"db": { "name": "bestool-test-nonexistent-db", "username": "u", "password": "p" }
+		}))
+		.unwrap();
+		let ctx = CheckContext {
+			tamanu_version: Version::parse("0.0.0").unwrap(),
+			tamanu_root: std::path::PathBuf::from("/nonexistent"),
+			config: Arc::new(config),
+			kind: ApiServerKind::Central,
+			database_url: "postgresql://localhost/bestool-test-nonexistent-db".into(),
+			db: None,
+			http_client: reqwest::Client::new(),
+			has_install: true,
+		};
+		let check = run(ctx).await;
+		match check.status {
+			CheckStatus::Fail(reason) => assert_ne!(
+				reason, "db error",
+				"should surface postgres's real rejection message, not the generic Display"
+			),
+			other => panic!("expected FAIL on a rejected connection, got {other:?}"),
+		}
+	}
 }

--- a/crates/alertd/src/doctor/checks/db_connect.rs
+++ b/crates/alertd/src/doctor/checks/db_connect.rs
@@ -118,10 +118,19 @@ mod tests {
 		};
 		let check = run(ctx).await;
 		match check.status {
-			CheckStatus::Fail(reason) => assert_ne!(
-				reason, "db error",
-				"should surface postgres's real rejection message, not the generic Display"
-			),
+			// Postgres rejects the startup packet with SQLSTATE 3D000
+			// (invalid_catalog_name), FATAL severity, and a message naming the
+			// missing database — e.g. `FATAL: database "..." does not exist`.
+			CheckStatus::Fail(reason) => {
+				assert!(
+					reason.contains("does not exist"),
+					"expected postgres's real 'database does not exist' rejection, got {reason:?}"
+				);
+				assert!(
+					reason.contains("bestool-test-nonexistent-db"),
+					"expected the message to name the missing database, got {reason:?}"
+				);
+			}
 			other => panic!("expected FAIL on a rejected connection, got {other:?}"),
 		}
 	}

--- a/crates/alertd/src/doctor/checks/db_connect.rs
+++ b/crates/alertd/src/doctor/checks/db_connect.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use super::CheckContext;
+use super::{CheckContext, fmt_db_error};
 use crate::doctor::check::Check;
 
 /// Connect latency above which the DB is treated as degraded.
@@ -38,7 +38,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Err(err) => Check::fail(
 			"db_connect",
 			format!("failed to connect to {host}/{name}"),
-			err.to_string(),
+			fmt_db_error(&err),
 		),
 	};
 


### PR DESCRIPTION
## Summary
- `db_connect` doctor check reported the generic, unhelpful `"db error"` for any connection attempt postgres actively rejected (`tokio_postgres::Error`'s Display for `Kind::Db` collapses to that literal string).
- Switched to `fmt_db_error`, the helper every other check in this crate already uses, so the alert surfaces the real severity/message/detail postgres sent back.

## Test plan
- [x] `cargo test -p bestool-alertd doctor::checks::db_connect` passes (`unreachable_postgres_alerts`)
- [x] `cargo clippy -p bestool-alertd --all-targets` clean
- [x] `cargo fmt -p bestool-alertd -- --check` clean
- [ ] Confirm next `db_connect` FAIL alert in canopy shows a specific postgres message instead of `"db error"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)