### PR TITLE
fix(alertd): report and compare the bestool binary version in status

### DIFF
--- a/crates/alertd/src/commands/control.rs
+++ b/crates/alertd/src/commands/control.rs
@@ -16,7 +16,7 @@ async fn reprint_status(addrs: &[std::net::SocketAddr], attempts: u32) {
 	println!();
 	for attempt in 1..=attempts {
 		tokio::time::sleep(Duration::from_secs(1)).await;
-		match super::get_status(addrs).await {
+		match super::get_status(addrs, None).await {
 			Ok(()) => return,
 			Err(err) if attempt == attempts => {
 				println!("(daemon status not available yet: {err})");

--- a/crates/alertd/src/commands/status.rs
+++ b/crates/alertd/src/commands/status.rs
@@ -4,7 +4,15 @@ use tracing::info;
 use super::try_connect_daemon;
 use crate::http_server::StatusResponse;
 
-pub async fn get_status(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
+/// Print the daemon's status. `local_version`, when given, is the version of the
+/// `bestool` binary invoking this (not this crate's version); the daemon reports
+/// the same kind of version, so a difference means the on-disk binary is newer
+/// than the running daemon. `None` skips that comparison (e.g. the reprint right
+/// after a restart, when a difference is expected and about to resolve).
+pub async fn get_status(
+	addrs: &[std::net::SocketAddr],
+	local_version: Option<&str>,
+) -> miette::Result<()> {
 	let (client, url) = try_connect_daemon(addrs).await?;
 
 	// Fetch /status
@@ -41,19 +49,29 @@ pub async fn get_status(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
 
 	info!("connected to daemon at {url}");
 
-	let local_version = crate::VERSION;
+	// Destructure exhaustively (no `..`): a new StatusResponse field then fails to
+	// compile here until it's surfaced below.
+	let StatusResponse {
+		name,
+		version,
+		started_at,
+		pid,
+		backups_running,
+		backups_configured,
+	} = status;
 
-	println!("Name:      {}", status.name);
-	println!("Version:   {}", status.version);
-	if status.version != local_version {
+	println!("Name:      {name}");
+	println!("Version:   {version}");
+	if let Some(local_version) = local_version
+		&& version != local_version
+	{
 		println!(
-			"           WARNING: running daemon is {}, but this CLI is {local_version}",
-			status.version
+			"           WARNING: running daemon is {version}, but this CLI is {local_version}"
 		);
 		println!("           Run `bestool alertd restart` to pick up the new version.");
 	}
-	println!("PID:       {}", status.pid);
-	println!("Started:   {}", status.started_at);
+	println!("PID:       {pid}");
+	println!("Started:   {started_at}");
 
 	let healthy = health
 		.get("healthy")
@@ -85,14 +103,14 @@ pub async fn get_status(addrs: &[std::net::SocketAddr]) -> miette::Result<()> {
 		println!("Watchdog:  disabled");
 	}
 
-	if status.backups_configured.is_empty() {
+	if backups_configured.is_empty() {
 		println!("Backups:   none configured");
 	} else {
-		println!("Backups:   {}", status.backups_configured.join(", "));
+		println!("Backups:   {}", backups_configured.join(", "));
 	}
-	if !status.backups_running.is_empty() {
-		println!("  running: {}", status.backups_running.len());
-		for backup in &status.backups_running {
+	if !backups_running.is_empty() {
+		println!("  running: {}", backups_running.len());
+		for backup in &backups_running {
 			let descr = describe_latest(&backup.latest);
 			let run_id = backup.run_id.as_deref().unwrap_or("-");
 			println!(

--- a/crates/alertd/src/commands/status.rs
+++ b/crates/alertd/src/commands/status.rs
@@ -2,7 +2,7 @@ use miette::miette;
 use tracing::info;
 
 use super::try_connect_daemon;
-use crate::http_server::StatusResponse;
+use crate::http_server::{HealthResponse, StatusResponse};
 
 /// Print the daemon's status. `local_version`, when given, is the version of the
 /// `bestool` binary invoking this (not this crate's version); the daemon reports
@@ -42,7 +42,7 @@ pub async fn get_status(
 		.map_err(|e| miette!("failed to fetch health: {e}"))?;
 
 	let health_status_code = health_response.status().as_u16();
-	let health: serde_json::Value = health_response
+	let health: HealthResponse = health_response
 		.json()
 		.await
 		.map_err(|e| miette!("failed to parse health response: {e}"))?;
@@ -73,10 +73,14 @@ pub async fn get_status(
 	println!("PID:       {pid}");
 	println!("Started:   {started_at}");
 
-	let healthy = health
-		.get("healthy")
-		.and_then(|v| v.as_bool())
-		.unwrap_or(false);
+	// Destructure exhaustively (no `..`): a new HealthResponse field then fails to
+	// compile here until it's surfaced below.
+	let HealthResponse {
+		healthy,
+		last_activity_secs_ago,
+		uptime_secs,
+		watchdog_timeout_secs,
+	} = health;
 
 	if healthy {
 		println!("Health:    ok");
@@ -84,23 +88,16 @@ pub async fn get_status(
 		println!("Health:    UNHEALTHY (HTTP {health_status_code})");
 	}
 
-	if let Some(uptime) = health.get("uptime_secs").and_then(|v| v.as_i64()) {
-		println!("Uptime:    {}", format_duration(uptime));
+	println!("Uptime:    {}", format_duration(uptime_secs));
+
+	match last_activity_secs_ago {
+		Some(last) => println!("Last tick: {last}s ago"),
+		None => println!("Last tick: (none yet)"),
 	}
 
-	if let Some(last) = health
-		.get("last_activity_secs_ago")
-		.and_then(|v| v.as_i64())
-	{
-		println!("Last tick: {last}s ago");
-	} else {
-		println!("Last tick: (none yet)");
-	}
-
-	if let Some(timeout) = health.get("watchdog_timeout_secs").and_then(|v| v.as_u64()) {
-		println!("Watchdog:  {}", format_duration(timeout as i64));
-	} else {
-		println!("Watchdog:  disabled");
+	match watchdog_timeout_secs {
+		Some(timeout) => println!("Watchdog:  {}", format_duration(timeout as i64)),
+		None => println!("Watchdog:  disabled"),
 	}
 
 	if backups_configured.is_empty() {

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -161,6 +161,7 @@ pub async fn run_with_shutdown(
 		let server_addrs = daemon_config.server_addrs.clone();
 		let watchdog_timeout = daemon_config.watchdog_timeout;
 		let backups = daemon_config.backups.clone();
+		let binary_version = daemon_config.binary_version.clone();
 		tokio::spawn(async move {
 			http_server::start_server(
 				ctx_for_server,
@@ -169,6 +170,7 @@ pub async fn run_with_shutdown(
 				&background_tasks_for_server,
 				control,
 				backups,
+				binary_version,
 			)
 			.await;
 		});

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -33,6 +33,7 @@ pub async fn start_server(
 	background_tasks: &[Arc<dyn BackgroundTask>],
 	control: DaemonControl,
 	backups: Option<Arc<crate::BackupRegistry>>,
+	binary_version: String,
 ) {
 	let started_at = Timestamp::now();
 	let pid = std::process::id();
@@ -42,6 +43,7 @@ pub async fn start_server(
 	let state = ServerState {
 		started_at,
 		pid,
+		binary_version,
 		internal_context,
 		watchdog_timeout,
 		task_endpoints: Arc::new(task_endpoints),

--- a/crates/alertd/src/http_server/endpoints/health.rs
+++ b/crates/alertd/src/http_server/endpoints/health.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use jiff::Timestamp;
 
-use crate::{http_server::state::ServerState, metrics};
+use crate::{
+	http_server::{state::ServerState, types::HealthResponse},
+	metrics,
+};
 
 pub async fn handle_health(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
 	let last_activity = metrics::last_activity_timestamp();
@@ -25,12 +28,16 @@ pub async fn handle_health(State(state): State<Arc<ServerState>>) -> impl IntoRe
 		None => true,
 	};
 
-	let body = serde_json::json!({
-		"healthy": healthy,
-		"last_activity_secs_ago": if last_activity == 0 { None } else { Some(now.saturating_sub(last_activity)) },
-		"uptime_secs": now.saturating_sub(started_at),
-		"watchdog_timeout_secs": state.watchdog_timeout.map(|t| t.as_secs()),
-	});
+	let body = HealthResponse {
+		healthy,
+		last_activity_secs_ago: if last_activity == 0 {
+			None
+		} else {
+			Some(now.saturating_sub(last_activity))
+		},
+		uptime_secs: now.saturating_sub(started_at),
+		watchdog_timeout_secs: state.watchdog_timeout.map(|t| t.as_secs()),
+	};
 
 	let status = if healthy {
 		StatusCode::OK

--- a/crates/alertd/src/http_server/endpoints/status.rs
+++ b/crates/alertd/src/http_server/endpoints/status.rs
@@ -11,7 +11,9 @@ pub async fn handle_status(State(state): State<Arc<ServerState>>) -> impl IntoRe
 	};
 	let status = StatusResponse {
 		name: "bestool-alertd".to_string(),
-		version: env!("CARGO_PKG_VERSION").to_string(),
+		// The bestool binary's version — what self-update targets and what operators
+		// recognise — not this crate's independent version.
+		version: state.binary_version.clone(),
 		started_at: state.started_at.to_string(),
 		pid: state.pid,
 		backups_running,

--- a/crates/alertd/src/http_server/state.rs
+++ b/crates/alertd/src/http_server/state.rs
@@ -8,6 +8,9 @@ use crate::{context::InternalContext, daemon::DaemonControl, tasks::TaskEndpoint
 pub struct ServerState {
 	pub started_at: Timestamp,
 	pub pid: u32,
+	/// Version of the running `bestool` binary (not this crate's version), so
+	/// `/status` reports what self-update targets and operators recognise.
+	pub binary_version: String,
 	pub internal_context: Arc<InternalContext>,
 	pub watchdog_timeout: Option<Duration>,
 	/// Endpoint handlers exposed by registered background tasks. Keyed by

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -22,6 +22,7 @@ pub async fn create_test_state() -> Arc<ServerState> {
 	Arc::new(ServerState {
 		started_at: Timestamp::now(),
 		pid: std::process::id(),
+		binary_version: "0.0.0-test".to_string(),
 		internal_context: ctx,
 		watchdog_timeout: Some(std::time::Duration::from_secs(600)),
 		task_endpoints: Arc::new(HashMap::new()),

--- a/crates/alertd/src/http_server/types.rs
+++ b/crates/alertd/src/http_server/types.rs
@@ -15,3 +15,19 @@ pub struct StatusResponse {
 	#[serde(default)]
 	pub backups_configured: Vec<String>,
 }
+
+/// The `/health` response: the watchdog's view of the daemon's liveness.
+#[derive(Serialize, Deserialize)]
+pub struct HealthResponse {
+	/// Whether the daemon is within its watchdog window (always true when the
+	/// watchdog is disabled). The endpoint also signals this via the HTTP status.
+	pub healthy: bool,
+	/// Seconds since a background task last reported activity; `None` if none has
+	/// yet (freshly started).
+	pub last_activity_secs_ago: Option<i64>,
+	/// Seconds since the daemon started.
+	pub uptime_secs: i64,
+	/// The configured watchdog timeout in seconds; `None` when the watchdog is
+	/// disabled.
+	pub watchdog_timeout_secs: Option<u64>,
+}

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -139,7 +139,7 @@ pub async fn run(args: AlertdArgs, ctx: Context) -> Result<()> {
 			} else {
 				server_addr
 			};
-			bestool_alertd::commands::get_status(&addrs).await
+			bestool_alertd::commands::get_status(&addrs, Some(env!("CARGO_PKG_VERSION"))).await
 		}
 		Command::Reload { server_addr } => {
 			let addrs = if server_addr.is_empty() {


### PR DESCRIPTION
🤖 A successful Windows self-update logged:

```
WARN alert daemon restarted but is not on the expected version expected=1.48.0 running=18.1.0
```

The daemon's `/status` endpoint reported `env!("CARGO_PKG_VERSION")` — the `bestool-alertd` **crate's** version (18.x) — but self-update compares the daemon's reported version against the `bestool` release it just installed (1.x). Those are two independent version lines, so the check never matched and every successful update warned.

## Changes

- `/status` now reports `DaemonConfig.binary_version` — the running `bestool` binary's version, already threaded into the daemon for the systemd status line. Wired through `ServerState` and `start_server`.
- The `alertd status` subcommand had the mirror-image bug: it prints the daemon version and compared it against `crate::VERSION` (the alertd crate's version). That only matched because `/status` used to report that same crate version; now that `/status` reports the bestool version, the comparison needs the caller's bestool version too. `get_status` takes `local_version: Option<&str>` — `Some` from the standalone `status` command (the bestool binary's version), `None` for the post-reload/restart reprint where a difference is expected and about to resolve.
- `get_status` now destructures `StatusResponse` exhaustively (no `..`), so any future field must be surfaced here to compile. It already prints every field (name, version, pid, started_at, configured + running backups).
- Gave `/health` the same treatment: it was consumed as an untyped `serde_json::Value`, so new health fields went unnoticed. Added a shared `HealthResponse` struct (used by the endpoint and the client) and destructured it exhaustively in the subcommand.

The `status`/`health` endpoint unit tests need `DATABASE_URL` (pre-existing); the rest is covered by the existing suite.
