### PR TITLE
fix(canopy): create the VSS expose dir so VSS works, and log fallback causes

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/postgresql.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql.rs
@@ -104,9 +104,13 @@ pub async fn prepare(config: &PostgresqlConfig, backup_type: &str) -> Result<Pre
 		snapshot => match snapshot_prepared(snapshot, &resolved, backup_type, need).await {
 			Ok(prepared) => Ok(prepared),
 			Err(err) => {
+				// Render the whole cause chain: `Display` shows only the outermost
+				// context ("creating VSS shadow copy"), hiding the operative reason
+				// (the diskshadow/lvs error) that says *why* the snapshot failed.
 				warn!(
 					strategy = ?snapshot,
-					"snapshot backend unavailable ({err}); falling back to pg_basebackup"
+					"snapshot backend unavailable ({}); falling back to pg_basebackup",
+					super::trim_error(&err)
 				);
 				basebackup_prepared(&resolved, backup_type, config, need).await
 			}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/vss.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/vss.rs
@@ -123,6 +123,15 @@ pub async fn prepare(
 	// Sweep a shadow left exposed here by a crashed run before re-creating.
 	reap_stale(&expose_target).await;
 
+	// diskshadow's `expose` needs the mount path to already exist as an empty
+	// directory — it does not create it, and fails with "The mount path must be an
+	// empty directory" otherwise. Create it (first run); reap_stale above has
+	// unexposed any shadow previously mounted here, so it's empty.
+	tokio::fs::create_dir_all(&expose_target)
+		.await
+		.into_diagnostic()
+		.wrap_err_with(|| format!("creating the VSS expose directory {expose_target}"))?;
+
 	info!(volume = %volume, expose_target = %expose_target, "creating VSS shadow copy");
 	run_diskshadow(&create_script(&volume, &expose_target, &metadata.to_string_lossy()))
 		.await


### PR DESCRIPTION
🤖 On a Windows host, canopy backups always fell back from VSS to `pg_basebackup` — which then can't fit for a large DB. Two fixes, one root cause and one that hid it.

## Root cause: the VSS expose directory was never created

`diskshadow`'s `expose %alias% "<path>"` requires the mount path to **already exist as an empty directory** — it does not create it, and fails with `The mount path must be an empty directory` otherwise. bestool never created its expose target (`<vol>\bestool-backup-shadow\<type>`), so on any host where it didn't already exist:

- the shadow `create` succeeded, but
- `expose` failed → `vss::prepare` errored → the run fell back to `pg_basebackup`.

Confirmed by driving bestool's exact `diskshadow` script by hand: `create` succeeds, `expose` fails with that message. This fix creates the directory (after `reap_stale` unexposes any prior shadow there) so `expose` succeeds and the VSS path works.

## The error was hidden

The fallback warning rendered only the outermost context via `Display`:

```
WARN snapshot backend unavailable (creating VSS shadow copy); falling back to pg_basebackup
```

`(creating VSS shadow copy)` is just the `wrap_err` wrapper — the operative `diskshadow` error underneath was dropped. Where the DB is too big for the `pg_basebackup` fallback to fit, this fallback is the whole game, so the log needs to say why. Now it renders the full cause chain via the existing `trim_error` helper (e.g. `… (creating VSS shadow copy: diskshadow failed (exit code: 1): The mount path must be an empty directory); falling back to pg_basebackup`).

Verified: builds on Linux and the Windows GNU target (lib + tests), clippy/fmt clean.
