### PR TITLE
feat: add Windows Tamanu Caddyfile version healthcheck

### DIFF
--- a/.workhorse/specs/tamanu/caddyfile-version.md
+++ b/.workhorse/specs/tamanu/caddyfile-version.md
@@ -1,5 +1,5 @@
 ---
-id: CFV
+id: CHK-CFV
 ---
 
 # Caddyfile version healthcheck

--- a/.workhorse/specs/tamanu/caddyfile-version.md
+++ b/.workhorse/specs/tamanu/caddyfile-version.md
@@ -1,0 +1,38 @@
+---
+id: CFV
+---
+
+# Caddyfile version healthcheck
+
+The Tamanu doctor runs a check that verifies the Caddyfile on a Windows Tamanu server declares a supported configuration version. Tamanu ships its Caddyfile with a version marker on the first line, and newer Tamanu releases depend on newer Caddyfile revisions; this check surfaces servers still running an outdated Caddyfile so it can be upgraded before it breaks.
+
+The check is one of the doctor's registry of checks and follows the shared outcome model in `tamanu/doctor.md` (pass, skip, warning, fail, broken).
+
+## Applicability
+
+The check only applies to a Windows host that has a Tamanu deployment.
+
+- It skips on any non-Windows host.
+- It skips on a Windows host with no Tamanu deployment.
+- It skips when caddy is not present — when no Caddyfile is found on disk at the standard Windows location.
+
+A skip carries a reason naming which precondition was not met.
+
+## Version marker
+
+Tamanu's Caddyfile declares its version on the literal first line, in the exact form `# tamanu caddyfile v<N>`, where `<N>` is the version number.
+
+- The marker must be the first line of the file. Trailing carriage-return and whitespace are ignored so the CRLF line endings of a Windows file still match.
+- `<N>` is read as an integer, so the marker keeps working past a single digit.
+- When the Caddyfile is present but its first line is not a valid marker in this form, the check fails, reporting that the Caddyfile version is missing or unreadable.
+
+## Outcomes
+
+For a Windows Tamanu server with a readable Caddyfile:
+
+- [ ] A Caddyfile whose marker version is 9 or greater passes.
+- [ ] A Caddyfile whose marker version is below 9 fails when the Tamanu version is 2.46.0 or greater.
+- [ ] A Caddyfile whose marker version is below 9 warns when the Tamanu version is below 2.46.0.
+- [ ] A Caddyfile with no valid first-line marker fails, regardless of the Tamanu version.
+
+The version threshold (9) and the Tamanu version boundary (2.46.0) are fixed in the check.

--- a/.workhorse/specs/tamanu/caddyfile-version.md
+++ b/.workhorse/specs/tamanu/caddyfile-version.md
@@ -6,7 +6,7 @@ id: CHK-CFV
 
 The Tamanu doctor runs a check that verifies the Caddyfile on a Windows Tamanu server declares a supported configuration version. Tamanu ships its Caddyfile with a version marker on the first line, and newer Tamanu releases depend on newer Caddyfile revisions; this check surfaces servers still running an outdated Caddyfile so it can be upgraded before it breaks.
 
-The check is one of the doctor's registry of checks and follows the shared outcome model in `tamanu/doctor.md` (pass, skip, warning, fail, broken).
+It is one of the healthchecks described by `tamanu/healthchecks.md` and follows the shared outcome model in `tamanu/doctor.md` (pass, skip, warning, fail, broken).
 
 ## Applicability
 

--- a/.workhorse/specs/tamanu/healthchecks.md
+++ b/.workhorse/specs/tamanu/healthchecks.md
@@ -1,0 +1,13 @@
+---
+id: CHK
+---
+
+# Healthchecks
+
+The doctor and the alertd daemon run a shared registry of named healthchecks against a host and its Tamanu deployment. Each check resolves to one of the outcomes and is selected, ordered, and rendered as described in `tamanu/doctor.md`.
+
+This spec is the parent for the healthcheck catalogue: the conventions common to every check, with each check that warrants its own acceptance criteria captured in a sibling spec.
+
+## Spec identifiers
+
+Every spec describing an individual healthcheck carries a frontmatter `id` of the form `CHK-<id>`, where `<id>` is a short identifier for that check (for example `CHK-CFV` for the Caddyfile version check). The shared `CHK-` prefix distinguishes healthcheck specs from other specs at a glance and groups them for code-to-spec traceability.

--- a/.workhorse/test-cases/d1/overview.md
+++ b/.workhorse/test-cases/d1/overview.md
@@ -1,0 +1,25 @@
+# Caddyfile version healthcheck — test cases
+
+Covers the `caddyfile_version` doctor check (verifies spec: CHK-CFV).
+
+## Marker parsing
+
+- [x] `# tamanu caddyfile v9` parses as version 9
+- [x] A CRLF line ending (`# tamanu caddyfile v9\r`) still parses
+- [x] Multi-digit versions parse (`# tamanu caddyfile v12` → 12)
+- [x] Trailing content after the number is rejected (`# tamanu caddyfile v9 beta`)
+- [x] Wrong prefix, wrong case, other comments, and an empty line are rejected
+
+## Outcomes (verifies spec: CHK-CFV)
+
+- [x] Marker version ≥ 9 passes on any Tamanu version
+- [x] Missing/invalid marker fails regardless of Tamanu version
+- [x] Marker version < 9 fails when Tamanu ≥ 2.46.0 (including the 2.46.0 boundary)
+- [x] Marker version < 9 warns when Tamanu < 2.46.0
+
+## Applicability (manual / integration)
+
+- [ ] Skips on a non-Windows host
+- [ ] Skips on a Windows host with no Tamanu deployment
+- [ ] Skips on a Windows Tamanu host with no Caddyfile on disk (caddy not present)
+- [ ] Reads `C:\Caddy\Caddyfile` / `Caddyfile.txt` on a real Windows install

--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -19,6 +19,7 @@ pub mod billing_tags;
 pub mod btrfs;
 pub mod caddy_certs;
 pub mod caddy_version;
+pub mod caddyfile_version;
 pub mod certificate_notification_errors;
 pub mod db_connect;
 pub mod db_version;
@@ -274,6 +275,10 @@ pub fn all() -> Vec<CheckEntry> {
 		// `TAMANU_DATABASE_URL`-only host.
 		entry!("caddy_version", caddy_version, host),
 		entry!("caddy_certs", caddy_certs, host),
+		// Tamanu-dependent: reads the Tamanu Caddyfile's version marker and needs
+		// the deployment's version to grade an outdated one. Windows-only and
+		// self-skips when caddy isn't present.
+		entry!("caddyfile_version", caddyfile_version),
 		entry!("http_errors", http_errors, host),
 		entry!("tailscale", tailscale, host, off_wire),
 		entry!("tailscale_config", tailscale_config, host),

--- a/crates/alertd/src/doctor/checks/caddyfile_version.rs
+++ b/crates/alertd/src/doctor/checks/caddyfile_version.rs
@@ -1,0 +1,200 @@
+//! Caddyfile version healthcheck.
+//!
+//! spec: CHK-CFV
+//!
+//! Tamanu ships its Windows Caddyfile with a version marker on the literal
+//! first line, in the exact form `# tamanu caddyfile v<N>`. Newer Tamanu
+//! releases depend on newer Caddyfile revisions, so this check reads that marker
+//! and flags a server still running an outdated (or unmarked) Caddyfile.
+//!
+//! Applies only to a Windows host with a Tamanu deployment; skips elsewhere, and
+//! skips when caddy isn't present (no Caddyfile on disk). A present-but-unmarked
+//! Caddyfile is a hard fail. Otherwise:
+//!   * v>=9                              → pass
+//!   * v<9  and Tamanu >= 2.46.0         → fail
+//!   * v<9  and Tamanu <  2.46.0         → warn
+
+use node_semver::Version;
+
+use bestool_tamanu::caddy;
+
+use super::CheckContext;
+use crate::doctor::check::Check;
+
+const CHECK_NAME: &str = "caddyfile_version";
+
+/// Lowest Caddyfile marker version considered current.
+const MIN_VERSION: u32 = 9;
+
+/// Tamanu version from which an outdated Caddyfile is a hard failure rather than
+/// a warning: below this, an old Caddyfile still works and only warrants a nudge
+/// to upgrade.
+const TAMANU_STRICT_FROM: &str = "2.46.0";
+
+pub async fn run(ctx: CheckContext) -> Check {
+	// Windows-only: the marked Caddyfile is a Windows deployment convention, and
+	// on Linux caddy is managed through the package manager.
+	if !cfg!(windows) {
+		return Check::skip(
+			CHECK_NAME,
+			"not a Windows host",
+			"the Caddyfile version check applies only to Windows Tamanu servers",
+		);
+	}
+
+	let path = caddy::caddyfile_path();
+	let contents = match std::fs::read_to_string(&path) {
+		Ok(contents) => contents,
+		Err(err) => {
+			// No Caddyfile means caddy isn't present on this host — a precondition
+			// the check needs, so it skips rather than reporting on the server.
+			return Check::skip(
+				CHECK_NAME,
+				"caddy not present",
+				format!("could not read a Caddyfile at {}: {err}", path.display()),
+			);
+		}
+	};
+
+	let version = parse_caddyfile_version(contents.lines().next().unwrap_or_default());
+	let strict_from = Version::parse(TAMANU_STRICT_FROM).expect("TAMANU_STRICT_FROM is valid semver");
+	let check = build_check(version, &ctx.tamanu_version, &strict_from);
+	match version {
+		Some(v) => check.with_detail("caddyfile_version", v),
+		None => check,
+	}
+}
+
+/// Read the Caddyfile version from its first line. The line must be exactly
+/// `# tamanu caddyfile v<N>` with `<N>` a non-negative integer and nothing
+/// trailing; a trailing carriage-return or whitespace is ignored so a CRLF
+/// Windows file still matches. Returns `None` when the line isn't a valid
+/// marker.
+fn parse_caddyfile_version(first_line: &str) -> Option<u32> {
+	first_line
+		.trim_end()
+		.strip_prefix("# tamanu caddyfile v")?
+		.parse()
+		.ok()
+}
+
+/// Classify a Caddyfile version against the thresholds, given the host's Tamanu
+/// version. `None` means the first line wasn't a valid marker.
+fn build_check(version: Option<u32>, tamanu_version: &Version, strict_from: &Version) -> Check {
+	let Some(version) = version else {
+		return Check::fail(
+			CHECK_NAME,
+			"Caddyfile version missing",
+			"the Caddyfile's first line is not a `# tamanu caddyfile v<N>` version marker",
+		);
+	};
+
+	if version >= MIN_VERSION {
+		return Check::pass(CHECK_NAME, format!("Caddyfile v{version}"));
+	}
+
+	if tamanu_version >= strict_from {
+		Check::fail(
+			CHECK_NAME,
+			format!("Caddyfile v{version}"),
+			format!(
+				"Caddyfile v{version} is older than v{MIN_VERSION}, which Tamanu {tamanu_version} requires"
+			),
+		)
+	} else {
+		Check::warning(
+			CHECK_NAME,
+			format!("Caddyfile v{version}"),
+			format!(
+				"Caddyfile v{version} is older than v{MIN_VERSION}; upgrade it before moving to Tamanu {strict_from}"
+			),
+		)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn v(s: &str) -> Version {
+		Version::parse(s).unwrap()
+	}
+
+	fn strict() -> Version {
+		v(TAMANU_STRICT_FROM)
+	}
+
+	#[test]
+	fn parses_bare_marker() {
+		assert_eq!(parse_caddyfile_version("# tamanu caddyfile v9"), Some(9));
+	}
+
+	#[test]
+	fn parses_marker_with_crlf() {
+		assert_eq!(parse_caddyfile_version("# tamanu caddyfile v9\r"), Some(9));
+	}
+
+	#[test]
+	fn parses_multi_digit_version() {
+		assert_eq!(parse_caddyfile_version("# tamanu caddyfile v12"), Some(12));
+	}
+
+	#[test]
+	fn rejects_trailing_content() {
+		assert_eq!(parse_caddyfile_version("# tamanu caddyfile v9 beta"), None);
+	}
+
+	#[test]
+	fn rejects_wrong_prefix() {
+		assert_eq!(parse_caddyfile_version("#tamanu caddyfile v9"), None);
+		assert_eq!(parse_caddyfile_version("# Tamanu Caddyfile v9"), None);
+		assert_eq!(parse_caddyfile_version("# some other comment"), None);
+		assert_eq!(parse_caddyfile_version(""), None);
+	}
+
+	fn status(check: &Check) -> &'static str {
+		use crate::doctor::check::CheckStatus::*;
+		match check.status {
+			Pass => "pass",
+			Skip(_) => "skip",
+			Warning(_) => "warning",
+			Fail(_) => "fail",
+			Broken(_) => "broken",
+		}
+	}
+
+	#[test]
+	fn missing_marker_fails_regardless_of_tamanu_version() {
+		assert_eq!(status(&build_check(None, &v("2.30.0"), &strict())), "fail");
+		assert_eq!(status(&build_check(None, &v("2.50.0"), &strict())), "fail");
+	}
+
+	#[test]
+	fn current_version_passes() {
+		assert_eq!(status(&build_check(Some(9), &v("2.50.0"), &strict())), "pass");
+		assert_eq!(status(&build_check(Some(9), &v("2.30.0"), &strict())), "pass");
+		assert_eq!(
+			status(&build_check(Some(10), &v("2.30.0"), &strict())),
+			"pass"
+		);
+	}
+
+	#[test]
+	fn outdated_fails_on_new_tamanu() {
+		assert_eq!(status(&build_check(Some(8), &v("2.50.0"), &strict())), "fail");
+		// The 2.46.0 boundary itself is strict.
+		assert_eq!(status(&build_check(Some(8), &v("2.46.0"), &strict())), "fail");
+	}
+
+	#[test]
+	fn outdated_warns_on_old_tamanu() {
+		assert_eq!(
+			status(&build_check(Some(8), &v("2.45.9"), &strict())),
+			"warning"
+		);
+		assert_eq!(
+			status(&build_check(Some(0), &v("2.0.0"), &strict())),
+			"warning"
+		);
+	}
+}


### PR DESCRIPTION
Adds a new doctor healthcheck (CHK-CFV) that verifies the version marker on a Windows Tamanu server's Caddyfile.
