### PR TITLE
feat(alertd): fall back to DATABASE_URL for generic database checks

### DIFF
--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -91,6 +91,10 @@ pub struct CheckContext {
 	/// but no install files to inspect). Drives whether the version comes from
 	/// the install or the DB, and whether the install root is reported.
 	pub has_install: bool,
+	/// Whether the database is a Tamanu one. `false` when the context was
+	/// synthesised from the generic `DATABASE_URL` fallback: the registry runs
+	/// only the generic database checks and skips everything Tamanu-specific.
+	pub is_tamanu: bool,
 }
 
 /// Whether the doctor is running as root (euid 0).
@@ -190,15 +194,30 @@ pub struct CheckEntry {
 
 macro_rules! entry {
 	// Tamanu-dependent check: skipped without running when the host has no
-	// Tamanu deployment.
+	// Tamanu deployment — including when the only database is a generic
+	// (non-Tamanu) one from the `DATABASE_URL` fallback.
 	($name:literal, $module:ident) => {
+		entry!(@tamanu $name, $module, true)
+	};
+	// Tamanu-dependent check rendered to the CLI but kept OFF the canopy
+	// `health[]` wire array — for checks that report a value already carried as
+	// a top-level status fact, so they're useful locally but shouldn't alert.
+	($name:literal, $module:ident, off_wire) => {
+		entry!(@tamanu $name, $module, false)
+	};
+	(@tamanu $name:literal, $module:ident, $on_wire:literal) => {
 		CheckEntry {
 			name: $name,
-			on_wire: true,
+			on_wire: $on_wire,
 			run: |ctx| {
 				Box::pin(async move {
 					match ctx.tamanu {
-						Some(tamanu) => $module::run(tamanu).await,
+						Some(tamanu) if tamanu.is_tamanu => $module::run(tamanu).await,
+						Some(_) => Check::skip(
+							$name,
+							"no Tamanu on this host",
+							"check needs a Tamanu deployment; this host only has a generic database (DATABASE_URL)",
+						),
 						None => Check::skip(
 							$name,
 							"no Tamanu on this host",
@@ -209,21 +228,27 @@ macro_rules! entry {
 			},
 		}
 	};
-	// Tamanu-dependent check rendered to the CLI but kept OFF the canopy
-	// `health[]` wire array — for checks that report a value already carried as
-	// a top-level status fact, so they're useful locally but shouldn't alert.
-	($name:literal, $module:ident, off_wire) => {
+	// Generic database check: runs against any database context — Tamanu's or
+	// the generic `DATABASE_URL` fallback — and skips only when there is no
+	// database at all.
+	($name:literal, $module:ident, db) => {
+		entry!(@db $name, $module, true)
+	};
+	($name:literal, $module:ident, db, off_wire) => {
+		entry!(@db $name, $module, false)
+	};
+	(@db $name:literal, $module:ident, $on_wire:literal) => {
 		CheckEntry {
 			name: $name,
-			on_wire: false,
+			on_wire: $on_wire,
 			run: |ctx| {
 				Box::pin(async move {
 					match ctx.tamanu {
 						Some(tamanu) => $module::run(tamanu).await,
 						None => Check::skip(
 							$name,
-							"no Tamanu on this host",
-							"check needs a Tamanu deployment, and this host has none",
+							"no database on this host",
+							"check needs a database, and this host has neither a Tamanu deployment nor a DATABASE_URL",
 						),
 					}
 				})
@@ -252,12 +277,12 @@ macro_rules! entry {
 /// Order here is the order they appear in the CLI render.
 pub fn all() -> Vec<CheckEntry> {
 	vec![
-		entry!("db_connect", db_connect),
+		entry!("db_connect", db_connect, db),
 		// Reports the postgres version, which is already the top-level `pgVersion`
 		// status fact — useful in the CLI render, but off the wire.
-		entry!("db_version", db_version, off_wire),
+		entry!("db_version", db_version, db, off_wire),
 		entry!("migrations", migrations),
-		entry!("pg_tuning", pg_tuning),
+		entry!("pg_tuning", pg_tuning, db),
 		entry!("disk_free", disk_free, host),
 		entry!("inodes", inodes, host),
 		entry!("btrfs", btrfs, host),
@@ -376,6 +401,7 @@ pub mod test_support {
 			db: Some(db),
 			http_client: reqwest::Client::new(),
 			has_install: true,
+			is_tamanu: true,
 		})
 	}
 
@@ -391,6 +417,7 @@ pub mod test_support {
 			db: None,
 			http_client: reqwest::Client::new(),
 			has_install: true,
+			is_tamanu: true,
 		}
 	}
 }
@@ -432,6 +459,7 @@ mod tests {
 				db: None,
 				http_client: reqwest::Client::new(),
 				has_install: false,
+				is_tamanu: true,
 			}),
 			http_client: reqwest::Client::new(),
 		}
@@ -471,6 +499,60 @@ mod tests {
 			"db_connect should run (and fail) with a db-only context, got {:?}",
 			check.to_wire()["result"]
 		);
+	}
+
+	/// A context synthesised from a generic `DATABASE_URL` (not Tamanu's): the
+	/// generic database checks run, everything Tamanu-specific skips.
+	fn generic_db_ctx() -> SweepContext {
+		let mut ctx = db_only_ctx();
+		ctx.tamanu.as_mut().unwrap().is_tamanu = false;
+		ctx
+	}
+
+	#[tokio::test]
+	async fn generic_db_checks_run_with_generic_context() {
+		// db_connect only needs the URL; an unreachable one must FAIL (an
+		// alert), proving the generic context isn't gated out.
+		let entry = all().into_iter().find(|e| e.name == "db_connect").unwrap();
+		let check = (entry.run)(generic_db_ctx()).await;
+		assert!(
+			matches!(check.status, CheckStatus::Fail(_)),
+			"db_connect should run (and fail) with a generic-db context, got {:?}",
+			check.to_wire()["result"]
+		);
+	}
+
+	#[tokio::test]
+	async fn tamanu_checks_skip_with_generic_context() {
+		// A generic database isn't Tamanu's: checks that query Tamanu tables or
+		// inspect the deployment must skip rather than fail against it.
+		for name in [
+			"migrations",
+			"tamanu_http",
+			"tamanu_service",
+			"version_drift",
+			"sync_sessions",
+		] {
+			let entry = all().into_iter().find(|e| e.name == name).unwrap();
+			let check = (entry.run)(generic_db_ctx()).await;
+			assert!(
+				matches!(check.status, CheckStatus::Skip(_)),
+				"{name} should skip with a generic (non-Tamanu) database, got {:?}",
+				check.to_wire()["result"]
+			);
+		}
+	}
+
+	#[tokio::test]
+	async fn host_checks_run_with_generic_context() {
+		for name in ["memory", "disk_free", "uptime"] {
+			let entry = all().into_iter().find(|e| e.name == name).unwrap();
+			let check = (entry.run)(generic_db_ctx()).await;
+			assert!(
+				!matches!(check.status, CheckStatus::Skip(_)),
+				"{name} should run with a generic database context"
+			);
+		}
 	}
 
 	#[tokio::test]

--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -213,12 +213,9 @@ macro_rules! entry {
 				Box::pin(async move {
 					match ctx.tamanu {
 						Some(tamanu) if tamanu.is_tamanu => $module::run(tamanu).await,
-						Some(_) => Check::skip(
-							$name,
-							"no Tamanu on this host",
-							"check needs a Tamanu deployment; this host only has a generic database (DATABASE_URL)",
-						),
-						None => Check::skip(
+						// A generic (non-Tamanu) database context skips for the same
+						// reason as no context at all: there's no Tamanu here.
+						_ => Check::skip(
 							$name,
 							"no Tamanu on this host",
 							"check needs a Tamanu deployment, and this host has none",

--- a/crates/alertd/src/doctor/checks/db_connect.rs
+++ b/crates/alertd/src/doctor/checks/db_connect.rs
@@ -77,6 +77,7 @@ mod tests {
 			db: None,
 			http_client: reqwest::Client::new(),
 			has_install: true,
+			is_tamanu: true,
 		};
 		let check = run(ctx).await;
 		assert!(
@@ -115,6 +116,7 @@ mod tests {
 			db: None,
 			http_client: reqwest::Client::new(),
 			has_install: true,
+			is_tamanu: true,
 		};
 		let check = run(ctx).await;
 		match check.status {

--- a/crates/alertd/src/doctor/server_info.rs
+++ b/crates/alertd/src/doctor/server_info.rs
@@ -47,7 +47,10 @@ pub struct Filesystem {
 #[serde(rename_all = "camelCase")]
 pub struct ServerInfo {
 	pub bestool_version: String,
-	pub tamanu_version: String,
+	/// Version of the Tamanu deployment. Absent on hosts with no Tamanu,
+	/// including hosts with only a generic (non-Tamanu) database.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub tamanu_version: Option<String>,
 	/// Filesystem root of the Tamanu install, when one was found on disk.
 	/// Absent on hosts driven by `TAMANU_DATABASE_URL` alone (no install).
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -122,7 +125,11 @@ pub struct ServerFacts {
 /// provided by the caller (`env!("CARGO_PKG_VERSION")` resolved in the bestool
 /// crate) rather than evaluated here, since in this library crate it would
 /// resolve to the library's own version instead of the running binary's.
-pub async fn gather(bestool_version: &str, tamanu_version: &str, facts: ServerFacts) -> ServerInfo {
+pub async fn gather(
+	bestool_version: &str,
+	tamanu_version: Option<String>,
+	facts: ServerFacts,
+) -> ServerInfo {
 	let disks = Disks::new_with_refreshed_list();
 	let filesystems = disks
 		.iter()
@@ -152,7 +159,7 @@ pub async fn gather(bestool_version: &str, tamanu_version: &str, facts: ServerFa
 
 	ServerInfo {
 		bestool_version: bestool_version.to_string(),
-		tamanu_version: tamanu_version.to_string(),
+		tamanu_version,
 		tamanu_root: facts.tamanu_root,
 		tamanu_server_kind: facts.tamanu_server_kind,
 		node_version: detect_node_version().await,

--- a/crates/alertd/src/doctor/sweep.rs
+++ b/crates/alertd/src/doctor/sweep.rs
@@ -241,7 +241,10 @@ pub async fn perform_sweep(
 	// for a database-only host), kept for the wire payload after `tamanu_ctx` is
 	// moved into the check context below. The server kind and (when there's a
 	// real install) its root go into the top-level status facts too.
-	let resolved_version = tamanu_ctx.as_ref().map(|c| c.tamanu_version.clone());
+	let resolved_version = tamanu_ctx
+		.as_ref()
+		.filter(|c| c.is_tamanu)
+		.map(|c| c.tamanu_version.clone());
 	let tamanu_server_kind = tamanu_ctx
 		.as_ref()
 		.filter(|c| c.is_tamanu)
@@ -330,13 +333,11 @@ pub async fn perform_sweep(
 	// `binary_version` is the running binary's (bestool's) version, threaded in
 	// by the caller. Evaluating `env!("CARGO_PKG_VERSION")` here would resolve
 	// to this library's version instead, which is the wrong answer for the wire
-	// payload. On hosts with no Tamanu, `0.0.0` is the agreed sentinel — canopy
-	// requires a version on every payload and request. A database-only host
-	// reports the version resolved from its DB rather than the sentinel.
-	let tamanu_version = resolved_version
-		.map(|v| v.to_string())
-		.unwrap_or_else(|| "0.0.0".into());
-	let info = server_info::gather(binary_version, &tamanu_version, facts).await;
+	// payload. On hosts with no Tamanu (including generic-database-only hosts),
+	// `tamanuVersion` is omitted from the payload entirely. A Tamanu
+	// database-only host reports the version resolved from its DB.
+	let tamanu_version = resolved_version.map(|v| v.to_string());
+	let info = server_info::gather(binary_version, tamanu_version, facts).await;
 	let info_value = serde_json::to_value(&info).into_diagnostic()?;
 
 	let overall =
@@ -497,8 +498,8 @@ mod tests {
 		};
 		assert_eq!(result_of("tamanu_http"), "skipped");
 		assert_ne!(result_of("memory"), "skipped");
-		// The 0.0.0 sentinel marks "no Tamanu" on the wire.
-		assert_eq!(sweep.payload["tamanuVersion"], "0.0.0");
+		// No Tamanu means no tamanuVersion on the wire at all.
+		assert!(sweep.payload.get("tamanuVersion").is_none());
 	}
 
 	#[test]

--- a/crates/alertd/src/doctor/sweep.rs
+++ b/crates/alertd/src/doctor/sweep.rs
@@ -33,30 +33,72 @@ pub fn severity_ceiling(severities: &HashMap<String, CheckSeverity>, name: &str)
 		.unwrap_or(ABSENT_CHECK_SEVERITY)
 }
 
-/// The Tamanu deployment a sweep runs against, when the host has one.
+/// Environment variable holding a generic (non-Tamanu) `postgresql://` URL.
+///
+/// Consulted only when there is no Tamanu install and no
+/// [`TAMANU_DATABASE_URL`] override: the sweep still gets a database to run
+/// the generic postgres checks against, while Tamanu-specific checks skip.
+///
+/// [`TAMANU_DATABASE_URL`]: bestool_tamanu::config::DATABASE_URL_ENV
+pub const GENERIC_DATABASE_URL_ENV: &str = "DATABASE_URL";
+
+/// The [`GENERIC_DATABASE_URL_ENV`] fallback, if set to a non-empty value.
+fn generic_database_url() -> Option<String> {
+	std::env::var(GENERIC_DATABASE_URL_ENV)
+		.ok()
+		.filter(|s| !s.is_empty())
+}
+
+/// The database context a sweep runs against, when the host has one.
+///
+/// Usually a Tamanu deployment; with only a generic [`GENERIC_DATABASE_URL_ENV`]
+/// it's a bare postgres and `is_tamanu` is false.
 #[derive(Clone)]
 pub struct SweepTamanu {
 	pub version: Version,
 	pub root: PathBuf,
 	pub config: Arc<TamanuConfig>,
 	pub database_url: String,
-	/// `false` when this was synthesised from a `TAMANU_DATABASE_URL` with no
-	/// Tamanu install on the host: DB checks run, but install-dependent ones
+	/// `false` when this was synthesised from a database URL with no Tamanu
+	/// install on the host: DB checks run, but install-dependent ones
 	/// (the install metadata, local HTTP, caddy, services, kopia) skip.
 	pub has_install: bool,
+	/// `false` when the URL came from the generic [`GENERIC_DATABASE_URL_ENV`]
+	/// fallback: it points at a postgres that isn't necessarily Tamanu's, so
+	/// only the generic database checks run against it and Tamanu-specific
+	/// ones (which query Tamanu tables) skip.
+	pub is_tamanu: bool,
 }
 
-/// Resolve the Tamanu context for a sweep from an optionally-discovered install.
+/// Resolve the database context for a sweep from an optionally-discovered
+/// install.
 ///
 /// * `Some(install)` → a real install: its config is loaded and `has_install`
 ///   is true.
 /// * no install but [`TAMANU_DATABASE_URL`] set → a DB-only context synthesised
 ///   from that URL (`has_install` false) so DB checks still run against it.
-/// * neither → `None`: host-level checks only.
+/// * no install but [`GENERIC_DATABASE_URL_ENV`] set → a generic (non-Tamanu)
+///   database context (`is_tamanu` false): the generic DB checks run, all
+///   Tamanu-specific ones skip.
+/// * none of those → `None`: host-level checks only.
 ///
 /// [`TAMANU_DATABASE_URL`]: bestool_tamanu::config::DATABASE_URL_ENV
 pub fn resolve_sweep_tamanu(install: Option<(Version, PathBuf)>) -> Result<Option<SweepTamanu>> {
-	use bestool_tamanu::config::{Database, TamanuConfig, database_url_override, load_config};
+	resolve_sweep_tamanu_from(
+		install,
+		bestool_tamanu::config::database_url_override(),
+		generic_database_url(),
+	)
+}
+
+/// [`resolve_sweep_tamanu`] with the environment reads made explicit, so the
+/// resolution order is testable without mutating process-global env vars.
+fn resolve_sweep_tamanu_from(
+	install: Option<(Version, PathBuf)>,
+	tamanu_url: Option<String>,
+	generic_url: Option<String>,
+) -> Result<Option<SweepTamanu>> {
+	use bestool_tamanu::config::{Database, TamanuConfig, load_config};
 
 	match install {
 		Some((version, root)) => {
@@ -68,21 +110,25 @@ pub fn resolve_sweep_tamanu(install: Option<(Version, PathBuf)>) -> Result<Optio
 				config: Arc::new(config),
 				database_url,
 				has_install: true,
+				is_tamanu: true,
 			}))
 		}
-		None => match database_url_override() {
-			Some(url) => {
-				let db = Database::from_url(&url)?;
-				Ok(Some(SweepTamanu {
-					version: Version::parse("0.0.0").into_diagnostic()?,
-					root: PathBuf::new(),
-					config: Arc::new(TamanuConfig::from_database(db)),
-					database_url: url,
-					has_install: false,
-				}))
-			}
-			None => Ok(None),
-		},
+		None => {
+			let (url, is_tamanu) = match (tamanu_url, generic_url) {
+				(Some(url), _) => (url, true),
+				(None, Some(url)) => (url, false),
+				(None, None) => return Ok(None),
+			};
+			let db = Database::from_url(&url)?;
+			Ok(Some(SweepTamanu {
+				version: Version::parse("0.0.0").into_diagnostic()?,
+				root: PathBuf::new(),
+				config: Arc::new(TamanuConfig::from_database(db)),
+				database_url: url,
+				has_install: false,
+				is_tamanu,
+			}))
+		}
 	}
 }
 
@@ -152,17 +198,27 @@ pub async fn perform_sweep(
 					}
 				};
 
-			let kind = bestool_tamanu::detect_kind(&t.config, db.as_deref()).await;
-			debug!(?kind, "detected Tamanu server kind for doctor sweep");
+			// A generic (non-Tamanu) database has no Tamanu tables to inspect,
+			// so don't probe it for kind or version; the value is unused since
+			// every Tamanu-dependent check skips.
+			let kind = if t.is_tamanu {
+				let kind = bestool_tamanu::detect_kind(&t.config, db.as_deref()).await;
+				debug!(?kind, "detected Tamanu server kind for doctor sweep");
+				kind
+			} else {
+				bestool_tamanu::ApiServerKind::Central
+			};
 
 			// With a real install, the version is the env-file/install version.
 			// Without one (a `TAMANU_DATABASE_URL`-only host), fall back to the
 			// version Tamanu last recorded in its own DB (`currentVersion`), so
 			// version-aware checks can still run against it.
 			let tamanu_version = match (t.has_install, db.as_deref()) {
-				(false, Some(client)) => bestool_tamanu::versions::current_version(client)
-					.await
-					.unwrap_or_else(|| t.version.clone()),
+				(false, Some(client)) if t.is_tamanu => {
+					bestool_tamanu::versions::current_version(client)
+						.await
+						.unwrap_or_else(|| t.version.clone())
+				}
 				_ => t.version.clone(),
 			};
 
@@ -175,6 +231,7 @@ pub async fn perform_sweep(
 				db,
 				http_client: http_client.clone(),
 				has_install: t.has_install,
+				is_tamanu: t.is_tamanu,
 			})
 		}
 		None => None,
@@ -185,10 +242,13 @@ pub async fn perform_sweep(
 	// moved into the check context below. The server kind and (when there's a
 	// real install) its root go into the top-level status facts too.
 	let resolved_version = tamanu_ctx.as_ref().map(|c| c.tamanu_version.clone());
-	let tamanu_server_kind = tamanu_ctx.as_ref().map(|c| match c.kind {
-		bestool_tamanu::ApiServerKind::Central => "central",
-		bestool_tamanu::ApiServerKind::Facility => "facility",
-	});
+	let tamanu_server_kind = tamanu_ctx
+		.as_ref()
+		.filter(|c| c.is_tamanu)
+		.map(|c| match c.kind {
+			bestool_tamanu::ApiServerKind::Central => "central",
+			bestool_tamanu::ApiServerKind::Facility => "facility",
+		});
 	let tamanu_root = tamanu
 		.as_ref()
 		.filter(|t| t.has_install)
@@ -261,6 +321,7 @@ pub async fn perform_sweep(
 		tamanu.as_ref().map(|t| t.config.as_ref()),
 		db.as_deref(),
 		cached_pg_version,
+		tamanu.as_ref().is_none_or(|t| t.is_tamanu),
 	)
 	.await;
 	facts.tamanu_root = tamanu_root;
@@ -295,6 +356,7 @@ async fn collect_server_facts(
 	config: Option<&TamanuConfig>,
 	db: Option<&tokio_postgres::Client>,
 	cached_pg_version: Option<String>,
+	is_tamanu: bool,
 ) -> ServerFacts {
 	let mut facts = ServerFacts {
 		canonical_url: config
@@ -321,19 +383,23 @@ async fn collect_server_facts(
 		}
 	}
 
-	match client
-		.query_opt(
-			"SELECT value FROM local_system_facts WHERE key = 'currentSyncTick'",
-			&[],
-		)
-		.await
-	{
-		Ok(Some(row)) => match row.try_get::<_, String>(0) {
-			Ok(tick) => facts.current_sync_tick = Some(tick),
-			Err(err) => warn!("decoding currentSyncTick: {err}"),
-		},
-		Ok(None) => {}
-		Err(err) => warn!("querying currentSyncTick: {err}"),
+	// `local_system_facts` is a Tamanu table; a generic database has no
+	// sync tick to read.
+	if is_tamanu {
+		match client
+			.query_opt(
+				"SELECT value FROM local_system_facts WHERE key = 'currentSyncTick'",
+				&[],
+			)
+			.await
+		{
+			Ok(Some(row)) => match row.try_get::<_, String>(0) {
+				Ok(tick) => facts.current_sync_tick = Some(tick),
+				Err(err) => warn!("decoding currentSyncTick: {err}"),
+			},
+			Ok(None) => {}
+			Err(err) => warn!("querying currentSyncTick: {err}"),
+		}
 	}
 
 	facts
@@ -587,6 +653,40 @@ mod tests {
 		sweep.apply_severities(&HashMap::new());
 		assert_eq!(sweep.results[0].0.status.wire_result(), "warning");
 		assert_eq!(sweep.overall, OverallResult::Degraded);
+	}
+
+	#[test]
+	fn resolve_prefers_tamanu_url_over_generic() {
+		let resolved = resolve_sweep_tamanu_from(
+			None,
+			Some("postgresql://u@localhost/tamanu".into()),
+			Some("postgresql://u@localhost/other".into()),
+		)
+		.unwrap()
+		.unwrap();
+		assert_eq!(resolved.database_url, "postgresql://u@localhost/tamanu");
+		assert!(resolved.is_tamanu);
+		assert!(!resolved.has_install);
+	}
+
+	#[test]
+	fn resolve_falls_back_to_generic_database_url() {
+		let resolved =
+			resolve_sweep_tamanu_from(None, None, Some("postgresql://u@localhost/other".into()))
+				.unwrap()
+				.unwrap();
+		assert_eq!(resolved.database_url, "postgresql://u@localhost/other");
+		assert!(!resolved.is_tamanu);
+		assert!(!resolved.has_install);
+	}
+
+	#[test]
+	fn resolve_without_any_url_is_none() {
+		assert!(
+			resolve_sweep_tamanu_from(None, None, None)
+				.unwrap()
+				.is_none()
+		);
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -650,13 +650,21 @@ async fn build_config(ctx: &Context, daemon: DaemonArgs) -> Result<bestool_alert
 	let install: Option<(Version, PathBuf)> = bestool_tamanu::try_find_tamanu(root.as_deref()).await?;
 
 	// A real install, a DB-only context synthesised from `TAMANU_DATABASE_URL`,
-	// or `None`. The daemon still runs and posts sweeps in every case; with
-	// `None`, Tamanu/DB checks are skipped, but with only a database URL the DB
-	// checks run while install-dependent ones skip.
+	// a generic (non-Tamanu) one from `DATABASE_URL`, or `None`. The daemon
+	// still runs and posts sweeps in every case; with `None`, Tamanu/DB checks
+	// are skipped; with only a database URL the DB checks run while
+	// install-dependent ones skip; and with only a generic URL just the generic
+	// DB checks run.
 	let tamanu = resolve_sweep_tamanu(install)?;
 	match &tamanu {
-		Some(t) => debug!(has_install = t.has_install, "resolved Tamanu sweep context"),
-		None => warn!("no Tamanu install and no TAMANU_DATABASE_URL; Tamanu checks will skip"),
+		Some(t) => debug!(
+			has_install = t.has_install,
+			is_tamanu = t.is_tamanu,
+			"resolved database sweep context"
+		),
+		None => warn!(
+			"no Tamanu install, no TAMANU_DATABASE_URL, and no DATABASE_URL; Tamanu and database checks will skip"
+		),
 	}
 
 	// A pool error here means postgres is down or unreachable. Don't abort

--- a/services/bestool-alertd.service
+++ b/services/bestool-alertd.service
@@ -32,6 +32,8 @@ Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
 # (it varies per tamanu install), so it is not baked into this unit: the
 # deployment drops a /etc/systemd/system/bestool-alertd.service.d/*.conf
 # override with `Environment=TAMANU_DATABASE_URL=...` on the hosts that need it.
+# On hosts with a postgres but no Tamanu, `Environment=DATABASE_URL=...` runs
+# the generic (non-Tamanu) database checks against it instead.
 
 # Runs as root with a restricted capability bounding set rather than the full
 # root set. As uid 0 the kernel grants the whole bounding set into the effective


### PR DESCRIPTION
When there is no Tamanu install and no `TAMANU_DATABASE_URL`, the doctor sweep now falls back to a plain `DATABASE_URL` so a host with a postgres but no Tamanu still gets database monitoring.

- `resolve_sweep_tamanu` gains the fallback, with a new `is_tamanu` flag on `SweepTamanu`/`CheckContext` (`TAMANU_DATABASE_URL` still takes precedence).
- The check registry gains a generic `db` class: `db_connect`, `db_version`, and `pg_tuning` run against any database, while Tamanu-specific checks skip with the usual "no Tamanu on this host" reason.
- A generic database is never probed for Tamanu kind/version or `currentSyncTick`, and `tamanuServerKind` isn't reported for it.
- `tamanuVersion` is now omitted from the wire payload on hosts with no Tamanu, instead of the `0.0.0` sentinel.
- The systemd unit comment documents the `DATABASE_URL` override.

Tests cover the resolution order, per-class run/skip behaviour against a generic database context, and the absent `tamanuVersion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J1hLn1MoiEifePC1jNaA6

---
_Generated by [Claude Code](https://claude.ai/code/session_016J1hLn1MoiEifePC1jNaA6)_