### PR TITLE
feat(tamanu): disable bottom-up ASLR for postgres on Windows, warn in doctor when unset

### DIFF
--- a/crates/alertd/src/doctor/checks/pg_tuning.rs
+++ b/crates/alertd/src/doctor/checks/pg_tuning.rs
@@ -256,6 +256,61 @@ const SETTINGS_QUERY: &str = "
 		current_setting('server_version_num')::bigint          AS server_version_num
 ";
 
+/// On Windows, warn when bottom-up ASLR is still enabled for the PostgreSQL
+/// executables — the missing "could not reattach to shared memory" mitigation
+/// that `bestool tamanu pg-tune` applies. Warn-only, and silent when the state
+/// can't be read, so a health sweep never alarms on a guess. A no-op elsewhere.
+#[cfg(windows)]
+async fn bottom_up_aslr_findings() -> Vec<Finding> {
+	let exes = ["postgres.exe", "pg_ctl.exe"];
+	let script = exes
+		.iter()
+		.map(|exe| format!("(Get-ProcessMitigation -Name '{exe}').Aslr.BottomUp"))
+		.collect::<Vec<_>>()
+		.join("; ");
+
+	let output = match tokio::process::Command::new("powershell")
+		.args(["-NoProfile", "-NonInteractive", "-Command", &script])
+		.output()
+		.await
+	{
+		Ok(output) if output.status.success() => output,
+		_ => return Vec::new(),
+	};
+
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	stdout
+		.lines()
+		.map(str::trim)
+		.filter(|line| !line.is_empty())
+		.zip(exes)
+		.filter(|&(line, _)| parse_bottom_up(line) == Some(false))
+		.map(|(_, exe)| Finding {
+			severity: Severity::Warn,
+			message: format!(
+				"bottom-up ASLR is still enabled for {exe} — risks the \"could not reattach to shared memory\" crash on start; disable it (bestool tamanu pg-tune does)"
+			),
+		})
+		.collect()
+}
+
+#[cfg(not(windows))]
+async fn bottom_up_aslr_findings() -> Vec<Finding> {
+	Vec::new()
+}
+
+/// Map the `Aslr.BottomUp` value Get-ProcessMitigation prints (`ON`/`OFF`/
+/// `NOTSET`) to whether the mitigation is disabled (`OFF`). `None` for anything
+/// unexpected, so the caller stays quiet rather than warning on a guess.
+#[cfg(windows)]
+fn parse_bottom_up(value: &str) -> Option<bool> {
+	match value.trim().to_ascii_uppercase().as_str() {
+		"OFF" => Some(true),
+		"ON" | "NOTSET" => Some(false),
+		_ => None,
+	}
+}
+
 pub async fn run(ctx: CheckContext) -> Check {
 	if !is_local(ctx.config.db.host.as_deref()) {
 		return Check::skip(
@@ -303,7 +358,8 @@ pub async fn run(ctx: CheckContext) -> Check {
 	}
 
 	let pg_major = (settings.server_version_num / 10000).max(0) as u32;
-	let findings = assess(&settings, total_ram, Platform::current(), pg_major);
+	let mut findings = assess(&settings, total_ram, Platform::current(), pg_major);
+	findings.extend(bottom_up_aslr_findings().await);
 
 	let summary = match findings.len() {
 		0 => "appears tuned".to_string(),
@@ -590,6 +646,16 @@ mod tests {
 			check.status.wire_result(),
 			check.status.reason().unwrap_or_default(),
 		);
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn parses_bottom_up_aslr_state() {
+		assert_eq!(parse_bottom_up("OFF"), Some(true));
+		assert_eq!(parse_bottom_up("off\r\n"), Some(true));
+		assert_eq!(parse_bottom_up("ON"), Some(false));
+		assert_eq!(parse_bottom_up("NOTSET"), Some(false));
+		assert_eq!(parse_bottom_up("wat"), None);
 	}
 
 	#[test]

--- a/crates/bestool/src/actions/tamanu/pg_tune.rs
+++ b/crates/bestool/src/actions/tamanu/pg_tune.rs
@@ -7,7 +7,9 @@
 //! checked against the server's own accepted range before anything is written,
 //! so a value PostgreSQL would reject never reaches the file — otherwise a
 //! later restart, ours or an unrelated reboot, would fail to start the server.
-//! It then reloads PostgreSQL so the reloadable settings take effect
+//! It also disables bottom-up ASLR for the PostgreSQL executables, the
+//! mitigation for the Windows "could not reattach to shared memory" startup
+//! crash. It then reloads PostgreSQL so the reloadable settings take effect
 //! immediately, and only when some settings still need a restart does it offer
 //! to restart PostgreSQL and then the Tamanu workloads.
 //!
@@ -136,6 +138,8 @@ pub async fn run(args: PgTuneArgs, ctx: Context) -> Result<()> {
 		info!("dry run: not writing {}", conf_path.display());
 		return Ok(());
 	}
+
+	ensure_bottom_up_aslr_disabled().await;
 
 	if updated == existing {
 		info!("already tuned; postgresql.conf is unchanged");
@@ -361,6 +365,42 @@ async fn reload_pg(data_dir: &Path) -> Result<()> {
 		);
 	}
 	Ok(())
+}
+
+/// Disable bottom-up ASLR for the PostgreSQL executables — the documented
+/// mitigation for the Windows "could not reattach to shared memory" startup
+/// crash, where a forked child can't map the shared memory segment at the
+/// address the postmaster used because ASLR relocated something into it.
+/// Idempotent and best-effort: a failure warns rather than aborting, since the
+/// tuning itself has already been applied.
+async fn ensure_bottom_up_aslr_disabled() {
+	// -ErrorAction Stop turns a cmdlet error into a terminating one, so a
+	// failure shows up as a non-zero exit rather than a note on stdout.
+	let script = "$ErrorActionPreference = 'Stop'; \
+		Set-ProcessMitigation -Name postgres.exe -Disable BottomUp; \
+		Set-ProcessMitigation -Name pg_ctl.exe -Disable BottomUp";
+	match run_powershell(script).await {
+		Ok(output) if output.status.success() => {
+			info!("disabled bottom-up ASLR for postgres.exe and pg_ctl.exe");
+		}
+		Ok(output) => warn!(
+			"could not disable bottom-up ASLR for PostgreSQL (see the runbook): {}",
+			String::from_utf8_lossy(&output.stderr).trim()
+		),
+		Err(err) => {
+			warn!(%err, "could not run Set-ProcessMitigation to disable bottom-up ASLR (see the runbook)");
+		}
+	}
+}
+
+/// Run a PowerShell one-liner and capture its output.
+async fn run_powershell(script: &str) -> Result<std::process::Output> {
+	tokio::process::Command::new("powershell")
+		.args(["-NoProfile", "-NonInteractive", "-Command", script])
+		.output()
+		.await
+		.into_diagnostic()
+		.wrap_err("running powershell")
 }
 
 /// The names of settings that changed but need a full restart to take effect,


### PR DESCRIPTION
🤖 Follow-up to #730/#733 (both merged). Adds the bottom-up ASLR mitigation for the Windows "could not reattach to shared memory" startup crash, which is what our runbook has been handling manually. That crash happens when a forked postgres backend can't map the shared-memory segment at the same address the postmaster used, because ASLR relocated something into it; disabling bottom-up ASLR for the postgres executables is the documented fix.

## Two pieces

- **`pg-tune` applies it.** After the dry-run guard (so it runs on every real invocation, even when the config is already tuned), it runs `Set-ProcessMitigation -Name postgres.exe -Disable BottomUp` (and `pg_ctl.exe`) via PowerShell. Idempotent, and best-effort: if it can't set the mitigation it warns and points at the runbook rather than aborting the tuning that already succeeded. `BottomUp` is a confirmed `-Disable` keyword ([Set-ProcessMitigation docs](https://learn.microsoft.com/en-us/powershell/module/processmitigations/set-processmitigation)).
- **The alertd `pg_tuning` doctor check warns when it's unset** (Windows only, warn-only). It reads `(Get-ProcessMitigation -Name postgres.exe).Aslr.BottomUp` and warns if either executable's bottom-up ASLR is still `ON`/`NOTSET`. It stays silent when the state can't be read, so a sweep never alarms on a guess. One PowerShell invocation per sweep (both executables in one call) to keep the daemon light.

IFEO keys on the executable **name**, not path, so setting it once covers future same-named binaries (survives minor PostgreSQL upgrades).

Windows-only paths throughout; `cargo check`/`clippy`/`fmt` pass for both crates on `x86_64-pc-windows-gnu` and on Linux (the doctor check compiles cross-platform, with the detection `#[cfg(windows)]`-gated). Adds a unit test for the `ON`/`OFF`/`NOTSET` parsing.
