### PR TITLE
feat(alertd): check-declared metrics on /metrics for munin and prometheus

### DIFF
--- a/.github/workflows/release-bestool.yml
+++ b/.github/workflows/release-bestool.yml
@@ -151,6 +151,12 @@ jobs:
           install -Dm644 services/bestool-alertd.service \
             "$deb_dir/usr/lib/systemd/system/bestool-alertd.service"
 
+          # Munin plugin for alertd's /metrics endpoint. Shipped into munin's
+          # available-plugins dir; the postinst activates it only when munin-node
+          # is installed, mirroring how the alertd unit ships disabled.
+          install -Dm755 contrib/munin/bestool_alertd \
+            "$deb_dir/usr/share/munin/plugins/bestool_alertd"
+
           # daemon-reload after install/upgrade/removal so systemd picks up unit
           # changes. The unit ships disabled, so nothing is enabled or started.
           cat > "$deb_dir/DEBIAN/postinst" << 'EOF'
@@ -158,6 +164,14 @@ jobs:
           set -e
           if [ -d /run/systemd/system ]; then
             systemctl daemon-reload || true
+          fi
+          # Activate the munin plugin where munin-node is present; a no-op
+          # elsewhere. Present-but-inactive otherwise, like the alertd unit.
+          if [ -d /etc/munin/plugins ] && [ ! -e /etc/munin/plugins/bestool_alertd ]; then
+            ln -s /usr/share/munin/plugins/bestool_alertd /etc/munin/plugins/bestool_alertd || true
+            if [ -d /run/systemd/system ]; then
+              systemctl try-reload-or-restart munin-node || true
+            fi
           fi
           EOF
           chmod 755 "$deb_dir/DEBIAN/postinst"
@@ -167,6 +181,14 @@ jobs:
           set -e
           if [ -d /run/systemd/system ]; then
             systemctl daemon-reload || true
+          fi
+          # On removal (not upgrade), drop the munin plugin symlink we created.
+          if { [ "$1" = remove ] || [ "$1" = purge ]; } \
+            && [ -L /etc/munin/plugins/bestool_alertd ]; then
+            rm -f /etc/munin/plugins/bestool_alertd || true
+            if [ -d /run/systemd/system ]; then
+              systemctl try-reload-or-restart munin-node || true
+            fi
           fi
           EOF
           chmod 755 "$deb_dir/DEBIAN/postrm"

--- a/contrib/munin/bestool_alertd
+++ b/contrib/munin/bestool_alertd
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Munin plugin for bestool-alertd: harvests the daemon's /metrics endpoint,
+# which serves munin-native output when asked with `Accept: text/x-munin`.
+#
+# Configuration (optional), in /etc/munin/plugin-conf.d/:
+#   [bestool_alertd]
+#   env.url http://[::1]:8271
+#
+# Activate by symlinking into /etc/munin/plugins/ and reloading munin-node. The
+# bestool deb does this automatically when munin-node is installed.
+
+set -eu
+
+accept='Accept: text/x-munin'
+
+# The daemon binds only the first loopback address it can (default [::1]:8271,
+# then 127.0.0.1:8271), so try IPv6 loopback first and fall back to IPv4 —
+# mirroring the daemon's own ordering. env.url pins a single base and skips the
+# probe.
+if [ -n "${url:-}" ]; then
+	bases="$url"
+else
+	bases="http://[::1]:8271 http://127.0.0.1:8271"
+fi
+
+# Fetch $1 (a path) from the first base that answers; print its body.
+fetch() {
+	for base in $bases; do
+		if body=$(curl -fsS -H "$accept" "$base$1" 2>/dev/null); then
+			printf '%s\n' "$body"
+			return 0
+		fi
+	done
+	return 1
+}
+
+case "${1:-}" in
+	autoconf)
+		if fetch /metrics >/dev/null 2>&1; then
+			echo yes
+		else
+			echo "no (bestool-alertd not reachable)"
+		fi
+		;;
+	config)
+		fetch "/metrics?config"
+		;;
+	*)
+		fetch /metrics
+		;;
+esac

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -161,6 +161,7 @@ pub async fn run_with_shutdown(
 		let server_addrs = daemon_config.server_addrs.clone();
 		let watchdog_timeout = daemon_config.watchdog_timeout;
 		let backups = daemon_config.backups.clone();
+		let metrics = daemon_config.metrics.clone();
 		let binary_version = daemon_config.binary_version.clone();
 		tokio::spawn(async move {
 			http_server::start_server(
@@ -170,6 +171,7 @@ pub async fn run_with_shutdown(
 				&background_tasks_for_server,
 				control,
 				backups,
+				metrics,
 				binary_version,
 			)
 			.await;

--- a/crates/alertd/src/doctor.rs
+++ b/crates/alertd/src/doctor.rs
@@ -2,10 +2,12 @@ pub mod check;
 pub mod checks;
 pub mod progress;
 pub mod server_info;
+pub mod stat;
 pub mod sweep;
 pub mod task;
 
+pub use stat::{MetricsSnapshot, Stat, StatKind, StatusCounts};
 pub use sweep::{
 	SweepResult, SweepTamanu, overall_from_payload, perform_sweep, resolve_sweep_tamanu,
 };
-pub use task::{BackupDispatch, DoctorTask};
+pub use task::{BackupDispatch, DoctorMetricsHandle, DoctorTask};

--- a/crates/alertd/src/doctor/check.rs
+++ b/crates/alertd/src/doctor/check.rs
@@ -1,6 +1,8 @@
 use bestool_canopy::schema::CheckSeverity;
 use serde_json::{Map, Value, json};
 
+use crate::doctor::stat::Stat;
+
 /// Outcome of a single healthcheck.
 ///
 /// Serialised on the wire as the per-check `result` field, a proper sum type
@@ -104,6 +106,10 @@ pub struct Check {
 	/// for instance) that belongs with server facts, not with
 	/// diagnostics.
 	pub payload_extras: Map<String, Value>,
+	/// Typed numeric metrics this check declares for the alertd `/metrics`
+	/// endpoint. Independent of `details`: the same number may be attached to
+	/// both. Never posted to canopy; rendered to munin/prometheus text only.
+	pub stats: Vec<Stat>,
 }
 
 impl Check {
@@ -114,6 +120,7 @@ impl Check {
 			summary: summary.into(),
 			details: Map::new(),
 			payload_extras: Map::new(),
+			stats: Vec::new(),
 		}
 	}
 
@@ -127,6 +134,7 @@ impl Check {
 			summary: summary.into(),
 			details: Map::new(),
 			payload_extras: Map::new(),
+			stats: Vec::new(),
 		}
 	}
 
@@ -141,6 +149,7 @@ impl Check {
 			summary: summary.into(),
 			details: Map::new(),
 			payload_extras: Map::new(),
+			stats: Vec::new(),
 		}
 	}
 
@@ -151,6 +160,7 @@ impl Check {
 			summary: summary.into(),
 			details: Map::new(),
 			payload_extras: Map::new(),
+			stats: Vec::new(),
 		}
 	}
 
@@ -167,6 +177,7 @@ impl Check {
 			summary: summary.into(),
 			details: Map::new(),
 			payload_extras: Map::new(),
+			stats: Vec::new(),
 		}
 	}
 
@@ -185,6 +196,19 @@ impl Check {
 	/// entry. See [`Self::payload_extras`].
 	pub fn with_payload_extra(mut self, key: &str, value: impl Into<Value>) -> Self {
 		self.payload_extras.insert(key.to_string(), value.into());
+		self
+	}
+
+	/// Declare a numeric metric for the alertd `/metrics` endpoint. See
+	/// [`Self::stats`] and [`Stat`].
+	pub fn with_stat(mut self, stat: Stat) -> Self {
+		self.stats.push(stat);
+		self
+	}
+
+	/// Declare several metrics at once. See [`Self::with_stat`].
+	pub fn with_stats(mut self, stats: impl IntoIterator<Item = Stat>) -> Self {
+		self.stats.extend(stats);
 		self
 	}
 
@@ -269,6 +293,7 @@ impl Check {
 			summary,
 			details,
 			payload_extras: Map::new(),
+			stats: Vec::new(),
 		})
 	}
 }

--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -38,6 +38,7 @@ pub mod ips_errors;
 pub mod load;
 pub mod memory;
 pub mod migrations;
+pub mod munin;
 pub mod patient_communication_errors;
 pub mod pg_tuning;
 pub mod report_errors;
@@ -313,6 +314,9 @@ pub fn all() -> Vec<CheckEntry> {
 		// Reports the host's LAN and best-guess WAN addresses as status facts
 		// (off the wire; carried in the top-level payload, like the timezone).
 		entry!("ips", ips, host, off_wire),
+		// Reports whether munin-node is installed as a top-level status fact
+		// (off the wire, like `ips`); not a health signal.
+		entry!("munin", munin, host, off_wire),
 		entry!("billing_tags", billing_tags, host),
 		// Tamanu-level: the config-derived FHIR expectation degrades to Unknown
 		// without config (see `services::expected`); the rest is DB/host-derived.

--- a/crates/alertd/src/doctor/checks/caddy_certs.rs
+++ b/crates/alertd/src/doctor/checks/caddy_certs.rs
@@ -40,6 +40,7 @@ use tracing::debug;
 use x509_parser::prelude::*;
 
 use super::SweepContext;
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 const NAME: &str = "caddy_certs";
@@ -147,6 +148,7 @@ pub async fn run(ctx: SweepContext) -> Check {
 	let mut details: Vec<Value> = Vec::new();
 	let mut seen: HashSet<Vec<u8>> = HashSet::new();
 
+	let mut stats: Vec<Stat> = Vec::new();
 	for (origin, cert) in &certs {
 		if !seen.insert(cert.der.clone()) {
 			continue; // same cert reached via multiple subjects/sources
@@ -191,6 +193,20 @@ pub async fn run(ctx: SweepContext) -> Check {
 			}
 		}
 
+		let cert_id = cert.sans.first().cloned().unwrap_or_else(|| origin.clone());
+		stats.push(
+			Stat::gauge("days_remaining", (days * 10.0).round() / 10.0)
+				.label("cert", cert_id.clone())
+				.help("Days until certificate expiry"),
+		);
+		if let Some(matches) = served_matches {
+			stats.push(
+				Stat::gauge("served_matches", if matches { 1.0 } else { 0.0 })
+					.label("cert", cert_id)
+					.help("Served cert matches configured cert (1/0)"),
+			);
+		}
+
 		details.push(json!({
 			"names": cert.sans,
 			"origin": origin,
@@ -213,7 +229,10 @@ pub async fn run(ctx: SweepContext) -> Check {
 		Some(Sev::Warn) => Check::warning(NAME, format!("{n} cert(s) checked"), reasons),
 		None => Check::pass(NAME, format!("{n} cert(s) valid")),
 	};
-	check.with_detail("certificates", Value::Array(details))
+	check
+		.with_detail("certificates", Value::Array(details))
+		.with_stat(Stat::gauge("count", n as f64).help("Certificates checked"))
+		.with_stats(stats)
 }
 
 /// caddy's `certificates/` store, probed at the well-known data-dir locations

--- a/crates/alertd/src/doctor/checks/caddyfile_version.rs
+++ b/crates/alertd/src/doctor/checks/caddyfile_version.rs
@@ -57,7 +57,8 @@ pub async fn run(ctx: CheckContext) -> Check {
 	};
 
 	let version = parse_caddyfile_version(contents.lines().next().unwrap_or_default());
-	let strict_from = Version::parse(TAMANU_STRICT_FROM).expect("TAMANU_STRICT_FROM is valid semver");
+	let strict_from =
+		Version::parse(TAMANU_STRICT_FROM).expect("TAMANU_STRICT_FROM is valid semver");
 	let check = build_check(version, &ctx.tamanu_version, &strict_from);
 	match version {
 		Some(v) => check.with_detail("caddyfile_version", v),
@@ -171,8 +172,14 @@ mod tests {
 
 	#[test]
 	fn current_version_passes() {
-		assert_eq!(status(&build_check(Some(9), &v("2.50.0"), &strict())), "pass");
-		assert_eq!(status(&build_check(Some(9), &v("2.30.0"), &strict())), "pass");
+		assert_eq!(
+			status(&build_check(Some(9), &v("2.50.0"), &strict())),
+			"pass"
+		);
+		assert_eq!(
+			status(&build_check(Some(9), &v("2.30.0"), &strict())),
+			"pass"
+		);
 		assert_eq!(
 			status(&build_check(Some(10), &v("2.30.0"), &strict())),
 			"pass"
@@ -181,9 +188,15 @@ mod tests {
 
 	#[test]
 	fn outdated_fails_on_new_tamanu() {
-		assert_eq!(status(&build_check(Some(8), &v("2.50.0"), &strict())), "fail");
+		assert_eq!(
+			status(&build_check(Some(8), &v("2.50.0"), &strict())),
+			"fail"
+		);
 		// The 2.46.0 boundary itself is strict.
-		assert_eq!(status(&build_check(Some(8), &v("2.46.0"), &strict())), "fail");
+		assert_eq!(
+			status(&build_check(Some(8), &v("2.46.0"), &strict())),
+			"fail"
+		);
 	}
 
 	#[test]

--- a/crates/alertd/src/doctor/checks/db_connect.rs
+++ b/crates/alertd/src/doctor/checks/db_connect.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use super::{CheckContext, fmt_db_error};
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 /// Connect latency above which the DB is treated as degraded.
@@ -46,6 +47,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 		.with_detail("db_host", host)
 		.with_detail("db_name", name)
 		.with_detail("latency_ms", latency_ms)
+		.with_stat(Stat::gauge("latency_ms", latency_ms as f64).help("Postgres connect latency"))
 }
 
 #[cfg(test)]

--- a/crates/alertd/src/doctor/checks/disk_free.rs
+++ b/crates/alertd/src/doctor/checks/disk_free.rs
@@ -4,6 +4,7 @@ use serde_json::{Map, Value, json};
 use sysinfo::Disks;
 
 use super::SweepContext;
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 const WARN_PCT_USED: f64 = 80.0;
@@ -45,6 +46,7 @@ pub async fn run(ctx: SweepContext) -> Check {
 	let mut worst_pct: f64 = 0.0;
 	let mut worst_summary = String::new();
 	let mut mounts: Vec<Value> = Vec::new();
+	let mut stats: Vec<Stat> = Vec::new();
 
 	for disk in considered {
 		let total = disk.total_space();
@@ -65,8 +67,24 @@ pub async fn run(ctx: SweepContext) -> Check {
 				human_bytes(total)
 			);
 		}
+		let mount = disk.mount_point().to_string_lossy().into_owned();
+		stats.push(
+			Stat::gauge("free_bytes", free as f64)
+				.label("mount", mount.clone())
+				.help("Free disk space"),
+		);
+		stats.push(
+			Stat::gauge("total_bytes", total as f64)
+				.label("mount", mount.clone())
+				.help("Total disk space"),
+		);
+		stats.push(
+			Stat::gauge("percent_used", pct)
+				.label("mount", mount.clone())
+				.help("Disk used, percent"),
+		);
 		mounts.push(json!({
-			"mountpoint": disk.mount_point().to_string_lossy(),
+			"mountpoint": mount,
 			"free_bytes": free,
 			"total_bytes": total,
 			"percent_used": pct,
@@ -91,7 +109,7 @@ pub async fn run(ctx: SweepContext) -> Check {
 	} else {
 		Check::pass("disk_free", worst_summary)
 	};
-	check.with_details(details)
+	check.with_details(details).with_stats(stats)
 }
 
 fn best_mount_for<'a>(disks: &'a Disks, path: &Path) -> Option<&'a sysinfo::Disk> {

--- a/crates/alertd/src/doctor/checks/fhir_jobs.rs
+++ b/crates/alertd/src/doctor/checks/fhir_jobs.rs
@@ -10,6 +10,7 @@ use jiff::Timestamp;
 use serde_json::{Map, Value};
 
 use super::{CheckContext, query_error_check};
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 const WARN_DEPTH: i64 = 200;
@@ -53,7 +54,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 	let active: i64 = row.try_get("active_depth").unwrap_or(0);
 	let oldest_active: Option<Timestamp> = row.try_get("oldest_active").ok();
 
-	let by_status_value = match client
+	let (by_status_value, by_status_counts) = match client
 		.query(
 			"SELECT status, count(*)::bigint AS n FROM fhir.jobs GROUP BY status",
 			&[],
@@ -62,14 +63,16 @@ pub async fn run(ctx: CheckContext) -> Check {
 	{
 		Ok(rows) => {
 			let mut by: Map<String, Value> = Map::new();
+			let mut counts: Vec<(String, i64)> = Vec::new();
 			for row in rows {
 				let status: String = row.try_get("status").unwrap_or_default();
 				let n: i64 = row.try_get("n").unwrap_or(0);
-				by.insert(status, Value::from(n));
+				by.insert(status.clone(), Value::from(n));
+				counts.push((status, n));
 			}
-			Value::Object(by)
+			(Value::Object(by), counts)
 		}
-		Err(_) => Value::Object(Map::new()),
+		Err(_) => (Value::Object(Map::new()), Vec::new()),
 	};
 
 	let oldest_age_secs = oldest_active
@@ -103,11 +106,23 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 	let mut check = check
 		.with_detail("active_depth", active)
-		.with_detail("by_status", by_status_value);
+		.with_detail("by_status", by_status_value)
+		.with_stat(
+			Stat::gauge("active_depth", active as f64).help("Active FHIR jobs (not Errored)"),
+		)
+		.with_stats(by_status_counts.into_iter().map(|(status, n)| {
+			Stat::gauge("jobs", n as f64)
+				.label("status", status)
+				.help("FHIR jobs by status")
+		}));
 	if let Some(ts) = oldest_active {
 		check = check
 			.with_detail("oldest_active", ts.to_string())
-			.with_detail("oldest_active_age_secs", oldest_age_secs);
+			.with_detail("oldest_active_age_secs", oldest_age_secs)
+			.with_stat(
+				Stat::gauge("oldest_active_age_secs", oldest_age_secs as f64)
+					.help("Age of the oldest active FHIR job"),
+			);
 	}
 	check
 }

--- a/crates/alertd/src/doctor/checks/http_errors.rs
+++ b/crates/alertd/src/doctor/checks/http_errors.rs
@@ -30,6 +30,7 @@ use serde_json::{Map, Value};
 use tracing::{debug, warn};
 
 use super::{SweepContext, fmt_chain};
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 const CADDY_METRICS_URL: &str = "http://localhost:2019/metrics";
@@ -200,7 +201,10 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		)
 		.with_detail("total_requests", 0u64)
 		.with_detail("window_seconds", window.as_secs())
-		.with_detail("baseline_source", source_label);
+		.with_detail("baseline_source", source_label)
+		.with_stat(Stat::gauge("requests", 0.0).help("Requests in the window"))
+		.with_stat(Stat::gauge("server_errors", 0.0).help("5xx responses in the window"))
+		.with_stat(Stat::gauge("window_seconds", window.as_secs() as f64));
 	}
 
 	let pct = ((errored as f64 / total as f64) * 100.0).round();
@@ -236,6 +240,15 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		.with_detail("window_seconds", window.as_secs())
 		.with_detail("baseline_source", source_label)
 		.with_detail("by_code", Value::Object(by_code))
+		.with_stat(Stat::gauge("requests", total as f64).help("Requests in the window"))
+		.with_stat(Stat::gauge("server_errors", errored as f64).help("5xx responses in the window"))
+		.with_stat(Stat::gauge("server_error_rate_pct", pct).help("5xx rate, percent"))
+		.with_stat(Stat::gauge("window_seconds", window.as_secs() as f64))
+		.with_stats(deltas.iter().map(|(code, n)| {
+			Stat::gauge("requests_by_code", *n as f64)
+				.label("code", code.clone())
+				.help("Requests in the window by HTTP status code")
+		}))
 }
 
 fn duration_between(earlier: Timestamp, later: Timestamp) -> Duration {
@@ -413,6 +426,30 @@ other_metric{foo=\"bar\"} 7
 	fn ignores_unrelated_metrics() {
 		let counts = parse_status_counts("foo_bar{code=\"500\"} 99");
 		assert!(counts.is_empty());
+	}
+
+	#[test]
+	fn build_check_emits_stats() {
+		let baseline = snap(0, &[("200", 100), ("500", 0), ("502", 0)]);
+		let current = snap(60, &[("200", 190), ("500", 5), ("502", 5)]);
+		let check = build_check(&baseline, &current, BaselineSource::History);
+
+		let scalar = |name: &str| check.stats.iter().find(|s| s.name == name).map(|s| s.value);
+		// delta: 90 + 5 + 5 requests, 10 server errors
+		assert_eq!(scalar("requests"), Some(100.0));
+		assert_eq!(scalar("server_errors"), Some(10.0));
+
+		// dimensioned by-code stats carry the code label
+		let by_code: Vec<_> = check
+			.stats
+			.iter()
+			.filter(|s| s.name == "requests_by_code")
+			.collect();
+		assert!(
+			by_code
+				.iter()
+				.any(|s| { s.labels == vec![("code", "502".to_string())] && s.value == 5.0 })
+		);
 	}
 
 	#[test]

--- a/crates/alertd/src/doctor/checks/load.rs
+++ b/crates/alertd/src/doctor/checks/load.rs
@@ -1,6 +1,7 @@
 use sysinfo::{CpuRefreshKind, RefreshKind, System};
 
 use super::SweepContext;
+use crate::doctor::Stat;
 use crate::doctor::check::{Check, CheckStatus};
 
 /// Multiplier on the logical core count above which the 5-minute load average
@@ -54,6 +55,10 @@ pub async fn run(_ctx: SweepContext) -> Check {
 		.with_detail("five_min", load.five)
 		.with_detail("fifteen_min", load.fifteen)
 		.with_detail("cores", cores)
+		.with_stat(Stat::gauge("one_min", load.one).help("1-minute load average"))
+		.with_stat(Stat::gauge("five_min", load.five).help("5-minute load average"))
+		.with_stat(Stat::gauge("fifteen_min", load.fifteen).help("15-minute load average"))
+		.with_stat(Stat::gauge("cores", cores as f64).help("Logical CPU cores"))
 }
 
 /// Tier the 5-minute load average against the logical core count.

--- a/crates/alertd/src/doctor/checks/memory.rs
+++ b/crates/alertd/src/doctor/checks/memory.rs
@@ -1,6 +1,7 @@
 use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 
 use super::SweepContext;
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 const WARN_PCT_USED: f64 = 90.0;
@@ -31,4 +32,25 @@ pub async fn run(_ctx: SweepContext) -> Check {
 		.with_detail("used_bytes", used)
 		.with_detail("total_bytes", total)
 		.with_detail("percent_used", pct)
+		.with_stat(Stat::gauge("used_bytes", used as f64).help("Memory in use"))
+		.with_stat(Stat::gauge("total_bytes", total as f64).help("Total memory"))
+		.with_stat(Stat::gauge("percent_used", pct).help("Memory used, percent"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn emits_memory_stats() {
+		let ctx = SweepContext {
+			tamanu: None,
+			http_client: reqwest::Client::new(),
+		};
+		let check = run(ctx).await;
+		let names: Vec<&str> = check.stats.iter().map(|s| s.name).collect();
+		assert!(names.contains(&"used_bytes"));
+		assert!(names.contains(&"total_bytes"));
+		assert!(names.contains(&"percent_used"));
+	}
 }

--- a/crates/alertd/src/doctor/checks/munin.rs
+++ b/crates/alertd/src/doctor/checks/munin.rs
@@ -1,0 +1,72 @@
+//! Reports whether munin-node is present on the host, as a top-level status
+//! fact for canopy (`munin: bool`).
+//!
+//! Not a health signal — always a pass, carried in `payload_extras` like the
+//! timezone — so the fleet can see which hosts can be harvested by munin
+//! (which scrapes alertd's `/metrics` in munin format).
+
+#[cfg(target_os = "linux")]
+use bestool_tamanu::systemd;
+
+use super::SweepContext;
+use crate::doctor::check::Check;
+
+const NAME: &str = "munin";
+#[cfg(target_os = "linux")]
+const UNIT: &str = "munin-node.service";
+
+pub async fn run(_ctx: SweepContext) -> Check {
+	build(detect().await)
+}
+
+/// Build the fact-check from the detection result. Split from [`run`] so tests
+/// exercise it without opening the shared systemd D-Bus connection, which is
+/// cached process-wide and hangs when reused across per-test tokio runtimes.
+fn build(detected: bool) -> Check {
+	let summary = if detected {
+		"munin-node present"
+	} else {
+		"munin-node not installed"
+	};
+	Check::pass(NAME, summary).with_payload_extra("munin", detected)
+}
+
+/// True when munin-node's systemd unit is installed, or its binary is on `PATH`.
+#[cfg(target_os = "linux")]
+async fn detect() -> bool {
+	if systemd::unit_file_exists(UNIT).await.unwrap_or(false) {
+		return true;
+	}
+	binary_on_path("munin-node")
+}
+
+/// munin is a Linux monitoring stack; treat other platforms as never having it.
+#[cfg(not(target_os = "linux"))]
+async fn detect() -> bool {
+	false
+}
+
+#[cfg(target_os = "linux")]
+fn binary_on_path(name: &str) -> bool {
+	let Some(path) = std::env::var_os("PATH") else {
+		return false;
+	};
+	std::env::split_paths(&path).any(|dir| dir.join(name).is_file())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn reports_the_munin_bool_fact() {
+		for detected in [true, false] {
+			let check = build(detected);
+			assert_eq!(check.name, "munin");
+			assert_eq!(
+				check.payload_extras.get("munin").and_then(|v| v.as_bool()),
+				Some(detected)
+			);
+		}
+	}
+}

--- a/crates/alertd/src/doctor/checks/sync_lookup.rs
+++ b/crates/alertd/src/doctor/checks/sync_lookup.rs
@@ -5,6 +5,7 @@
 //! treat the lookup as not tracked and pass.
 
 use super::{CheckContext, query_error_check};
+use crate::doctor::Stat;
 use crate::doctor::check::{Check, CheckStatus};
 use bestool_tamanu::ApiServerKind;
 
@@ -53,7 +54,10 @@ pub async fn run(ctx: CheckContext) -> Check {
 		_ => Check::pass(NAME, "lookup table up to date"),
 	};
 
-	let mut check = check.with_detail("age_seconds", age_seconds);
+	let mut check = check.with_detail("age_seconds", age_seconds).with_stat(
+		Stat::gauge("age_seconds", age_seconds as f64)
+			.help("Seconds since the lookup table last updated"),
+	);
 	if let Some(tick) = last_sync_tick {
 		check = check.with_detail("last_sync_tick", tick);
 	}

--- a/crates/alertd/src/doctor/checks/sync_sessions.rs
+++ b/crates/alertd/src/doctor/checks/sync_sessions.rs
@@ -1,6 +1,7 @@
 use jiff::Timestamp;
 
 use super::{CheckContext, query_error_check};
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 pub async fn run(ctx: CheckContext) -> Check {
@@ -29,7 +30,11 @@ pub async fn run(ctx: CheckContext) -> Check {
 	let row = match client.query_opt(query, &[]).await {
 		Ok(Some(r)) => r,
 		Ok(None) => {
-			return Check::pass("sync_sessions", "no sync sessions").with_detail("active_count", 0);
+			return Check::pass("sync_sessions", "no sync sessions")
+				.with_detail("active_count", 0)
+				.with_stat(Stat::gauge("active", 0.0).help("Active sync sessions"))
+				.with_stat(Stat::gauge("stuck_15m", 0.0))
+				.with_stat(Stat::gauge("stuck_45m", 0.0));
 		}
 		Err(err) => {
 			if let Some(db) = err.as_db_error()
@@ -69,7 +74,14 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 	let mut check = check
 		.with_detail("active_count", active)
-		.with_detail("stuck_count", stuck_warn);
+		.with_detail("stuck_count", stuck_warn)
+		.with_stat(Stat::gauge("active", active as f64).help("Active sync sessions"))
+		.with_stat(
+			Stat::gauge("stuck_15m", stuck_warn as f64).help("Sessions running over 15 minutes"),
+		)
+		.with_stat(
+			Stat::gauge("stuck_45m", stuck_fail as f64).help("Sessions running over 45 minutes"),
+		);
 	if let Some(ts) = oldest {
 		check = check.with_detail("oldest_started_at", ts.to_string());
 	}

--- a/crates/alertd/src/doctor/checks/sync_snapshot_tables.rs
+++ b/crates/alertd/src/doctor/checks/sync_snapshot_tables.rs
@@ -10,6 +10,7 @@
 use bestool_tamanu::ApiServerKind;
 
 use super::{CheckContext, query_error_check};
+use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 const NAME: &str = "sync_snapshot_tables";
@@ -58,6 +59,10 @@ pub async fn run(ctx: CheckContext) -> Check {
 	check
 		.with_detail("table_count", tables)
 		.with_detail("sessions_24h", sessions)
+		.with_stat(Stat::gauge("table_count", tables as f64).help("Leftover sync-snapshot tables"))
+		.with_stat(
+			Stat::gauge("sessions_24h", sessions as f64).help("Sync sessions in the last 24h"),
+		)
 }
 
 enum Verdict {

--- a/crates/alertd/src/doctor/stat.rs
+++ b/crates/alertd/src/doctor/stat.rs
@@ -1,0 +1,172 @@
+//! Typed metrics a healthcheck can declare for the alertd `/metrics` endpoint.
+//!
+//! A check computes its numbers once and may attach them both to its canopy
+//! payload (via `details`) and, as typed [`Stat`]s, to the metrics surface. The
+//! `/metrics` endpoint renders the declared stats to munin or prometheus text;
+//! the check name provides the metric namespace and `labels` carry dimensioned
+//! data (a status, an HTTP code, a mountpoint).
+
+use jiff::Timestamp;
+
+/// The kind of a declared metric, matching the subset of metric types munin and
+/// prometheus have in common.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatKind {
+	/// A value that can rise and fall (prometheus gauge, munin `GAUGE`).
+	Gauge,
+	/// A monotonically increasing cumulative total (prometheus counter, munin
+	/// `COUNTER`).
+	Counter,
+}
+
+impl StatKind {
+	/// The prometheus `# TYPE` token.
+	pub fn prometheus(self) -> &'static str {
+		match self {
+			StatKind::Gauge => "gauge",
+			StatKind::Counter => "counter",
+		}
+	}
+
+	/// The munin field `.type` token.
+	pub fn munin(self) -> &'static str {
+		match self {
+			StatKind::Gauge => "GAUGE",
+			StatKind::Counter => "COUNTER",
+		}
+	}
+}
+
+/// One numeric metric declared by a healthcheck.
+///
+/// Build with [`Stat::gauge`] / [`Stat::counter`] and attach to a check with
+/// `Check::with_stat`. Units belong in the `name` by prometheus convention
+/// (`_seconds`, `_bytes`); dimensioned data is expressed with [`Stat::label`],
+/// called once per dimension value.
+#[derive(Debug, Clone)]
+pub struct Stat {
+	/// Metric name within the check's namespace; snake_case, valid as both a
+	/// prometheus name segment and a munin field.
+	pub name: &'static str,
+	pub value: f64,
+	pub kind: StatKind,
+	/// Dimension labels in insertion order: static keys, dynamic values.
+	pub labels: Vec<(&'static str, String)>,
+	/// Human description: prometheus `# HELP`, munin field label.
+	pub help: Option<String>,
+}
+
+impl Stat {
+	pub fn gauge(name: &'static str, value: f64) -> Self {
+		Self {
+			name,
+			value,
+			kind: StatKind::Gauge,
+			labels: Vec::new(),
+			help: None,
+		}
+	}
+
+	pub fn counter(name: &'static str, value: f64) -> Self {
+		Self {
+			name,
+			value,
+			kind: StatKind::Counter,
+			labels: Vec::new(),
+			help: None,
+		}
+	}
+
+	/// Attach a dimension label. Call once per value for dimensioned data (e.g.
+	/// once per FHIR job status).
+	pub fn label(mut self, key: &'static str, value: impl Into<String>) -> Self {
+		self.labels.push((key, value.into()));
+		self
+	}
+
+	pub fn help(mut self, help: impl Into<String>) -> Self {
+		self.help = Some(help.into());
+		self
+	}
+}
+
+/// Census of check outcomes in a sweep, capped to canopy's severity ceilings.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StatusCounts {
+	pub passing: u32,
+	pub warning: u32,
+	pub failing: u32,
+	pub skipped: u32,
+	pub broken: u32,
+}
+
+impl StatusCounts {
+	/// Every check in the sweep.
+	pub fn total(&self) -> u32 {
+		self.passing + self.warning + self.failing + self.skipped + self.broken
+	}
+
+	/// Checks that actually ran (everything but skipped).
+	pub fn active(&self) -> u32 {
+		self.total() - self.skipped
+	}
+}
+
+/// A rendering-ready view of the latest sweep's metrics: the per-check declared
+/// stats plus the global status census, both drawn from one sweep so they stay
+/// internally consistent.
+#[derive(Debug, Clone)]
+pub struct MetricsSnapshot {
+	pub computed_at: Timestamp,
+	/// `(check name, stat)` pairs; the check name is the metric namespace.
+	pub stats: Vec<(&'static str, Stat)>,
+	pub counts: StatusCounts,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn gauge_builder_defaults() {
+		let s = Stat::gauge("age_seconds", 42.0);
+		assert_eq!(s.name, "age_seconds");
+		assert_eq!(s.value, 42.0);
+		assert_eq!(s.kind, StatKind::Gauge);
+		assert!(s.labels.is_empty());
+		assert!(s.help.is_none());
+	}
+
+	#[test]
+	fn counter_kind() {
+		assert_eq!(Stat::counter("requests_total", 1.0).kind, StatKind::Counter);
+	}
+
+	#[test]
+	fn labels_keep_insertion_order() {
+		let s = Stat::gauge("jobs", 3.0)
+			.label("status", "Queued")
+			.label("queue", "fhir");
+		assert_eq!(
+			s.labels,
+			vec![
+				("status", "Queued".to_string()),
+				("queue", "fhir".to_string()),
+			]
+		);
+	}
+
+	#[test]
+	fn help_is_attached() {
+		let s = Stat::gauge("x", 1.0).help("a thing");
+		assert_eq!(s.help.as_deref(), Some("a thing"));
+	}
+
+	#[test]
+	fn kind_wire_tokens() {
+		assert_eq!(StatKind::Gauge.prometheus(), "gauge");
+		assert_eq!(StatKind::Counter.prometheus(), "counter");
+		assert_eq!(StatKind::Gauge.munin(), "GAUGE");
+		assert_eq!(StatKind::Counter.munin(), "COUNTER");
+	}
+}

--- a/crates/alertd/src/doctor/stat.rs
+++ b/crates/alertd/src/doctor/stat.rs
@@ -110,6 +110,17 @@ impl StatusCounts {
 	pub fn active(&self) -> u32 {
 		self.total() - self.skipped
 	}
+
+	/// The per-state counts in the stable order both metric formats emit.
+	pub fn by_state(&self) -> [(&'static str, u32); 5] {
+		[
+			("passing", self.passing),
+			("warning", self.warning),
+			("failing", self.failing),
+			("skipped", self.skipped),
+			("broken", self.broken),
+		]
+	}
 }
 
 /// A rendering-ready view of the latest sweep's metrics: the per-check declared

--- a/crates/alertd/src/doctor/task.rs
+++ b/crates/alertd/src/doctor/task.rs
@@ -8,7 +8,12 @@ use serde_json::{Value, json};
 use tokio::sync::{Mutex, mpsc};
 use tracing::warn;
 
-use crate::doctor::{self, check::Check, progress::DoctorEvent};
+use crate::doctor::{
+	self,
+	check::{Check, CheckStatus},
+	progress::DoctorEvent,
+	stat::{MetricsSnapshot, StatusCounts},
+};
 use crate::tasks::TaskEndpointHandler;
 use crate::{BackgroundTask, TaskContext, TaskEndpoint, TaskEndpointResponse};
 
@@ -103,6 +108,62 @@ impl DoctorTask {
 			inner: Arc::new(inner),
 		}
 	}
+
+	/// A cloneable handle the HTTP `/metrics` endpoint uses to read the latest
+	/// sweep's declared stats and status census.
+	pub fn metrics_handle(&self) -> DoctorMetricsHandle {
+		DoctorMetricsHandle {
+			inner: self.inner.clone(),
+		}
+	}
+}
+
+/// Read-only view of the doctor task's latest sweep for the metrics endpoint.
+///
+/// Capping is applied on read (via [`DoctorTaskInner::capped`]) so the status
+/// census reflects canopy's current severity ceilings, matching what the
+/// `latest` endpoint and the CLI show.
+#[derive(Clone)]
+pub struct DoctorMetricsHandle {
+	inner: Arc<DoctorTaskInner>,
+}
+
+impl DoctorMetricsHandle {
+	/// The latest sweep rendered into a [`MetricsSnapshot`], or `None` if the
+	/// daemon hasn't completed a sweep yet.
+	pub async fn snapshot(&self) -> Option<MetricsSnapshot> {
+		let latest = self.inner.latest.lock().await.clone()?;
+		let sweep = self.inner.capped(latest.sweep).await;
+
+		let counts = census(&sweep.results);
+		let stats = sweep
+			.results
+			.iter()
+			.flat_map(|(check, _)| check.stats.iter().map(|stat| (check.name, stat.clone())))
+			.collect();
+
+		Some(MetricsSnapshot {
+			computed_at: latest.computed_at,
+			stats,
+			counts,
+		})
+	}
+}
+
+/// Tally check outcomes into a [`StatusCounts`]. Expects statuses already capped
+/// to canopy's ceilings, so the census matches what operators see elsewhere.
+fn census(results: &[(Check, bool)]) -> StatusCounts {
+	let mut counts = StatusCounts::default();
+	for (check, _) in results {
+		match &check.status {
+			CheckStatus::Pass => counts.passing += 1,
+			CheckStatus::Warning(_) => counts.warning += 1,
+			CheckStatus::Fail(_) => counts.failing += 1,
+			CheckStatus::Skip(_) => counts.skipped += 1,
+			CheckStatus::Broken(_) => counts.broken += 1,
+		}
+	}
+	counts
 }
 
 impl DoctorTaskInner {
@@ -351,5 +412,46 @@ mod tests {
 		let check = Check::fail("disk_free", "1% free", "out of space");
 		let capped = cap_check(check, None);
 		assert!(matches!(capped.status, CheckStatus::Fail(_)));
+	}
+
+	#[test]
+	fn census_counts_each_status() {
+		let results = vec![
+			(Check::pass("a", ""), true),
+			(Check::pass("b", ""), true),
+			(Check::warning("c", "", "w"), true),
+			(Check::fail("d", "", "f"), true),
+			(Check::skip("e", "", "s"), true),
+			(Check::broken("g", "", "b"), true),
+		];
+		let c = census(&results);
+		assert_eq!(c.passing, 2);
+		assert_eq!(c.warning, 1);
+		assert_eq!(c.failing, 1);
+		assert_eq!(c.skipped, 1);
+		assert_eq!(c.broken, 1);
+		assert_eq!(c.total(), 6);
+		// active = ran (everything but skipped)
+		assert_eq!(c.active(), 5);
+	}
+
+	#[test]
+	fn census_reflects_severity_capping() {
+		// A fail capped to a warn ceiling must count as warning, not failing —
+		// the census tracks what operators see after capping.
+		let mut sweep = doctor::SweepResult {
+			server_id: None,
+			results: vec![(Check::fail("disk_free", "1% free", "out of space"), true)],
+			overall: doctor::check::OverallResult::Failing,
+			payload: json!({}),
+			pg_version: None,
+		};
+		let mut severities = HashMap::new();
+		severities.insert("disk_free".to_string(), CheckSeverity::Warn);
+		sweep.apply_severities(&severities);
+
+		let c = census(&sweep.results);
+		assert_eq!(c.failing, 0);
+		assert_eq!(c.warning, 1);
 	}
 }

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 mod endpoints;
+mod metrics_render;
 mod state;
 #[cfg(test)]
 mod test_utils;
@@ -26,6 +27,10 @@ pub use endpoints::*;
 pub use state::ServerState;
 pub use types::*;
 
+#[expect(
+	clippy::too_many_arguments,
+	reason = "daemon wiring; each shared resource is threaded in explicitly"
+)]
 pub async fn start_server(
 	internal_context: Arc<InternalContext>,
 	addrs: Vec<std::net::SocketAddr>,
@@ -33,6 +38,7 @@ pub async fn start_server(
 	background_tasks: &[Arc<dyn BackgroundTask>],
 	control: DaemonControl,
 	backups: Option<Arc<crate::BackupRegistry>>,
+	metrics: Option<crate::doctor::DoctorMetricsHandle>,
 	binary_version: String,
 ) {
 	let started_at = Timestamp::now();
@@ -49,6 +55,7 @@ pub async fn start_server(
 		task_endpoints: Arc::new(task_endpoints),
 		control,
 		backups,
+		metrics,
 	};
 
 	let app = Router::new()

--- a/crates/alertd/src/http_server/endpoints/metrics.rs
+++ b/crates/alertd/src/http_server/endpoints/metrics.rs
@@ -1,42 +1,159 @@
-use axum::{http::StatusCode, response::IntoResponse};
+use std::sync::Arc;
+
+use axum::{
+	extract::{RawQuery, State},
+	http::{HeaderMap, StatusCode, header},
+	response::IntoResponse,
+};
 use tracing::error;
 
+use crate::http_server::{ServerState, metrics_render};
 use crate::metrics;
 
-pub async fn handle_metrics() -> impl IntoResponse {
-	match metrics::gather_metrics() {
-		Ok(metrics) => (StatusCode::OK, metrics).into_response(),
+/// Media type a munin plugin sends in `Accept` to select munin-native output.
+/// There is no registered type for munin's format; this endpoint and the
+/// bundled plugin agree on it privately.
+const MUNIN_MEDIA_TYPE: &str = "text/x-munin";
+
+/// Prometheus text exposition content type.
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+pub async fn handle_metrics(
+	State(state): State<Arc<ServerState>>,
+	headers: HeaderMap,
+	RawQuery(query): RawQuery,
+) -> impl IntoResponse {
+	let wants_munin = headers
+		.get(header::ACCEPT)
+		.and_then(|v| v.to_str().ok())
+		.is_some_and(|accept| accept.contains(MUNIN_MEDIA_TYPE));
+
+	let snapshot = match &state.metrics {
+		Some(handle) => handle.snapshot().await,
+		None => None,
+	};
+
+	if wants_munin {
+		// Munin's two-call protocol: `?config` asks for field metadata, a bare
+		// request for values.
+		let config = query
+			.as_deref()
+			.is_some_and(|q| q.split('&').any(|p| p == "config"));
+		let body = metrics_render::render_munin(
+			snapshot.as_ref(),
+			metrics::last_activity_timestamp(),
+			config,
+		);
+		return ([(header::CONTENT_TYPE, "text/plain; charset=utf-8")], body).into_response();
+	}
+
+	// Prometheus: keep the existing registry gauge output verbatim (so existing
+	// scrapers are undisturbed), then append the sweep-derived metrics.
+	let mut body = match metrics::gather_metrics() {
+		Ok(text) => text,
 		Err(e) => {
 			error!("failed to gather metrics: {e:?}");
-			(
+			return (
 				StatusCode::INTERNAL_SERVER_ERROR,
 				format!("Failed to gather metrics: {e}\n"),
 			)
-				.into_response()
+				.into_response();
 		}
+	};
+	if let Some(snapshot) = &snapshot {
+		body.push_str(&metrics_render::render_prometheus(snapshot));
 	}
+	([(header::CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)], body).into_response()
 }
 
 #[cfg(test)]
 mod tests {
-	use axum::{http::StatusCode, response::IntoResponse};
+	use std::{collections::HashMap, sync::Arc, time::Duration};
+
+	use axum::{
+		body::to_bytes,
+		extract::{RawQuery, State},
+		http::{HeaderMap, HeaderValue, StatusCode, header},
+		response::IntoResponse,
+	};
+	use jiff::Timestamp;
 
 	use super::*;
+	use crate::{context::InternalContext, http_server::ServerState};
+
+	/// The prometheus registry is process-global and initialises exactly once;
+	/// guard it so parallel tests don't double-init.
+	fn init_metrics_once() {
+		static INIT: std::sync::Once = std::sync::Once::new();
+		INIT.call_once(crate::metrics::init_metrics);
+	}
+
+	/// A minimal server state with no doctor metrics handle and no database —
+	/// enough to exercise the endpoint's format negotiation.
+	fn state() -> Arc<ServerState> {
+		let ctx = Arc::new(InternalContext {
+			pg_pool: None,
+			http_client: reqwest::Client::new(),
+			canopy_client: None,
+			reload: tokio::sync::watch::channel(0).1,
+			restart: None,
+		});
+		Arc::new(ServerState {
+			started_at: Timestamp::now(),
+			pid: std::process::id(),
+			binary_version: "0.0.0-test".to_string(),
+			internal_context: ctx,
+			watchdog_timeout: Some(Duration::from_secs(600)),
+			task_endpoints: Arc::new(HashMap::new()),
+			control: crate::daemon::DaemonControl::detached(),
+			backups: None,
+			metrics: None,
+		})
+	}
+
+	async fn body_of(response: axum::response::Response) -> String {
+		let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+		String::from_utf8(body.to_vec()).unwrap()
+	}
 
 	#[tokio::test]
-	async fn test_metrics_endpoint() {
-		// Initialize metrics for the test
-		crate::metrics::init_metrics();
-
-		let response = handle_metrics().await.into_response();
-
-		assert_eq!(response.status(), StatusCode::OK);
-		let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+	async fn default_is_prometheus() {
+		init_metrics_once();
+		let response = handle_metrics(State(state()), HeaderMap::new(), RawQuery(None))
 			.await
-			.unwrap();
-		let body_str = String::from_utf8(body.to_vec()).unwrap();
+			.into_response();
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			response.headers().get(header::CONTENT_TYPE).unwrap(),
+			PROMETHEUS_CONTENT_TYPE
+		);
+		assert!(body_of(response).await.contains("# HELP"));
+	}
 
-		// Basic check that it returns Prometheus-formatted metrics
-		assert!(body_str.contains("# HELP"));
+	#[tokio::test]
+	async fn accept_munin_selects_munin() {
+		init_metrics_once();
+		let mut headers = HeaderMap::new();
+		headers.insert(header::ACCEPT, HeaderValue::from_static(MUNIN_MEDIA_TYPE));
+		let response = handle_metrics(State(state()), headers, RawQuery(None))
+			.await
+			.into_response();
+		let body = body_of(response).await;
+		// No sweep handle wired: liveness graph only, no census.
+		assert!(body.contains("multigraph bes_alertd_daemon"));
+		assert!(!body.contains("multigraph bes_alertd_checks"));
+	}
+
+	#[tokio::test]
+	async fn munin_config_query_is_honoured() {
+		init_metrics_once();
+		let mut headers = HeaderMap::new();
+		headers.insert(header::ACCEPT, HeaderValue::from_static(MUNIN_MEDIA_TYPE));
+		let response = handle_metrics(State(state()), headers, RawQuery(Some("config".into())))
+			.await
+			.into_response();
+		let body = body_of(response).await;
+		assert!(body.contains("graph_category bestool"));
+		assert!(!body.contains(".value "));
 	}
 }

--- a/crates/alertd/src/http_server/metrics_render.rs
+++ b/crates/alertd/src/http_server/metrics_render.rs
@@ -1,0 +1,355 @@
+//! Render a [`MetricsSnapshot`] to prometheus or munin text.
+//!
+//! One snapshot drives both formats. Prometheus models dimensioned data with
+//! labels (`bes_alertd_fhir_jobs_jobs{status="Queued"}`); munin models it as
+//! fields within a per-check multigraph. The liveness/sweep timestamps ride
+//! along in both so a scraper can tell whether the daemon (and its last sweep)
+//! is fresh.
+
+use std::fmt::Write as _;
+
+use crate::doctor::{MetricsSnapshot, Stat};
+
+/// Common prefix for every metric this daemon exposes.
+const PREFIX: &str = "bes_alertd";
+
+/// The five census states, in a stable order for both formats. Values come
+/// from [`StatusCounts::by_state`], which uses the same order.
+const STATE_NAMES: [&str; 5] = ["passing", "warning", "failing", "skipped", "broken"];
+
+/// Format an `f64` for a metric value. Rust's `Display` prints whole numbers
+/// without a trailing `.0` and never uses scientific notation, which is exactly
+/// what both formats want.
+fn value(v: f64) -> String {
+	format!("{v}")
+}
+
+/// Prometheus label-value escaping: backslash, double-quote, newline.
+fn escape_label(v: &str) -> String {
+	v.replace('\\', "\\\\")
+		.replace('"', "\\\"")
+		.replace('\n', "\\n")
+}
+
+/// Sanitise a munin field-name segment to `[a-z0-9_]`.
+fn munin_field_segment(s: &str) -> String {
+	s.chars()
+		.map(|c| {
+			if c.is_ascii_alphanumeric() {
+				c.to_ascii_lowercase()
+			} else {
+				'_'
+			}
+		})
+		.collect()
+}
+
+/// The munin field id for a stat: the stat name, plus each label value folded
+/// in. Always starts with the stat name (a letter), so it's a valid field id.
+fn munin_field(stat: &Stat) -> String {
+	let mut id = munin_field_segment(stat.name);
+	for (_, v) in &stat.labels {
+		id.push('_');
+		id.push_str(&munin_field_segment(v));
+	}
+	id
+}
+
+/// The human label for a munin field: the label values joined, else the help,
+/// else the stat name.
+fn munin_field_label(stat: &Stat) -> String {
+	if !stat.labels.is_empty() {
+		stat.labels
+			.iter()
+			.map(|(_, v)| v.as_str())
+			.collect::<Vec<_>>()
+			.join(" ")
+	} else if let Some(help) = &stat.help {
+		help.clone()
+	} else {
+		stat.name.to_string()
+	}
+}
+
+/// The prometheus metric name for a stat within a check's namespace.
+fn prom_name(check: &str, stat: &Stat) -> String {
+	format!("{PREFIX}_{check}_{}", stat.name)
+}
+
+/// Render the snapshot's prometheus body (census + per-check stats). Does not
+/// include the liveness gauge, which the caller appends from the registry to
+/// preserve its exact existing output.
+pub fn render_prometheus(snapshot: &MetricsSnapshot) -> String {
+	let mut out = String::new();
+
+	out.push_str(&format!(
+		"# HELP {PREFIX}_last_sweep_unix Unix time of the last doctor sweep\n"
+	));
+	out.push_str(&format!("# TYPE {PREFIX}_last_sweep_unix gauge\n"));
+	out.push_str(&format!(
+		"{PREFIX}_last_sweep_unix {}\n",
+		snapshot.computed_at.as_second()
+	));
+
+	out.push_str(&format!(
+		"# HELP {PREFIX}_checks Number of doctor checks by outcome\n"
+	));
+	out.push_str(&format!("# TYPE {PREFIX}_checks gauge\n"));
+	for (state, count) in snapshot.counts.by_state() {
+		out.push_str(&format!("{PREFIX}_checks{{state=\"{state}\"}} {count}\n"));
+	}
+
+	// Group per-check stats into prometheus metric families (same name = same
+	// family), preserving first-seen order so output is stable.
+	let mut order: Vec<String> = Vec::new();
+	let mut families: std::collections::HashMap<String, Family> = std::collections::HashMap::new();
+	for (check, stat) in &snapshot.stats {
+		let name = prom_name(check, stat);
+		let family = families.entry(name.clone()).or_insert_with(|| {
+			order.push(name.clone());
+			Family {
+				help: stat.help.clone(),
+				kind: stat.kind.prometheus(),
+				lines: Vec::new(),
+			}
+		});
+		if family.help.is_none() {
+			family.help.clone_from(&stat.help);
+		}
+		let labels = if stat.labels.is_empty() {
+			String::new()
+		} else {
+			let inner = stat
+				.labels
+				.iter()
+				.map(|(k, v)| format!("{k}=\"{}\"", escape_label(v)))
+				.collect::<Vec<_>>()
+				.join(",");
+			format!("{{{inner}}}")
+		};
+		family
+			.lines
+			.push(format!("{name}{labels} {}", value(stat.value)));
+	}
+
+	for name in order {
+		let family = &families[&name];
+		if let Some(help) = &family.help {
+			let _ = writeln!(out, "# HELP {name} {}", help.replace('\n', " "));
+		}
+		let _ = writeln!(out, "# TYPE {name} {}", family.kind);
+		for line in &family.lines {
+			out.push_str(line);
+			out.push('\n');
+		}
+	}
+
+	out
+}
+
+struct Family {
+	help: Option<String>,
+	kind: &'static str,
+	lines: Vec<String>,
+}
+
+/// Render munin text. In `config` mode, field metadata; otherwise, values. The
+/// daemon liveness/sweep graph is always emitted; the census and per-check
+/// graphs need a sweep (their field sets are only known from one).
+pub fn render_munin(
+	snapshot: Option<&MetricsSnapshot>,
+	last_activity: i64,
+	config: bool,
+) -> String {
+	let mut out = String::new();
+
+	// Daemon graph: liveness and (when available) last-sweep timestamps.
+	out.push_str("multigraph bes_alertd_daemon\n");
+	if config {
+		out.push_str("graph_title alertd daemon activity\n");
+		out.push_str("graph_category bestool\n");
+		out.push_str("last_activity.label last activity (unix)\n");
+		out.push_str("last_activity.type GAUGE\n");
+		if snapshot.is_some() {
+			out.push_str("last_sweep.label last sweep (unix)\n");
+			out.push_str("last_sweep.type GAUGE\n");
+		}
+	} else {
+		let _ = writeln!(out, "last_activity.value {last_activity}");
+		if let Some(s) = snapshot {
+			let _ = writeln!(out, "last_sweep.value {}", s.computed_at.as_second());
+		}
+	}
+
+	let Some(snapshot) = snapshot else {
+		return out;
+	};
+
+	// Census graph.
+	out.push_str("\nmultigraph bes_alertd_checks\n");
+	if config {
+		out.push_str("graph_title Doctor checks by outcome\n");
+		out.push_str("graph_category bestool\n");
+		out.push_str("graph_vlabel checks\n");
+		for state in STATE_NAMES {
+			let _ = writeln!(out, "{state}.label {state}");
+			let _ = writeln!(out, "{state}.type GAUGE");
+		}
+		out.push_str("total.label total\n");
+		out.push_str("total.type GAUGE\n");
+	} else {
+		for (state, count) in snapshot.counts.by_state() {
+			let _ = writeln!(out, "{state}.value {count}");
+		}
+		let _ = writeln!(out, "total.value {}", snapshot.counts.total());
+	}
+
+	// Per-check graphs, one multigraph per check, in first-seen order.
+	let mut order: Vec<&str> = Vec::new();
+	let mut by_check: std::collections::HashMap<&str, Vec<&Stat>> =
+		std::collections::HashMap::new();
+	for (check, stat) in &snapshot.stats {
+		by_check
+			.entry(check)
+			.or_insert_with(|| {
+				order.push(check);
+				Vec::new()
+			})
+			.push(stat);
+	}
+
+	for check in order {
+		let _ = write!(out, "\nmultigraph {PREFIX}_{check}\n");
+		let stats = &by_check[check];
+		if config {
+			let _ = writeln!(out, "graph_title {check}");
+			out.push_str("graph_category bestool\n");
+			for stat in stats {
+				let field = munin_field(stat);
+				let _ = writeln!(out, "{field}.label {}", munin_field_label(stat));
+				let _ = writeln!(out, "{field}.type {}", stat.kind.munin());
+				if let Some(help) = &stat.help {
+					let _ = writeln!(out, "{field}.info {}", help.replace('\n', " "));
+				}
+			}
+		} else {
+			for stat in stats {
+				let _ = writeln!(out, "{}.value {}", munin_field(stat), value(stat.value));
+			}
+		}
+	}
+
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::doctor::StatusCounts;
+
+	fn snapshot() -> MetricsSnapshot {
+		MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(1_690_000_000).unwrap(),
+			counts: StatusCounts {
+				passing: 30,
+				warning: 2,
+				failing: 1,
+				skipped: 5,
+				broken: 0,
+			},
+			stats: vec![
+				(
+					"sync_lookup",
+					Stat::gauge("age_seconds", 12.0).help("Sync lookup staleness"),
+				),
+				("fhir_jobs", Stat::gauge("active_depth", 4.0)),
+				(
+					"fhir_jobs",
+					Stat::gauge("jobs", 3.0).label("status", "Queued"),
+				),
+				(
+					"fhir_jobs",
+					Stat::gauge("jobs", 1.0).label("status", "Errored"),
+				),
+			],
+		}
+	}
+
+	#[test]
+	fn prometheus_census_and_families() {
+		let out = render_prometheus(&snapshot());
+		assert!(out.contains("bes_alertd_last_sweep_unix 1690000000"));
+		assert!(out.contains("bes_alertd_checks{state=\"passing\"} 30"));
+		assert!(out.contains("bes_alertd_checks{state=\"failing\"} 1"));
+		// Scalar stat.
+		assert!(out.contains("# TYPE bes_alertd_sync_lookup_age_seconds gauge"));
+		assert!(out.contains("# HELP bes_alertd_sync_lookup_age_seconds Sync lookup staleness"));
+		assert!(out.contains("bes_alertd_sync_lookup_age_seconds 12"));
+		// Dimensioned stat: one family, two label series.
+		assert!(out.contains("bes_alertd_fhir_jobs_jobs{status=\"Queued\"} 3"));
+		assert!(out.contains("bes_alertd_fhir_jobs_jobs{status=\"Errored\"} 1"));
+		// The family header appears exactly once for the labelled metric.
+		assert_eq!(
+			out.matches("# TYPE bes_alertd_fhir_jobs_jobs gauge")
+				.count(),
+			1
+		);
+	}
+
+	#[test]
+	fn munin_values() {
+		let s = snapshot();
+		let out = render_munin(Some(&s), 1_690_000_100, false);
+		assert!(out.contains("multigraph bes_alertd_daemon"));
+		assert!(out.contains("last_activity.value 1690000100"));
+		assert!(out.contains("last_sweep.value 1690000000"));
+		assert!(out.contains("multigraph bes_alertd_checks"));
+		assert!(out.contains("passing.value 30"));
+		assert!(out.contains("total.value 38"));
+		assert!(out.contains("multigraph bes_alertd_fhir_jobs"));
+		assert!(out.contains("active_depth.value 4"));
+		// Labelled stat expands to one field per value.
+		assert!(out.contains("jobs_queued.value 3"));
+		assert!(out.contains("jobs_errored.value 1"));
+	}
+
+	#[test]
+	fn munin_config() {
+		let s = snapshot();
+		let out = render_munin(Some(&s), 0, true);
+		assert!(out.contains("multigraph bes_alertd_checks"));
+		assert!(out.contains("graph_title Doctor checks by outcome"));
+		assert!(out.contains("passing.type GAUGE"));
+		assert!(out.contains("multigraph bes_alertd_fhir_jobs"));
+		assert!(out.contains("graph_category bestool"));
+		assert!(out.contains("jobs_queued.label Queued"));
+		assert!(out.contains("jobs_queued.type GAUGE"));
+		// No values in config mode.
+		assert!(!out.contains(".value "));
+	}
+
+	#[test]
+	fn munin_without_snapshot_is_liveness_only() {
+		let values = render_munin(None, 42, false);
+		assert!(values.contains("last_activity.value 42"));
+		assert!(!values.contains("multigraph bes_alertd_checks"));
+		assert!(!values.contains("last_sweep"));
+
+		let config = render_munin(None, 0, true);
+		assert!(config.contains("multigraph bes_alertd_daemon"));
+		assert!(!config.contains("last_sweep"));
+	}
+
+	#[test]
+	fn kind_is_respected() {
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![("http_errors", Stat::counter("requests_total", 9.0))],
+		};
+		assert!(
+			render_prometheus(&s).contains("# TYPE bes_alertd_http_errors_requests_total counter")
+		);
+		assert!(render_munin(Some(&s), 0, true).contains("requests_total.type COUNTER"));
+	}
+}

--- a/crates/alertd/src/http_server/state.rs
+++ b/crates/alertd/src/http_server/state.rs
@@ -22,4 +22,7 @@ pub struct ServerState {
 	/// Backup run registry, when backups are compiled in; lets `/status` list
 	/// in-flight runs.
 	pub backups: Option<Arc<crate::BackupRegistry>>,
+	/// Handle to the doctor task's latest sweep, when a doctor task is
+	/// registered; feeds per-check stats and the status census to `/metrics`.
+	pub metrics: Option<crate::doctor::DoctorMetricsHandle>,
 }

--- a/crates/alertd/src/http_server/test_utils.rs
+++ b/crates/alertd/src/http_server/test_utils.rs
@@ -28,5 +28,6 @@ pub async fn create_test_state() -> Arc<ServerState> {
 		task_endpoints: Arc::new(HashMap::new()),
 		control: crate::daemon::DaemonControl::detached(),
 		backups: None,
+		metrics: None,
 	})
 }

--- a/crates/alertd/src/lib.rs
+++ b/crates/alertd/src/lib.rs
@@ -82,6 +82,11 @@ pub struct DaemonConfig {
 	/// daemon's status so an operator can see what's backing up right now.
 	pub backups: Option<Arc<BackupRegistry>>,
 
+	/// Handle to the doctor task's latest sweep, set when a doctor task is
+	/// registered. Feeds the `/metrics` endpoint the per-check declared stats
+	/// and the status census.
+	pub metrics: Option<crate::doctor::DoctorMetricsHandle>,
+
 	/// Version of the running `bestool` binary, shown in the systemd status line.
 	///
 	/// Distinct from this crate's own [`VERSION`]: `bestool` and `bestool-alertd`
@@ -124,6 +129,7 @@ impl DaemonConfig {
 			watchdog_timeout: Some(Duration::from_secs(10 * 60)),
 			background_tasks: Vec::new(),
 			backups: None,
+			metrics: None,
 			// Fallback only; the binary sets its own version via
 			// `with_binary_version`. This crate's version differs from bestool's.
 			binary_version: VERSION.to_string(),
@@ -144,6 +150,12 @@ impl DaemonConfig {
 	/// Attach the backup registry, so the daemon's status can list in-flight runs.
 	pub fn with_backups(mut self, registry: Arc<BackupRegistry>) -> Self {
 		self.backups = Some(registry);
+		self
+	}
+
+	/// Attach the doctor metrics handle, so `/metrics` can serve per-check stats.
+	pub fn with_metrics_handle(mut self, metrics: crate::doctor::DoctorMetricsHandle) -> Self {
+		self.metrics = Some(metrics);
 		self
 	}
 

--- a/crates/bestool/src/actions/alertd.rs
+++ b/crates/bestool/src/actions/alertd.rs
@@ -229,7 +229,9 @@ fn with_daemon_tasks(
 		crate::actions::self_update::task::SelfUpdateTask::new(),
 	));
 
-	config.with_task(Arc::new(doctor))
+	config
+		.with_metrics_handle(doctor.metrics_handle())
+		.with_task(Arc::new(doctor))
 }
 
 /// The in-process backup trigger: routes each type canopy requests via

--- a/crates/bestool/src/actions/tamanu/doctor.rs
+++ b/crates/bestool/src/actions/tamanu/doctor.rs
@@ -452,6 +452,7 @@ fn results_from_wire(payload: &Value) -> Vec<(Check, bool)> {
 					summary: String::new(),
 					details: serde_json::Map::new(),
 					payload_extras: serde_json::Map::new(),
+					stats: Vec::new(),
 				},
 				true,
 			))

--- a/docs/plans/alertd-check-metrics.md
+++ b/docs/plans/alertd-check-metrics.md
@@ -1,0 +1,198 @@
+# alertd check-declared metrics + munin/prometheus endpoint
+
+## Goal
+
+Surface the numeric telemetry the doctor healthchecks already gather (cert
+validity, FHIR queue depth, sync staleness, active sessions, snapshot-table
+counts, disk/memory/load, …) as first-class metrics that munin can harvest,
+served off alertd's existing `/metrics` route. Checks *declare* typed stats;
+one renderer emits either munin-native text or prometheus text depending on the
+request's `Accept` header. A global status census (passing/warning/failing/
+skipped/broken) is derived automatically from each sweep.
+
+Munin is the priority consumer (there is no munin-prometheus bridge plugin in
+the fleet), so a thin munin plugin ships in the bestool deb.
+
+Separately, report a top-level `munin: bool` fact to canopy when munin-node is
+present on the host.
+
+## Background (current state)
+
+- Checks live under `crates/alertd/src/doctor/checks/`; each returns one
+  `Check` (`doctor/check.rs`) carrying `status`, `summary`, and a loosely-typed
+  `details: Map<String, Value>` (canopy-bound JSON). Numeric data today is only
+  in `details` — as scalars, dimensioned maps (`fhir_jobs.by_status`,
+  `http_errors.by_code`), or arrays of objects (per-cert, per-mount).
+- The doctor task (`doctor/task.rs`) runs a sweep every 60s and caches the
+  latest `SweepResult`; it applies canopy's severity ceilings on read
+  (`capped()`), and already exposes `/tasks/doctor/{latest,recompute}`.
+- The HTTP server (`http_server.rs`, axum) has a `/metrics` route
+  (`endpoints/metrics.rs`) that returns prometheus text from a global registry
+  holding a single gauge, `bes_alertd_last_activity_unix` (`metrics.rs`) — a
+  liveness signal for `/health` and the watchdog.
+- `ServerState` (`http_server/state.rs`) is threaded from `DaemonConfig`
+  (`daemon.rs`); `backups: Option<Arc<BackupRegistry>>` is the precedent for an
+  optional shared handle reaching a handler.
+- Pure-fact contributors already exist: the `ips` check is `on_wire: false`,
+  always passes, and attaches top-level payload facts via `payload_extras`,
+  which `build_payload` (`sweep.rs`) lifts alongside `osTimezone`.
+- `systemd::is_enabled(unit)` exists (`crates/tamanu/src/systemd.rs`) with a
+  non-Linux stub.
+- The deb is assembled by hand in `.github/workflows/release-bestool.yml`
+  (installs the systemd unit, shell completions, docs via `install -D`; runs a
+  `postinst` that does `systemctl daemon-reload`).
+
+## Design
+
+### Stat type
+
+New `crates/alertd/src/doctor/stat.rs`:
+
+```rust
+pub enum StatKind { Gauge, Counter }
+
+pub struct Stat {
+    name: &'static str,                  // snake_case; valid prom name & munin field
+    value: f64,                          // ints and floats both fit
+    kind: StatKind,
+    labels: Vec<(&'static str, String)>, // static keys, dynamic values, insertion order
+    help: Option<String>,                // prom HELP / munin field label
+}
+```
+
+Builder mirrors the existing `.with_detail` ergonomics:
+
+```rust
+Stat::gauge("age_seconds", age as f64).help("Sync lookup staleness")
+Stat::counter("requests_total", n as f64)
+Stat::gauge("jobs", n as f64).label("status", status)   // called once per status
+```
+
+`Check` gains `stats: Vec<Stat>` plus `with_stat(Stat)` / `with_stats(iter)`;
+all `Check::{pass,skip,warning,fail,broken}` constructors initialise it empty.
+`details` (canopy JSON) and `stats` (metrics) stay separate — a check computes
+a number once and may attach it to both. Units live in the stat *name* by
+prometheus convention (`_seconds`, `_bytes`); no separate unit field.
+
+### Naming
+
+- Prometheus: `bes_alertd_<check>_<stat>{label="…"} <value>`, e.g.
+  `bes_alertd_fhir_jobs_jobs{status="Queued"} 4`. `# HELP`/`# TYPE` emitted per
+  metric.
+- Munin: one multigraph per check, id `bes_alertd_<check>`, `graph_category
+  bestool`; each stat is a field. A labelled stat expands to one field per
+  label-value — field id `<stat>_<value…>` sanitised to `[a-z0-9_]`, field
+  label = the human value. Field type: `Gauge`→`GAUGE`, `Counter`→`COUNTER`.
+
+### Global status census
+
+Derived from the cached sweep, capped to canopy's severity ceilings so it
+matches what operators see elsewhere:
+
+```
+bes_alertd_checks{state="passing|warning|failing|skipped|broken"} N   # prom
+bes_alertd_checks  → munin graph, same five fields + total                # munin
+```
+
+`active` = ran (total − skipped); the full breakdown lets any subset be
+derived.
+
+### Endpoint & format negotiation
+
+Reuse the existing `/metrics` route (no new path):
+
+- Default / `*/*` / prometheus Accept → prometheus text
+  (`text/plain; version=0.0.4`). Existing scrapers keep working; they just get
+  the sweep-derived series in addition to the liveness gauge.
+- `Accept: text/x-munin` → munin native text.
+- Munin's two-call protocol: `?config` → munin config lines only; bare request
+  → values. (No dirtyconfig — keep config and fetch as separate, unambiguous
+  responses. The plugin makes both calls.)
+- The `bes_alertd_last_activity_unix` liveness gauge is always included: as-is
+  in prom mode; as a `bes_alertd_daemon` munin graph in munin mode.
+
+Config and values are rendered from the *same* snapshot per scrape, so they are
+always internally consistent. Known munin wrinkle to note in code: a check
+flipping skipped↔ran changes its field set (rare on a stable host); v1 accepts
+this rather than persisting a superset.
+
+### Wiring
+
+- `MetricsSnapshot { computed_at, stats: Vec<(&'static str /*check*/, Stat)>,
+  counts: StatusCounts }` and `StatusCounts` defined alongside the doctor task.
+- `DoctorMetricsHandle` (an `Arc` over the doctor task's inner) with
+  `async fn snapshot(&self) -> Option<MetricsSnapshot>`: reads the cached sweep,
+  applies `capped()` for the status counts, and collects each check's `stats`.
+  `DoctorTask::metrics_handle(&self)` hands one out.
+- `ServerState` gains `metrics: Option<DoctorMetricsHandle>`, threaded through
+  `DaemonConfig` and `start_server` exactly like `backups`. The bestool binary
+  (`crates/bestool/src/actions/alertd.rs`) grabs the handle from the concrete
+  `DoctorTask` before boxing it into the task list and passes it into the
+  daemon config.
+- Rendering lives in the http layer: `http_server/metrics_render.rs` with
+  `render_prometheus(&MetricsSnapshot, liveness) -> String` and
+  `render_munin(&MetricsSnapshot, liveness, config: bool) -> String`, plus munin
+  field/graph-name sanitisation. `endpoints/metrics.rs` negotiates format from
+  the `Accept` header and `?config`, pulls the snapshot from `ServerState`, and
+  renders. When no sweep is cached yet, emit just the liveness gauge (and, in
+  munin config mode, its graph).
+
+### `munin` payload fact
+
+New host-level fact-check `doctor/checks/munin.rs`, mirroring `ips`:
+`on_wire: false`, always `Pass`, attaches top-level `munin: bool` via
+`with_payload_extra("munin", detected)`. Detected = `munin-node.service`
+enabled (`systemd::is_enabled("munin-node")`) OR the `munin-node` binary is on
+`PATH`; non-Linux → `false`. The canopy status payload is free-form JSON
+(`status()` posts a `serde_json::Value`), so no request-schema change is needed;
+canopy surfacing the field is its own concern, out of scope here.
+
+### Munin plugin in the deb
+
+- Source in-repo at `contrib/munin/bestool_alertd`: a thin POSIX-sh curl
+  wrapper. `config` arg → `GET /metrics?config`; otherwise `GET /metrics`; both
+  send `Accept: text/x-munin`. Target base tries `http://[::1]:8271` then
+  `http://127.0.0.1:8271` (mirroring the daemon's v6-first bind order), with an
+  `env.url` override (munin `plugin-conf.d` convention).
+- `release-bestool.yml` installs it to `/usr/share/munin/plugins/bestool_alertd`
+  (mode 0755) — munin's available-plugins dir.
+- The existing `postinst` gains: if munin-node is installed
+  (`/etc/munin/plugins` exists), symlink the plugin active and reload
+  munin-node; otherwise a no-op. Mirrors shipping the alertd unit disabled —
+  present, wired up only where wanted.
+
+## Implementation steps
+
+1. `doctor/stat.rs`: `Stat`, `StatKind`, builders (`gauge`, `counter`, `label`,
+   `help`); register `pub mod stat;` in the doctor module root. Unit tests for
+   the builder and label ordering.
+2. `doctor/check.rs`: add `stats` field + `with_stat`/`with_stats`; init in all
+   constructors.
+3. `MetricsSnapshot` + `StatusCounts` + `DoctorMetricsHandle::snapshot()` in the
+   doctor task; `DoctorTask::metrics_handle()`. Test status-count derivation
+   respects capping.
+4. `http_server/metrics_render.rs`: prometheus + munin renderers and name
+   sanitisation. Golden tests: prom output, munin config, munin values, label→
+   field expansion, name sanitisation.
+5. `http_server/state.rs` + `daemon.rs` + `actions/alertd.rs`: thread
+   `metrics: Option<DoctorMetricsHandle>` through, mirroring `backups`.
+6. `endpoints/metrics.rs`: rewrite `handle_metrics` to negotiate `Accept` +
+   `?config`, render from the snapshot, always include the liveness gauge.
+   Tests: prom default, munin values, munin config, no-sweep-yet.
+7. Instrument the named checks with `.with_stat(...)`: `caddy_certs`,
+   `fhir_jobs`, `sync_lookup`, `sync_sessions`, `sync_snapshot_tables`,
+   `disk_free`, `memory`, `load`, `db_connect`, `http_errors`. Extend existing
+   per-check tests to assert the emitted stats.
+8. `doctor/checks/munin.rs`: the `munin` fact-check; register in `checks::all()`
+   as a host-level, `on_wire: false` check. Test detection wiring.
+9. `contrib/munin/bestool_alertd` plugin script; edit `release-bestool.yml` to
+   install it; extend `postinst` with the conditional munin-node symlink+reload.
+
+## Scope
+
+- **This branch:** everything in the steps above — mechanism, endpoint, global
+  census, munin fact, plugin in the deb, and the named-set instrumentation.
+- **Stacked follow-up:** instrument the remaining numeric checks (the `*_errors`
+  family counts, `inodes`, `btrfs`, `external_users`, `tamanu_http`, `pg_tuning`,
+  `sync_session_errors`, …) and add p50/p99 snapshot-table *size* percentiles
+  (net-new SQL — no size measurement exists today).


### PR DESCRIPTION
🤖 Adds a metrics surface to alertd that munin can harvest, alongside the supporting plumbing.

## Summary

- A new `Stat` type lets doctor healthchecks declare typed numeric metrics (gauge/counter, labels, help) via `Check::with_stat`, kept separate from the canopy `details`.
- `/metrics` now serves either prometheus text (the default) or munin-native text, negotiated on the `Accept` header (`text/x-munin`), with munin's `?config` mode for field metadata. The existing `bes_alertd_last_activity_unix` liveness gauge is unchanged.
- A global status census is exposed as `bes_alertd_checks{state="passing|warning|failing|skipped|broken"}` (plus total), derived from the latest sweep with canopy's severity ceilings applied.
- Instruments the first batch of checks — `caddy_certs`, `fhir_jobs`, `sync_lookup`, `sync_sessions`, `sync_snapshot_tables`, `disk_free`, `memory`, `load`, `db_connect`, `http_errors` — including dimensioned data via labels (fhir jobs by status, http requests by code, per-mount disk, per-cert expiry).
- Reports a top-level `munin: bool` fact to canopy when munin-node is installed.
- Ships a munin plugin in the deb at `/usr/share/munin/plugins/bestool_alertd`; the postinst activates it when munin-node is present and the postrm removes it on package removal.

## Format negotiation

- Default / prometheus `Accept` → prometheus exposition text, so existing scrapers are undisturbed (they just gain the new series).
- `Accept: text/x-munin` → munin native. `?config` returns field metadata; a bare request returns values.

The `DoctorMetricsHandle` threading the latest sweep into `ServerState` mirrors the existing `backups` handle.

## Follow-up (not in this PR)

Instrumenting the remaining numeric checks (the `*_errors` family, `inodes`, `btrfs`, `external_users`, `tamanu_http`, `pg_tuning`, …) and adding p50/p99 snapshot-table sizes — which needs new SQL, as no size measurement exists today — will come as a stacked PR.
