### PR TITLE
fix(canopy): stop orphaned pg_basebackup colliding with the next run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "url",
+ "win32job",
  "windows-service",
  "x509-parser",
 ]
@@ -8300,6 +8301,16 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "win32job"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6a6724ccfbf34154a8691bd868b0fcd2be2ca3f7b47b32614654f1a01b191c"
+dependencies = [
+ "thiserror 1.0.69",
+ "windows 0.61.3",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -48,4 +48,5 @@ rustix = { version = "1", features = ["process"] }
 sd-notify = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
+win32job = "2.0.3"
 windows-service = "0.8.0"

--- a/crates/alertd/src/child_confinement.rs
+++ b/crates/alertd/src/child_confinement.rs
@@ -1,0 +1,54 @@
+//! Bind spawned child processes' lifetime to the daemon's.
+//!
+//! Backups spawn helpers (`pg_basebackup`, `kopia`) as child processes. If the
+//! daemon exits mid-backup — a clean stop, a crash, an OOM kill, or a self-update
+//! restart — those children must go with it. On Linux systemd's cgroup tears the
+//! whole unit down, so this is handled there. On Windows nothing ties a child to
+//! its parent by default: a stranded `pg_basebackup` keeps streaming into the
+//! stable staging dir, and the run the restarted daemon starts collides with it
+//! (`could not create directory ...: File exists`). A job object with
+//! kill-on-close makes every child die when the daemon process does.
+
+/// Confine every process the daemon spawns to the daemon's own lifetime, so none
+/// outlive it. A no-op on platforms where the service manager already guarantees
+/// this (Linux under systemd).
+pub fn confine_children() {
+	#[cfg(windows)]
+	imp::confine();
+}
+
+#[cfg(windows)]
+mod imp {
+	use tracing::{info, warn};
+	use win32job::{ExtendedLimitInfo, Job};
+
+	pub fn confine() {
+		let mut info = ExtendedLimitInfo::new();
+		info.limit_kill_on_job_close();
+
+		let job = match Job::create_with_limit_info(&info) {
+			Ok(job) => job,
+			Err(err) => {
+				warn!(
+					"could not create the job object to confine backup children ({err}); \
+					 they may outlive a daemon restart"
+				);
+				return;
+			}
+		};
+
+		if let Err(err) = job.assign_current_process() {
+			warn!(
+				"could not assign the daemon to its job object ({err}); \
+				 backup children may outlive a daemon restart"
+			);
+			return;
+		}
+
+		// Keep the handle open for the daemon's whole life: closing it is what fires
+		// the kill, so it must outlive every backup. `into_handle` yields the raw
+		// handle without running `Drop` (which would close it here and now).
+		let _ = job.into_handle();
+		info!("confined child processes to the daemon's lifetime");
+	}
+}

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -81,6 +81,10 @@ pub async fn run_with_shutdown(
 ) -> Result<()> {
 	info!("starting alertd daemon");
 
+	// Tie spawned children (pg_basebackup, kopia) to this process, so a daemon
+	// restart can't leave a backup running to collide with the next one.
+	crate::child_confinement::confine_children();
+
 	metrics::init_metrics();
 	metrics::record_activity();
 

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -4,6 +4,7 @@ pub use bestool_canopy as canopy;
 pub use bestool_canopy::Redacted;
 
 pub mod backup;
+mod child_confinement;
 pub mod commands;
 mod context;
 mod daemon;

--- a/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/basebackup.rs
@@ -67,6 +67,11 @@ pub async fn prepare(
 	#[cfg(unix)]
 	make_writable_by_postgres(&root).await?;
 
+	// Guard against a second stream into the same stable dir: if the destination
+	// has reappeared since we cleared the staging root, another pg_basebackup is
+	// already writing there (an orphan from a daemon that exited mid-run).
+	ensure_dest_clear(&dest).await?;
+
 	info!(dest = %dest.display(), "streaming pg_basebackup");
 	let mut cmd = super::pg_command(&super::postgres_bin("pg_basebackup", &resolved.data_dir));
 	cmd.args(basebackup_args(&dest));
@@ -90,6 +95,23 @@ pub async fn prepare(
 	#[cfg(unix)]
 	make_readable_by_kopia(&root).await;
 	Ok((dest, root))
+}
+
+/// Refuse to stream when the destination already exists right before the run: it
+/// means another pg_basebackup is writing into the shared stable dir (an orphan
+/// left by a daemon that exited mid-run). Two streams into one target collide
+/// mid-extraction (`could not create directory ...: File exists`) and corrupt both
+/// copies, so fail with a clear cause instead of racing. If the check itself can't
+/// run, assume clear rather than block a legitimate backup.
+async fn ensure_dest_clear(dest: &Path) -> Result<()> {
+	if tokio::fs::try_exists(dest).await.unwrap_or(false) {
+		bail!(
+			"another process is already writing a base backup to {}; \
+			 refusing to start a second pg_basebackup into the same directory",
+			dest.display()
+		);
+	}
+	Ok(())
 }
 
 /// The error for a failed run: exit status plus what pg_basebackup said on
@@ -191,6 +213,17 @@ mod tests {
 				.join("16")
 				.join("main")
 		);
+	}
+
+	#[tokio::test]
+	async fn ensure_dest_clear_rejects_a_reappeared_destination() {
+		let tmp = tempfile::tempdir().unwrap();
+		let dest = tmp.path().join("12").join("main");
+		// Absent (the normal case, after the staging root was cleared): proceed.
+		assert!(ensure_dest_clear(&dest).await.is_ok());
+		// Present again just before streaming: another writer is active; refuse.
+		tokio::fs::create_dir_all(&dest).await.unwrap();
+		assert!(ensure_dest_clear(&dest).await.is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 A backup on a Windows host failed with:

```
pg_basebackup: error: could not create directory
"C:\ProgramData\bestool\backup-source\tamanu-postgres\12\main/global": File exists
```

That error appears *during* extraction, after pg_basebackup's own empty-check on `main` has already passed, which only happens when a second live `pg_basebackup` is streaming into the same target at once.

The daemon's registry runs at most one backup at a time, so the second writer comes from a *previous* daemon instance. Backup children (`pg_basebackup`, `kopia`) are spawned with plain `cmd.output()` — no job object, no `kill_on_drop` — so when the service exits mid-backup (an OOM kill, a crash, or a self-update restart) the child is orphaned and keeps writing. The restarted daemon then starts a fresh backup into the same stable staging dir and the two collide. The per-type lock can't prevent it: the dead daemon's lock is already released and the orphan holds none. Linux is unaffected because systemd's cgroup tears the whole unit down.

## Changes

- Confine spawned children to the daemon's lifetime with a Windows job object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) assigned to the daemon process at startup, so the OS kills every child when the daemon exits for any reason. Uses the `win32job` safe wrapper (the workspace forbids `unsafe`). New `crates/alertd/src/child_confinement.rs`, called from `daemon::run_with_shutdown`; a no-op off Windows.
- `basebackup::prepare` refuses to start when the destination has reappeared since the staging root was cleared, rather than racing a second stream into it.

The job object's runtime kill behaviour needs verification on a Windows host; it can't be exercised off-platform.
