### PR TITLE
fix(alertd): make sync_sessions doctor checks index-friendly

### DIFF
--- a/crates/alertd/src/doctor/checks/sync_facility_stale.rs
+++ b/crates/alertd/src/doctor/checks/sync_facility_stale.rs
@@ -16,10 +16,15 @@ const NAME: &str = "sync_facility_stale";
 const WARN_MINUTES: f64 = 10.0;
 const FAIL_MINUTES: f64 = 30.0;
 
+// The 30-day bound keeps the jsonb expansion off the full table (millions of
+// rows on long-lived centrals). It cannot change any tier: staleness saturates
+// at FAIL past 30 minutes, so a last success older than 30 days grades the
+// same as none at all — only the reported timestamp saturates at the window.
 const SQL: &str = "WITH facility_sessions AS ( \
 		SELECT jsonb_array_elements_text(parameters->'facilityIds') AS facility_id, \
 			created_at, completed_at, errors \
 		FROM sync_sessions WHERE parameters->>'isMobile' <> 'true' \
+			AND created_at > now() - interval '30 days' \
 	), active AS ( \
 		SELECT DISTINCT facility_id FROM facility_sessions \
 		WHERE created_at > now() - interval '48 hours' \
@@ -56,8 +61,8 @@ pub async fn run(ctx: CheckContext) -> Check {
 	for row in &rows {
 		let facility_id: String = row.try_get("facility_id").unwrap_or_default();
 		let last: Option<String> = row.try_get("last_successful_sync").ok();
-		// A facility that is active but has never had a successful sync (NULL
-		// minutes) is as bad as a very stale one: treat it as a failure.
+		// A facility that is active but has no successful sync in the window
+		// (NULL minutes) is as bad as a very stale one: treat it as a failure.
 		let minutes: Option<f64> = row.try_get("minutes_since_success").ok();
 		let entry = json!({
 			"facility_id": facility_id,

--- a/crates/alertd/src/doctor/checks/sync_sessions.rs
+++ b/crates/alertd/src/doctor/checks/sync_sessions.rs
@@ -8,17 +8,22 @@ pub async fn run(ctx: CheckContext) -> Check {
 		return Check::fail("sync_sessions", "no DB connection", "db_connect failed");
 	};
 
+	// The completed_at predicate lives in the outer WHERE rather than on each
+	// aggregate FILTER: Postgres can't push FILTER predicates into an index, so
+	// the filtered form seq-scans the whole table (millions of rows on
+	// long-lived centrals) while this form hits the completed_at index.
 	let query = r#"
 		SELECT
-			count(*) FILTER (WHERE completed_at IS NULL) AS active_count,
+			count(*) AS active_count,
 			count(*) FILTER (
-				WHERE completed_at IS NULL AND start_time < now() - interval '15 minutes'
+				WHERE start_time < now() - interval '15 minutes'
 			) AS stuck_warn,
 			count(*) FILTER (
-				WHERE completed_at IS NULL AND start_time < now() - interval '45 minutes'
+				WHERE start_time < now() - interval '45 minutes'
 			) AS stuck_fail,
-			min(start_time) FILTER (WHERE completed_at IS NULL) AS oldest_started_at
+			min(start_time) AS oldest_started_at
 		FROM sync_sessions
+		WHERE completed_at IS NULL
 	"#;
 
 	let row = match client.query_opt(query, &[]).await {


### PR DESCRIPTION
Two doctor sweep queries seq-scanned all of sync_sessions every sweep,
which on long-lived centrals (Tonga: 2.7M rows / 1.2GB) presented as a
sustained Postgres CPU spike:

- sync_sessions: move the completed_at IS NULL predicate from the
  aggregate FILTERs to the outer WHERE so the existing completed_at
  index is used; semantics unchanged.
- sync_facility_stale: bound the jsonb facility expansion to 30 days.
  Tiering saturates at FAIL past 30 minutes, so this cannot change any
  grade; only the reported last-success timestamp saturates.

Pairs with tamanu#10473 which adds indexes for the remaining
time-filtered sweep queries.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

