### PR TITLE
fix(postgres): bump to 1.2.0 so published crates see pgtune

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "bestool-postgres"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bytes",
  "fraction",

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 axum = "0.8.9"
 bestool-canopy = { version = "0.7.2", path = "../canopy" }
 bestool-kopia = { version = "0.5.0", path = "../kopia" }
-bestool-postgres = { version = "1.1.0", path = "../postgres" }
+bestool-postgres = { version = "1.2.0", path = "../postgres" }
 bestool-tamanu = { version = "0.16.4", path = "../tamanu", features = ["canopy-registration"] }
 bytes = "1.9.0"
 dirs = "6.0.0"

--- a/crates/postgres/Cargo.toml
+++ b/crates/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bestool-postgres"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["Félix Saparelli <felix@passcod.name>", "BES Developers <contact@bes.au>"]
 license = "GPL-3.0-or-later"

--- a/crates/tamanu/Cargo.toml
+++ b/crates/tamanu/Cargo.toml
@@ -17,7 +17,7 @@ canopy-registration = ["dep:bestool-canopy"]
 
 [dependencies]
 bestool-canopy = { version = "0.7.2", path = "../canopy", optional = true }
-bestool-postgres = { version = "1.1.0", path = "../postgres" }
+bestool-postgres = { version = "1.2.0", path = "../postgres" }
 dirs = "6.0.0"
 duct = "1.1.0"
 futures = { workspace = true }


### PR DESCRIPTION
See commit message: unblocks the failed bestool-alertd 18.0.4 publish (release-plz #544) and fixes Windows builds against published bestool-tamanu. Verified locally with cargo check.