### PR TITLE
fix(tamanu): elevate logs and sync so journalctl can read the journal

### DIFF
--- a/crates/bestool/src/actions/tamanu/logs.rs
+++ b/crates/bestool/src/actions/tamanu/logs.rs
@@ -26,7 +26,7 @@ use bestool_tamanu::{
 
 use crate::actions::{
 	Context,
-	tamanu::{TamanuArgs, find_tamanu},
+	tamanu::{TamanuArgs, find_tamanu, lifecycle},
 };
 
 /// The literal pseudo-service name that triggers caddy log tailing
@@ -172,6 +172,12 @@ pub async fn run(args: LogsArgs, ctx: Context) -> Result<()> {
 	} else {
 		bail!("tamanu logs is only supported on Linux (systemd) and Windows (pm2)");
 	};
+
+	// On systemd, reading a unit's journal (`journalctl -u …`) needs root or
+	// membership in `adm`/`systemd-journal`; without it journalctl returns no
+	// entries and exits 0, so the tail comes back empty with no error. Elevate
+	// the same way the other tamanu subcommands do so the journal is readable.
+	lifecycle::ensure_root_or_reexec(supervisor)?;
 
 	// Read `features.patientPortal` from the DB so that `bestool tamanu logs
 	// tamanu-patientportal` actually matches when the flag is on; without

--- a/crates/bestool/src/actions/tamanu/sync.rs
+++ b/crates/bestool/src/actions/tamanu/sync.rs
@@ -15,7 +15,7 @@ use bestool_tamanu::{ApiServerKind, config::load_config, services::Supervisor};
 
 use crate::actions::{
 	Context,
-	tamanu::{TamanuArgs, find_tamanu},
+	tamanu::{TamanuArgs, find_tamanu, lifecycle},
 };
 
 /// Trigger a manual sync on a facility server and watch it run.
@@ -130,6 +130,15 @@ pub async fn run(args: SyncArgs, ctx: Context) -> Result<()> {
 		Supervisor::Pm2 => "tamanu-sync",
 		Supervisor::Systemd => "tamanu-facility-sync",
 	};
+
+	// When we're going to tail the sync service, its journal (`journalctl -u
+	// … -f`) needs root or `adm`/`systemd-journal` membership on systemd —
+	// otherwise the follow shows no lines. Elevate before triggering the sync
+	// so the re-exec doesn't fire the `/sync/run` POST twice. `--no-follow`
+	// never touches the journal, so it stays unprivileged.
+	if !args.no_follow {
+		lifecycle::ensure_root_or_reexec(supervisor)?;
+	}
 
 	let base_url = config
 		.sync_api_url()


### PR DESCRIPTION
🤖 `bestool tamanu logs caddy` (and any `logs`/`sync` invocation) came back empty on a host where the logs plainly existed.

## Cause

On Linux, `logs` and `sync` shell out to `journalctl -u <unit>` to read a service's journal. Reading a *system* unit's journal needs root, or membership in `adm`/`systemd-journal`. Run as an ordinary user without that access, `journalctl` returns no entries and exits 0 — so the tail comes back empty with no error, and bestool's success path (which only bails on a non-zero exit) reports nothing.

The four lifecycle commands (`start`, `stop`, `restart`, `status`) already guard against this by calling `lifecycle::ensure_root_or_reexec`, which re-execs the process under `sudo` when not already root. `logs` and `sync` were the only two commands that touch `journalctl` without doing so.

## Fix

- `logs`: call `ensure_root_or_reexec` once the systemd supervisor is resolved, before any journal or DB work.
- `sync`: call it only when it will actually follow logs (not `--no-follow`), and before the `/sync/run` POST so the re-exec doesn't trigger the sync twice.

Both are no-ops on Windows/pm2, which read `.log` files directly and are unaffected.

No tests: the change is a guarded `ensure_root_or_reexec` call that re-execs the process under `sudo` and exits, which isn't unit-testable — matching its four existing untested siblings.
