### PR TITLE
fix(canopy): follow events→checks migration, drop removed wire types

### DIFF
--- a/crates/bestool/src/canopy_contract.rs
+++ b/crates/bestool/src/canopy_contract.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 use bestool_canopy::schema::{
 	BackupCapabilitiesArgs, BackupCredentialsArgs, BackupPurpose, BackupTarget, BeginArgs,
 	BeginResponse, CheckSeverity, CompleteArgs, CompleteResponse, CredentialProcessOutput,
-	NewEvent, ReportArgs, RunOutcome, Severity,
+	ReportArgs, RunOutcome,
 };
 use serde_json::{Value, json};
 use tokio::sync::OnceCell;
@@ -112,82 +112,6 @@ fn response_schema(path: &str, method: &str) -> String {
 		"/paths/{}/{method}/responses/200/content/application~1json/schema",
 		escape(path),
 	)
-}
-
-#[tokio::test]
-#[ignore = "live canopy contract test; run by the dedicated CI job"]
-async fn events_request_matches_spec() {
-	let spec = spec().await;
-	assert_operation_exists(spec, "/events", "post");
-
-	let event = NewEvent::builder()
-		.source("bestool-contract-test".to_owned())
-		.ref_("host/alert:target".to_owned())
-		.message("message".to_owned())
-		.description("description".to_owned())
-		.severity(Severity::Warning)
-		.occurred_at("2026-01-01T00:00:00Z".parse().unwrap())
-		.active(true)
-		.build();
-	let instance = serde_json::to_value(&event).unwrap();
-	assert_valid(spec, &request_schema("/events", "post"), &instance);
-
-	// Negative case, proving the validation isn't vacuous: a retired syslog
-	// severity must be rejected.
-	let mut invalid = instance.clone();
-	invalid["severity"] = json!("notice");
-	let validator = validator_at(spec, &request_schema("/events", "post"));
-	assert!(
-		!validator.is_valid(&invalid),
-		"spec validation accepted a retired severity; the validator is not checking refs",
-	);
-}
-
-#[tokio::test]
-#[ignore = "live canopy contract test; run by the dedicated CI job"]
-async fn severity_vocabulary_matches_spec() {
-	let spec = spec().await;
-	let spec_levels: Vec<&str> = resolve(spec, "/components/schemas/Severity")
-		.get("enum")
-		.and_then(Value::as_array)
-		.expect("Severity schema has an enum")
-		.iter()
-		.map(|v| v.as_str().expect("Severity enum values are strings"))
-		.collect();
-
-	// Exhaustive match: adding a Severity variant breaks this and forces the
-	// list below to be updated.
-	use Severity::*;
-	const ALL: &[Severity] = &[Critical, Error, Warning, Info, Debug];
-	for severity in ALL {
-		match severity {
-			Critical | Error | Warning | Info | Debug => {}
-		}
-	}
-
-	let ours: Vec<String> = ALL
-		.iter()
-		.map(|s| {
-			serde_json::to_value(s)
-				.unwrap()
-				.as_str()
-				.unwrap()
-				.to_owned()
-		})
-		.collect();
-
-	for level in &spec_levels {
-		assert!(
-			serde_json::from_value::<Severity>(json!(level)).is_ok(),
-			"canopy severity {level:?} does not deserialise into bestool's Severity",
-		);
-	}
-	for level in &ours {
-		assert!(
-			spec_levels.contains(&level.as_str()),
-			"bestool severity {level:?} is not accepted by canopy (spec has {spec_levels:?})",
-		);
-	}
 }
 
 #[tokio::test]

--- a/crates/canopy/tests/schema.rs
+++ b/crates/canopy/tests/schema.rs
@@ -5,7 +5,7 @@
 
 use bestool_canopy::schema::{
 	BackupPurpose, BackupTarget, BeginArgs, BeginResponse, CompleteArgs, CompleteResponse,
-	CredentialProcessOutput, Issue, NewEvent, ReportArgs, RunOutcome, Severity,
+	CredentialProcessOutput, ReportArgs, RunOutcome,
 };
 
 #[test]
@@ -124,58 +124,4 @@ fn backup_target_repo_password_is_redacted() {
 	let debug = format!("{target:?}");
 	assert!(!debug.contains("hunter2"), "{debug}");
 	assert!(debug.contains("<redacted>"), "{debug}");
-}
-
-#[test]
-fn new_event_omits_optional_fields() {
-	let event = NewEvent::builder()
-		.source("src".to_owned())
-		.ref_("host/alert:tgt".to_owned())
-		.message("msg".to_owned())
-		.build();
-	let json = serde_json::to_string(&event).unwrap();
-	assert!(json.contains("\"source\":\"src\""));
-	assert!(json.contains("\"ref\":\"host/alert:tgt\""));
-	assert!(json.contains("\"message\":\"msg\""));
-	assert!(!json.contains("description"));
-	assert!(!json.contains("severity"));
-	assert!(!json.contains("occurredAt"));
-	assert!(!json.contains("active"));
-}
-
-#[test]
-fn new_event_serialises_occurred_at_camel_case_and_severity_lowercase() {
-	let event = NewEvent::builder()
-		.source("src".to_owned())
-		.ref_("ref".to_owned())
-		.message("msg".to_owned())
-		.description("desc".to_owned())
-		.severity(Severity::Warning)
-		.occurred_at("2025-01-01T00:00:00Z".parse().unwrap())
-		.active(true)
-		.build();
-	let json = serde_json::to_string(&event).unwrap();
-	assert!(json.contains("\"occurredAt\":"));
-	assert!(json.contains("\"severity\":\"warning\""));
-	assert!(json.contains("\"active\":true"));
-}
-
-#[test]
-fn datetime_fields_deserialise_into_jiff_timestamp() {
-	let issue: Issue = serde_json::from_value(serde_json::json!({
-		"active": true,
-		"created_at": "2026-01-02T03:04:05Z",
-		"first_seen": "2026-01-02T03:04:05Z",
-		"last_seen": "2026-01-02T03:04:05Z",
-		"id": "6f8a2b1c-0000-4000-8000-000000000000",
-		"message": "disk full",
-		"ref": "host/alert:disk",
-		"severity": "warning",
-		"source": "alertd",
-		"updated_at": "2026-01-02T03:04:05Z",
-	}))
-	.unwrap();
-
-	let created: jiff::Timestamp = issue.created_at;
-	assert_eq!(created, "2026-01-02T03:04:05Z".parse().unwrap());
 }


### PR DESCRIPTION
🤖 CI is red on every PR right now (Clippy, macos test, ubuntu-arm test all fail at the same step) because the canopy schema tests no longer compile — not because of anything in those PRs. This unblocks them.

## Cause

`crates/canopy/build.rs` generates the `bestool_canopy::schema` module by fetching canopy's OpenAPI doc **live** from `https://meta.tamanu.app/api/openapi.json` at build time, so the wire types track canopy as it evolves. Live canopy has since removed the `Issue`, `NewEvent`, and `Severity` schemas — it's migrated alerting to the checks / `CheckSeverity` model. The generated module no longer exports those three names, so the test code that imported them stopped compiling.

The committed `openapi.snapshot.json` (offline fallback only) still has the old model, which is why this wasn't caught earlier and why `main` was last green before the live schema drifted; a rebuild of `main` today fails identically.

## Fix

Follow the migration on the test side:

- `crates/canopy/tests/schema.rs` — drop the `NewEvent` / `Issue` / `Severity` round-trip cases.
- `crates/bestool/src/canopy_contract.rs` — drop `events_request_matches_spec` and `severity_vocabulary_matches_spec`; the `/events` endpoint and `Severity` vocabulary they asserted are gone from live canopy.

No runtime code posted events or read issues (the only references were these tests), so nothing else changes. The `CheckSeverity` contract coverage that replaces this stays in place. The committed snapshot is refreshed automatically by the release-plz workflow, so it's left alone here.

## Verification

- `cargo clippy --all-targets --all-features` — clean.
- `cargo test -p bestool-canopy --test schema` — 6 pass.
- `cargo test -p bestool --all-features --no-run` — compiles.
