### PR TITLE
feat(alertd): group munin metrics, report liveness as age, spec the metrics

### DIFF
--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -1,0 +1,58 @@
+---
+id: MET
+---
+
+# Doctor metrics
+
+The alertd daemon exposes the numeric telemetry its healthchecks gather as metrics on its `/metrics` endpoint, in either prometheus or munin format.
+See [CHK](healthchecks.md) for the checks themselves and [DOC](doctor.md) for the sweep that produces them.
+
+Metrics are additive telemetry: what a check declares as metrics never changes its verdict, its summary, or the facts it reports to Canopy.
+
+## The endpoint
+
+`/metrics` serves prometheus text by default, and for a request whose `Accept` offers `*/*` or a prometheus content type, so existing scrapers are unaffected.
+It serves munin text when the request's `Accept` asks for the munin content type.
+
+Munin scrapes in two calls: a config request returns field and graph metadata, and a bare request returns values.
+Both are rendered from the same sweep snapshot within a scrape, so a graph's declared fields and its values always agree.
+
+A thin munin plugin ships in the bestool deb and is wired active on hosts where munin-node is present.
+The daemon also reports whether munin-node is present on the host as a top-level fact to Canopy.
+
+## Daemon liveness
+
+The daemon always reports how long ago it was last active, and — once it has completed a sweep — how long ago that sweep finished, each as an age in seconds rather than an absolute timestamp, so a scrape can alert on staleness without computing the difference itself.
+
+## Check census
+
+Every sweep yields a count of checks by outcome — passing, warning, failing, skipped, broken — and a total, capped to Canopy's effective severities so the census matches what operators see elsewhere.
+In munin the census is a single stacked-area graph, so the make-up of the host's check outcomes reads at a glance.
+
+## Declared metrics
+
+A check declares typed metrics. Each metric carries:
+
+- a name in `snake_case` that is a valid prometheus name and munin field;
+- a value;
+- a kind — a gauge that rises and falls, or a counter that only increases;
+- optional labels: dimensions with a fixed key and a per-series value, such as a mount point, an HTTP status code, or a percentile;
+- a human description;
+- an optional group (see below).
+
+A metric's unit lives in its name by convention — `_seconds`, `_bytes`, `_ms` — and a metric that measures a duration or a size always names its unit, so no metric reads as a bare unitless number when it is really a quantity.
+
+## Grouping into munin graphs
+
+Prometheus models dimensioned metrics with labels natively: one metric family per name, one series per label combination.
+
+Munin has no labels, so a check's metrics are grouped into graphs.
+There is one graph per group; a metric with no explicit group forms its own graph, named for the metric.
+Metrics that share a unit and are read together — a total and its components, a warn tier beside its fail tier, used beside total — declare a shared group and share a graph.
+Metrics of different units are never placed in the same graph, so no graph mixes scales on one axis.
+The label-dimensioned series of a single metric — one per mount, per status code, per percentile — are the fields of that metric's graph.
+
+## Sync session durations
+
+The sync-sessions check reports the number of currently active sync sessions, and, for the most recently completed session, the duration in seconds of each phase of the sync: the snapshot phase, the persist phase, and the session overall.
+The phase durations share one graph.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,6 @@ dependencies = [
  "jiff",
  "miette",
  "node-semver",
- "prometheus",
  "reqwest",
  "rustix 1.1.4",
  "rustls",
@@ -5493,21 +5492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5580,26 +5564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost 0.13.5",
-]
-
-[[package]]
-name = "protobuf"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/crates/alertd/Cargo.toml
+++ b/crates/alertd/Cargo.toml
@@ -26,7 +26,6 @@ hickory-resolver = "0.26.1"
 jiff = { version = "0.2.28", features = ["serde"] }
 node-semver = "2.2.0"
 miette = { workspace = true }
-prometheus = "0.14.0"
 reqwest = { workspace = true }
 rustls = "0.23.40"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/alertd/src/daemon.rs
+++ b/crates/alertd/src/daemon.rs
@@ -85,7 +85,6 @@ pub async fn run_with_shutdown(
 	// restart can't leave a backup running to collide with the next one.
 	crate::child_confinement::confine_children();
 
-	metrics::init_metrics();
 	metrics::record_activity();
 
 	let pool = daemon_config.pg_pool.clone();

--- a/crates/alertd/src/doctor/checks/billing_tags.rs
+++ b/crates/alertd/src/doctor/checks/billing_tags.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 use bestool_tamanu::server_info::load_cached_tags;
 
 use super::SweepContext;
-use crate::doctor::{Stat, check::Check, server_info::fetch_imds_tags};
+use crate::doctor::{check::Check, server_info::fetch_imds_tags};
 
 const CHECK_NAME: &str = "billing_tags";
 const BILLING_PREFIX: &str = "billing.";
@@ -145,14 +145,6 @@ impl Reconciliation {
 		check
 			.with_detail("missing", missing_detail)
 			.with_detail("mismatched", mismatched_detail)
-			.with_stat(
-				Stat::gauge("missing", self.missing.len() as f64)
-					.help("Billing tags missing from IMDS"),
-			)
-			.with_stat(
-				Stat::gauge("mismatched", self.mismatched.len() as f64)
-					.help("Billing tags disagreeing with canopy"),
-			)
 	}
 }
 

--- a/crates/alertd/src/doctor/checks/disk_free.rs
+++ b/crates/alertd/src/doctor/checks/disk_free.rs
@@ -70,11 +70,13 @@ pub async fn run(ctx: SweepContext) -> Check {
 		let mount = disk.mount_point().to_string_lossy().into_owned();
 		stats.push(
 			Stat::gauge("free_bytes", free as f64)
+				.group("bytes")
 				.label("mount", mount.clone())
 				.help("Free disk space"),
 		);
 		stats.push(
 			Stat::gauge("total_bytes", total as f64)
+				.group("bytes")
 				.label("mount", mount.clone())
 				.help("Total disk space"),
 		);

--- a/crates/alertd/src/doctor/checks/fhir_jobs.rs
+++ b/crates/alertd/src/doctor/checks/fhir_jobs.rs
@@ -120,7 +120,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 			.with_detail("oldest_active", ts.to_string())
 			.with_detail("oldest_active_age_secs", oldest_age_secs)
 			.with_stat(
-				Stat::gauge("oldest_active_age_secs", oldest_age_secs as f64)
+				Stat::gauge("oldest_active_age_seconds", oldest_age_secs as f64)
 					.help("Age of the oldest active FHIR job"),
 			);
 	}

--- a/crates/alertd/src/doctor/checks/fhir_service_requests_unresolved.rs
+++ b/crates/alertd/src/doctor/checks/fhir_service_requests_unresolved.rs
@@ -40,9 +40,15 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 	if rows.is_empty() {
 		return Check::pass(NAME, "no unresolved FHIR service requests")
-			.with_stat(Stat::gauge("fail", 0.0).help("Requests unresolved past the fail threshold"))
 			.with_stat(
-				Stat::gauge("warn", 0.0).help("Requests unresolved past the warn threshold"),
+				Stat::gauge("fail", 0.0)
+					.group("thresholds")
+					.help("Requests unresolved past the fail threshold"),
+			)
+			.with_stat(
+				Stat::gauge("warn", 0.0)
+					.group("thresholds")
+					.help("Requests unresolved past the warn threshold"),
 			);
 	}
 
@@ -64,9 +70,15 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 	if warn.is_empty() && fail.is_empty() {
 		return Check::pass(NAME, "no unresolved FHIR service requests")
-			.with_stat(Stat::gauge("fail", 0.0).help("Requests unresolved past the fail threshold"))
 			.with_stat(
-				Stat::gauge("warn", 0.0).help("Requests unresolved past the warn threshold"),
+				Stat::gauge("fail", 0.0)
+					.group("thresholds")
+					.help("Requests unresolved past the fail threshold"),
+			)
+			.with_stat(
+				Stat::gauge("warn", 0.0)
+					.group("thresholds")
+					.help("Requests unresolved past the warn threshold"),
 			);
 	}
 
@@ -83,10 +95,14 @@ pub async fn run(ctx: CheckContext) -> Check {
 	};
 	check
 		.with_stat(
-			Stat::gauge("fail", fail_n as f64).help("Requests unresolved past the fail threshold"),
+			Stat::gauge("fail", fail_n as f64)
+				.group("thresholds")
+				.help("Requests unresolved past the fail threshold"),
 		)
 		.with_stat(
-			Stat::gauge("warn", warn_n as f64).help("Requests unresolved past the warn threshold"),
+			Stat::gauge("warn", warn_n as f64)
+				.group("thresholds")
+				.help("Requests unresolved past the warn threshold"),
 		)
 		.with_detail("fail", Value::Array(fail))
 		.with_detail("warn", Value::Array(warn))

--- a/crates/alertd/src/doctor/checks/http_errors.rs
+++ b/crates/alertd/src/doctor/checks/http_errors.rs
@@ -202,9 +202,16 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		.with_detail("total_requests", 0u64)
 		.with_detail("window_seconds", window.as_secs())
 		.with_detail("baseline_source", source_label)
-		.with_stat(Stat::gauge("requests", 0.0).help("Requests in the window"))
-		.with_stat(Stat::gauge("server_errors", 0.0).help("5xx responses in the window"))
-		.with_stat(Stat::gauge("window_seconds", window.as_secs() as f64));
+		.with_stat(
+			Stat::gauge("requests", 0.0)
+				.group("traffic")
+				.help("Requests in the window"),
+		)
+		.with_stat(
+			Stat::gauge("server_errors", 0.0)
+				.group("traffic")
+				.help("5xx responses in the window"),
+		);
 	}
 
 	let pct = ((errored as f64 / total as f64) * 100.0).round();
@@ -240,10 +247,17 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		.with_detail("window_seconds", window.as_secs())
 		.with_detail("baseline_source", source_label)
 		.with_detail("by_code", Value::Object(by_code))
-		.with_stat(Stat::gauge("requests", total as f64).help("Requests in the window"))
-		.with_stat(Stat::gauge("server_errors", errored as f64).help("5xx responses in the window"))
+		.with_stat(
+			Stat::gauge("requests", total as f64)
+				.group("traffic")
+				.help("Requests in the window"),
+		)
+		.with_stat(
+			Stat::gauge("server_errors", errored as f64)
+				.group("traffic")
+				.help("5xx responses in the window"),
+		)
 		.with_stat(Stat::gauge("server_error_rate_pct", pct).help("5xx rate, percent"))
-		.with_stat(Stat::gauge("window_seconds", window.as_secs() as f64))
 		.with_stats(deltas.iter().map(|(code, n)| {
 			Stat::gauge("requests_by_code", *n as f64)
 				.label("code", code.clone())

--- a/crates/alertd/src/doctor/checks/load.rs
+++ b/crates/alertd/src/doctor/checks/load.rs
@@ -55,9 +55,21 @@ pub async fn run(_ctx: SweepContext) -> Check {
 		.with_detail("five_min", load.five)
 		.with_detail("fifteen_min", load.fifteen)
 		.with_detail("cores", cores)
-		.with_stat(Stat::gauge("one_min", load.one).help("1-minute load average"))
-		.with_stat(Stat::gauge("five_min", load.five).help("5-minute load average"))
-		.with_stat(Stat::gauge("fifteen_min", load.fifteen).help("15-minute load average"))
+		.with_stat(
+			Stat::gauge("one_min", load.one)
+				.group("averages")
+				.help("1-minute load average"),
+		)
+		.with_stat(
+			Stat::gauge("five_min", load.five)
+				.group("averages")
+				.help("5-minute load average"),
+		)
+		.with_stat(
+			Stat::gauge("fifteen_min", load.fifteen)
+				.group("averages")
+				.help("15-minute load average"),
+		)
 		.with_stat(Stat::gauge("cores", cores as f64).help("Logical CPU cores"))
 }
 

--- a/crates/alertd/src/doctor/checks/memory.rs
+++ b/crates/alertd/src/doctor/checks/memory.rs
@@ -32,8 +32,16 @@ pub async fn run(_ctx: SweepContext) -> Check {
 		.with_detail("used_bytes", used)
 		.with_detail("total_bytes", total)
 		.with_detail("percent_used", pct)
-		.with_stat(Stat::gauge("used_bytes", used as f64).help("Memory in use"))
-		.with_stat(Stat::gauge("total_bytes", total as f64).help("Total memory"))
+		.with_stat(
+			Stat::gauge("used_bytes", used as f64)
+				.group("bytes")
+				.help("Memory in use"),
+		)
+		.with_stat(
+			Stat::gauge("total_bytes", total as f64)
+				.group("bytes")
+				.help("Total memory"),
+		)
 		.with_stat(Stat::gauge("percent_used", pct).help("Memory used, percent"))
 }
 

--- a/crates/alertd/src/doctor/checks/pg_tuning.rs
+++ b/crates/alertd/src/doctor/checks/pg_tuning.rs
@@ -401,16 +401,24 @@ pub async fn run(ctx: CheckContext) -> Check {
 			settings.effective_io_concurrency,
 		)
 		.with_detail("max_wal_size_bytes", settings.max_wal_size)
-		.with_stat(Stat::gauge("total_ram_bytes", total_ram as f64).help("Host RAM"))
 		.with_stat(
-			Stat::gauge("pg_ram_budget_bytes", budget as f64).help("RAM budget for postgres"),
+			Stat::gauge("total_ram_bytes", total_ram as f64)
+				.group("bytes")
+				.help("Host RAM"),
+		)
+		.with_stat(
+			Stat::gauge("pg_ram_budget_bytes", budget as f64)
+				.group("bytes")
+				.help("RAM budget for postgres"),
 		)
 		.with_stat(
 			Stat::gauge("shared_buffers_bytes", settings.shared_buffers as f64)
+				.group("bytes")
 				.help("shared_buffers"),
 		)
 		.with_stat(
 			Stat::gauge("shared_buffers_expected_bytes", expected_shared as f64)
+				.group("bytes")
 				.help("Expected shared_buffers for this host"),
 		)
 		.with_stat(
@@ -418,6 +426,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 				"effective_cache_size_bytes",
 				settings.effective_cache_size as f64,
 			)
+			.group("bytes")
 			.help("effective_cache_size"),
 		)
 		.with_stat(
@@ -425,14 +434,21 @@ pub async fn run(ctx: CheckContext) -> Check {
 				"maintenance_work_mem_bytes",
 				settings.maintenance_work_mem as f64,
 			)
+			.group("bytes")
 			.help("maintenance_work_mem"),
 		)
-		.with_stat(Stat::gauge("work_mem_bytes", settings.work_mem as f64).help("work_mem"))
+		.with_stat(
+			Stat::gauge("work_mem_bytes", settings.work_mem as f64)
+				.group("bytes")
+				.help("work_mem"),
+		)
 		.with_stat(
 			Stat::gauge("max_connections", settings.max_connections as f64).help("max_connections"),
 		)
 		.with_stat(
-			Stat::gauge("max_wal_size_bytes", settings.max_wal_size as f64).help("max_wal_size"),
+			Stat::gauge("max_wal_size_bytes", settings.max_wal_size as f64)
+				.group("bytes")
+				.help("max_wal_size"),
 		)
 }
 

--- a/crates/alertd/src/doctor/checks/sync_facility_stale.rs
+++ b/crates/alertd/src/doctor/checks/sync_facility_stale.rs
@@ -80,10 +80,14 @@ pub async fn run(ctx: CheckContext) -> Check {
 	if warn.is_empty() && fail.is_empty() {
 		return Check::pass(NAME, "all facilities syncing")
 			.with_stat(
-				Stat::gauge("fail", 0.0).help("Facilities past the fail staleness threshold"),
+				Stat::gauge("fail", 0.0)
+					.group("thresholds")
+					.help("Facilities past the fail staleness threshold"),
 			)
 			.with_stat(
-				Stat::gauge("warn", 0.0).help("Facilities past the warn staleness threshold"),
+				Stat::gauge("warn", 0.0)
+					.group("thresholds")
+					.help("Facilities past the warn staleness threshold"),
 			);
 	}
 
@@ -102,10 +106,14 @@ pub async fn run(ctx: CheckContext) -> Check {
 	};
 	check
 		.with_stat(
-			Stat::gauge("fail", fail_n as f64).help("Facilities past the fail staleness threshold"),
+			Stat::gauge("fail", fail_n as f64)
+				.group("thresholds")
+				.help("Facilities past the fail staleness threshold"),
 		)
 		.with_stat(
-			Stat::gauge("warn", warn_n as f64).help("Facilities past the warn staleness threshold"),
+			Stat::gauge("warn", warn_n as f64)
+				.group("thresholds")
+				.help("Facilities past the warn staleness threshold"),
 		)
 		.with_detail("fail", Value::Array(fail))
 		.with_detail("warn", Value::Array(warn))

--- a/crates/alertd/src/doctor/checks/sync_restart_loop.rs
+++ b/crates/alertd/src/doctor/checks/sync_restart_loop.rs
@@ -54,8 +54,16 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 	if warn.is_empty() && fail.is_empty() {
 		return Check::pass(NAME, "no sync restart loops")
-			.with_stat(Stat::gauge("fail", 0.0).help("Facilities past the fail restart rate"))
-			.with_stat(Stat::gauge("warn", 0.0).help("Facilities past the warn restart rate"));
+			.with_stat(
+				Stat::gauge("fail", 0.0)
+					.group("thresholds")
+					.help("Facilities past the fail restart rate"),
+			)
+			.with_stat(
+				Stat::gauge("warn", 0.0)
+					.group("thresholds")
+					.help("Facilities past the warn restart rate"),
+			);
 	}
 
 	let (fail_n, warn_n) = (fail.len(), warn.len());
@@ -70,8 +78,16 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Check::fail(NAME, summary, "facilities in sync restart loop")
 	};
 	check
-		.with_stat(Stat::gauge("fail", fail_n as f64).help("Facilities past the fail restart rate"))
-		.with_stat(Stat::gauge("warn", warn_n as f64).help("Facilities past the warn restart rate"))
+		.with_stat(
+			Stat::gauge("fail", fail_n as f64)
+				.group("thresholds")
+				.help("Facilities past the fail restart rate"),
+		)
+		.with_stat(
+			Stat::gauge("warn", warn_n as f64)
+				.group("thresholds")
+				.help("Facilities past the warn restart rate"),
+		)
 		.with_detail("fail", Value::Array(fail))
 		.with_detail("warn", Value::Array(warn))
 }

--- a/crates/alertd/src/doctor/checks/sync_sessions.rs
+++ b/crates/alertd/src/doctor/checks/sync_sessions.rs
@@ -32,9 +32,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Ok(None) => {
 			return Check::pass("sync_sessions", "no sync sessions")
 				.with_detail("active_count", 0)
-				.with_stat(Stat::gauge("active", 0.0).help("Active sync sessions"))
-				.with_stat(Stat::gauge("stuck_15m", 0.0))
-				.with_stat(Stat::gauge("stuck_45m", 0.0));
+				.with_stat(Stat::gauge("active", 0.0).help("Active sync sessions"));
 		}
 		Err(err) => {
 			if let Some(db) = err.as_db_error()
@@ -75,15 +73,74 @@ pub async fn run(ctx: CheckContext) -> Check {
 	let mut check = check
 		.with_detail("active_count", active)
 		.with_detail("stuck_count", stuck_warn)
-		.with_stat(Stat::gauge("active", active as f64).help("Active sync sessions"))
-		.with_stat(
-			Stat::gauge("stuck_15m", stuck_warn as f64).help("Sessions running over 15 minutes"),
-		)
-		.with_stat(
-			Stat::gauge("stuck_45m", stuck_fail as f64).help("Sessions running over 45 minutes"),
-		);
+		.with_stat(Stat::gauge("active", active as f64).help("Active sync sessions"));
 	if let Some(ts) = oldest {
 		check = check.with_detail("oldest_started_at", ts.to_string());
 	}
+
+	// Phase durations of the most recently completed session, so operators can
+	// see how long each phase of a sync takes over time. Grading is unchanged;
+	// these are additional telemetry only.
+	let durations = last_session_phase_durations(client).await;
+	if let Some(s) = durations.snapshot {
+		check = check.with_stat(
+			Stat::gauge("snapshot_duration_seconds", s)
+				.group("durations")
+				.help("Snapshot phase of the last completed sync"),
+		);
+	}
+	if let Some(s) = durations.persist {
+		check = check.with_stat(
+			Stat::gauge("persist_duration_seconds", s)
+				.group("durations")
+				.help("Persist phase of the last completed sync"),
+		);
+	}
+	if let Some(s) = durations.total {
+		check = check.with_stat(
+			Stat::gauge("total_duration_seconds", s)
+				.group("durations")
+				.help("Total duration of the last completed sync"),
+		);
+	}
 	check
+}
+
+/// Phase durations, in seconds, of one sync session.
+struct PhaseDurations {
+	snapshot: Option<f64>,
+	persist: Option<f64>,
+	total: Option<f64>,
+}
+
+/// Durations of the phases of the most recently completed sync session:
+/// the snapshot phase, the persist phase, and the session overall. A phase
+/// whose timestamps are missing (an older session, or one that skipped it) is
+/// left out. Returns all-absent when no session has completed or the query
+/// fails — this is telemetry, never a reason to fail the check.
+async fn last_session_phase_durations(client: &tokio_postgres::Client) -> PhaseDurations {
+	let none = PhaseDurations {
+		snapshot: None,
+		persist: None,
+		total: None,
+	};
+	let query = "SELECT snapshot_started_at, snapshot_completed_at, persist_completed_at, \
+		start_time, completed_at \
+		FROM sync_sessions WHERE completed_at IS NOT NULL \
+		ORDER BY completed_at DESC LIMIT 1";
+	let Ok(Some(row)) = client.query_opt(query, &[]).await else {
+		return none;
+	};
+	let at = |col| row.try_get::<_, Option<Timestamp>>(col).ok().flatten();
+	let between = |end: Option<Timestamp>, start: Option<Timestamp>| match (end, start) {
+		(Some(end), Some(start)) => Some((end - start).get_seconds().max(0) as f64),
+		_ => None,
+	};
+	let snapshot_started = at("snapshot_started_at");
+	let snapshot_completed = at("snapshot_completed_at");
+	PhaseDurations {
+		snapshot: between(snapshot_completed, snapshot_started),
+		persist: between(at("persist_completed_at"), snapshot_completed),
+		total: between(at("completed_at"), at("start_time")),
+	}
 }

--- a/crates/alertd/src/doctor/checks/sync_snapshot_tables.rs
+++ b/crates/alertd/src/doctor/checks/sync_snapshot_tables.rs
@@ -80,13 +80,11 @@ pub async fn run(ctx: CheckContext) -> Check {
 	let mut check = check
 		.with_detail("table_count", tables)
 		.with_detail("sessions_24h", sessions)
-		.with_stat(Stat::gauge("table_count", tables as f64).help("Leftover sync-snapshot tables"))
-		.with_stat(
-			Stat::gauge("sessions_24h", sessions as f64).help("Sync sessions in the last 24h"),
-		);
+		.with_stat(Stat::gauge("table_count", tables as f64).help("Leftover sync-snapshot tables"));
 	if let Some(p50) = p50 {
 		check = check.with_stat(
 			Stat::gauge("table_size_bytes", p50)
+				.group("sizes")
 				.label("quantile", "0.5")
 				.help("Snapshot-table size percentiles"),
 		);
@@ -94,13 +92,16 @@ pub async fn run(ctx: CheckContext) -> Check {
 	if let Some(p99) = p99 {
 		check = check.with_stat(
 			Stat::gauge("table_size_bytes", p99)
+				.group("sizes")
 				.label("quantile", "0.99")
 				.help("Snapshot-table size percentiles"),
 		);
 	}
 	if let Some(total) = total_bytes {
 		check = check.with_stat(
-			Stat::gauge("total_size_bytes", total).help("Total size of all snapshot tables"),
+			Stat::gauge("total_size_bytes", total)
+				.group("sizes")
+				.help("Total size of all snapshot tables"),
 		);
 	}
 	check

--- a/crates/alertd/src/doctor/checks/uptime.rs
+++ b/crates/alertd/src/doctor/checks/uptime.rs
@@ -1,7 +1,6 @@
 use sysinfo::System;
 
 use super::SweepContext;
-use crate::doctor::Stat;
 use crate::doctor::check::Check;
 
 /// Below this uptime the host has rebooted recently, which may be unexpected.
@@ -19,9 +18,7 @@ pub async fn run(_ctx: SweepContext) -> Check {
 	} else {
 		Check::pass("uptime", summary)
 	};
-	check
-		.with_detail("uptime_secs", secs)
-		.with_stat(Stat::gauge("uptime_seconds", secs as f64).help("Host uptime"))
+	check.with_detail("uptime_secs", secs)
 }
 
 fn humanise(secs: u64) -> String {
@@ -34,19 +31,5 @@ fn humanise(secs: u64) -> String {
 		format!("{h}h {m}m")
 	} else {
 		format!("{m}m")
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[tokio::test]
-	async fn emits_uptime_stat() {
-		let ctx = SweepContext::builder()
-			.http_client(reqwest::Client::new())
-			.build();
-		let check = run(ctx).await;
-		assert!(check.stats.iter().any(|s| s.name == "uptime_seconds"));
 	}
 }

--- a/crates/alertd/src/doctor/stat.rs
+++ b/crates/alertd/src/doctor/stat.rs
@@ -54,6 +54,11 @@ pub struct Stat {
 	pub labels: Vec<(&'static str, String)>,
 	/// Human description: prometheus `# HELP`, munin field label.
 	pub help: Option<String>,
+	/// Munin graph group within the check: metrics sharing a group render as
+	/// fields of one graph. `None` gives the metric its own graph, named for
+	/// it. Only meaningful for munin; prometheus dimensions everything by name
+	/// and labels regardless.
+	pub group: Option<&'static str>,
 }
 
 impl Stat {
@@ -64,6 +69,7 @@ impl Stat {
 			kind: StatKind::Gauge,
 			labels: Vec::new(),
 			help: None,
+			group: None,
 		}
 	}
 
@@ -74,6 +80,7 @@ impl Stat {
 			kind: StatKind::Counter,
 			labels: Vec::new(),
 			help: None,
+			group: None,
 		}
 	}
 
@@ -86,6 +93,14 @@ impl Stat {
 
 	pub fn help(mut self, help: impl Into<String>) -> Self {
 		self.help = Some(help.into());
+		self
+	}
+
+	/// Place this metric in a named munin graph group, so metrics that share a
+	/// unit and are read together render on one graph. Metrics of different
+	/// units should stay in separate groups (the default: their own graph).
+	pub fn group(mut self, group: &'static str) -> Self {
+		self.group = Some(group);
 		self
 	}
 }
@@ -171,6 +186,15 @@ mod tests {
 	fn help_is_attached() {
 		let s = Stat::gauge("x", 1.0).help("a thing");
 		assert_eq!(s.help.as_deref(), Some("a thing"));
+	}
+
+	#[test]
+	fn group_defaults_none_and_is_attachable() {
+		assert!(Stat::gauge("x", 1.0).group.is_none());
+		assert_eq!(
+			Stat::gauge("used_bytes", 1.0).group("bytes").group,
+			Some("bytes")
+		);
 	}
 
 	#[test]

--- a/crates/alertd/src/http_server/endpoints/metrics.rs
+++ b/crates/alertd/src/http_server/endpoints/metrics.rs
@@ -2,10 +2,9 @@ use std::sync::Arc;
 
 use axum::{
 	extract::{RawQuery, State},
-	http::{HeaderMap, StatusCode, header},
+	http::{HeaderMap, header},
 	response::IntoResponse,
 };
-use tracing::error;
 
 use crate::http_server::{ServerState, metrics_render};
 use crate::metrics;
@@ -33,36 +32,22 @@ pub async fn handle_metrics(
 		None => None,
 	};
 
+	// Ages are computed at scrape time from the last-activity/last-sweep instants
+	// and this `now`, so a scraper reads "N seconds ago" directly.
+	let now = jiff::Timestamp::now().as_second();
+	let last_activity = metrics::last_activity_timestamp();
+
 	if wants_munin {
 		// Munin's two-call protocol: `?config` asks for field metadata, a bare
 		// request for values.
 		let config = query
 			.as_deref()
 			.is_some_and(|q| q.split('&').any(|p| p == "config"));
-		let body = metrics_render::render_munin(
-			snapshot.as_ref(),
-			metrics::last_activity_timestamp(),
-			config,
-		);
+		let body = metrics_render::render_munin(snapshot.as_ref(), now, last_activity, config);
 		return ([(header::CONTENT_TYPE, "text/plain; charset=utf-8")], body).into_response();
 	}
 
-	// Prometheus: keep the existing registry gauge output verbatim (so existing
-	// scrapers are undisturbed), then append the sweep-derived metrics.
-	let mut body = match metrics::gather_metrics() {
-		Ok(text) => text,
-		Err(e) => {
-			error!("failed to gather metrics: {e:?}");
-			return (
-				StatusCode::INTERNAL_SERVER_ERROR,
-				format!("Failed to gather metrics: {e}\n"),
-			)
-				.into_response();
-		}
-	};
-	if let Some(snapshot) = &snapshot {
-		body.push_str(&metrics_render::render_prometheus(snapshot));
-	}
+	let body = metrics_render::render_prometheus(snapshot.as_ref(), now, last_activity);
 	([(header::CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)], body).into_response()
 }
 
@@ -80,13 +65,6 @@ mod tests {
 
 	use super::*;
 	use crate::{context::InternalContext, http_server::ServerState};
-
-	/// The prometheus registry is process-global and initialises exactly once;
-	/// guard it so parallel tests don't double-init.
-	fn init_metrics_once() {
-		static INIT: std::sync::Once = std::sync::Once::new();
-		INIT.call_once(crate::metrics::init_metrics);
-	}
 
 	/// A minimal server state with no doctor metrics handle and no database —
 	/// enough to exercise the endpoint's format negotiation.
@@ -118,7 +96,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn default_is_prometheus() {
-		init_metrics_once();
 		let response = handle_metrics(State(state()), HeaderMap::new(), RawQuery(None))
 			.await
 			.into_response();
@@ -132,7 +109,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn accept_munin_selects_munin() {
-		init_metrics_once();
 		let mut headers = HeaderMap::new();
 		headers.insert(header::ACCEPT, HeaderValue::from_static(MUNIN_MEDIA_TYPE));
 		let response = handle_metrics(State(state()), headers, RawQuery(None))
@@ -146,7 +122,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn munin_config_query_is_honoured() {
-		init_metrics_once();
 		let mut headers = HeaderMap::new();
 		headers.insert(header::ACCEPT, HeaderValue::from_static(MUNIN_MEDIA_TYPE));
 		let response = handle_metrics(State(state()), headers, RawQuery(Some("config".into())))

--- a/crates/alertd/src/http_server/metrics_render.rs
+++ b/crates/alertd/src/http_server/metrics_render.rs
@@ -76,27 +76,50 @@ fn prom_name(check: &str, stat: &Stat) -> String {
 	format!("{PREFIX}_{check}_{}", stat.name)
 }
 
-/// Render the snapshot's prometheus body (census + per-check stats). Does not
-/// include the liveness gauge, which the caller appends from the registry to
-/// preserve its exact existing output.
-pub fn render_prometheus(snapshot: &MetricsSnapshot) -> String {
+/// Render the prometheus body: daemon liveness (as an age), and — when a sweep
+/// is cached — the check census and per-check stats. `now` and `last_activity`
+/// are unix seconds; the liveness age is their difference, computed here so a
+/// scraper reads seconds-since directly.
+pub fn render_prometheus(
+	snapshot: Option<&MetricsSnapshot>,
+	now: i64,
+	last_activity: i64,
+) -> String {
 	let mut out = String::new();
 
-	out.push_str(&format!(
-		"# HELP {PREFIX}_last_sweep_unix Unix time of the last doctor sweep\n"
-	));
-	out.push_str(&format!("# TYPE {PREFIX}_last_sweep_unix gauge\n"));
-	out.push_str(&format!(
-		"{PREFIX}_last_sweep_unix {}\n",
-		snapshot.computed_at.as_second()
-	));
+	let _ = writeln!(
+		out,
+		"# HELP {PREFIX}_last_activity_age_seconds Seconds since the daemon was last active"
+	);
+	let _ = writeln!(out, "# TYPE {PREFIX}_last_activity_age_seconds gauge");
+	let _ = writeln!(
+		out,
+		"{PREFIX}_last_activity_age_seconds {}",
+		now - last_activity
+	);
 
-	out.push_str(&format!(
-		"# HELP {PREFIX}_checks Number of doctor checks by outcome\n"
-	));
-	out.push_str(&format!("# TYPE {PREFIX}_checks gauge\n"));
+	let Some(snapshot) = snapshot else {
+		return out;
+	};
+
+	let _ = writeln!(
+		out,
+		"# HELP {PREFIX}_last_sweep_age_seconds Seconds since the last doctor sweep"
+	);
+	let _ = writeln!(out, "# TYPE {PREFIX}_last_sweep_age_seconds gauge");
+	let _ = writeln!(
+		out,
+		"{PREFIX}_last_sweep_age_seconds {}",
+		now - snapshot.computed_at.as_second()
+	);
+
+	let _ = writeln!(
+		out,
+		"# HELP {PREFIX}_checks Number of doctor checks by outcome"
+	);
+	let _ = writeln!(out, "# TYPE {PREFIX}_checks gauge");
 	for (state, count) in snapshot.counts.by_state() {
-		out.push_str(&format!("{PREFIX}_checks{{state=\"{state}\"}} {count}\n"));
+		let _ = writeln!(out, "{PREFIX}_checks{{state=\"{state}\"}} {count}");
 	}
 
 	// Group per-check stats into prometheus metric families (same name = same
@@ -158,26 +181,30 @@ struct Family {
 /// graphs need a sweep (their field sets are only known from one).
 pub fn render_munin(
 	snapshot: Option<&MetricsSnapshot>,
+	now: i64,
 	last_activity: i64,
 	config: bool,
 ) -> String {
 	let mut out = String::new();
 
-	// Daemon graph: liveness and (when available) last-sweep timestamps.
-	out.push_str("multigraph bes_alertd_daemon\n");
+	// Daemon graph: how long ago the daemon was last active and last swept, as
+	// ages in seconds rather than raw timestamps (which graph as an ever-rising
+	// line). `now` and the instants are unix seconds.
+	let _ = writeln!(out, "multigraph bes_alertd_daemon");
 	if config {
-		out.push_str("graph_title alertd daemon activity\n");
-		out.push_str("graph_category bestool\n");
-		out.push_str("last_activity.label last activity (unix)\n");
-		out.push_str("last_activity.type GAUGE\n");
+		let _ = writeln!(out, "graph_title alertd daemon activity");
+		let _ = writeln!(out, "graph_category bestool");
+		let _ = writeln!(out, "graph_vlabel seconds ago");
+		let _ = writeln!(out, "last_activity.label last activity (seconds ago)");
+		let _ = writeln!(out, "last_activity.type GAUGE");
 		if snapshot.is_some() {
-			out.push_str("last_sweep.label last sweep (unix)\n");
-			out.push_str("last_sweep.type GAUGE\n");
+			let _ = writeln!(out, "last_sweep.label last sweep (seconds ago)");
+			let _ = writeln!(out, "last_sweep.type GAUGE");
 		}
 	} else {
-		let _ = writeln!(out, "last_activity.value {last_activity}");
+		let _ = writeln!(out, "last_activity.value {}", now - last_activity);
 		if let Some(s) = snapshot {
-			let _ = writeln!(out, "last_sweep.value {}", s.computed_at.as_second());
+			let _ = writeln!(out, "last_sweep.value {}", now - s.computed_at.as_second());
 		}
 	}
 
@@ -186,17 +213,22 @@ pub fn render_munin(
 	};
 
 	// Census graph.
-	out.push_str("\nmultigraph bes_alertd_checks\n");
+	let _ = writeln!(out, "\nmultigraph bes_alertd_checks");
 	if config {
-		out.push_str("graph_title Doctor checks by outcome\n");
-		out.push_str("graph_category bestool\n");
-		out.push_str("graph_vlabel checks\n");
+		let _ = writeln!(out, "graph_title Doctor checks by outcome");
+		let _ = writeln!(out, "graph_category bestool");
+		let _ = writeln!(out, "graph_vlabel checks");
+		// Stack the outcome counts as areas so the make-up reads at a glance;
+		// the total rides over them as a line rather than adding to the stack.
+		let _ = writeln!(out, "graph_args --lower-limit 0");
 		for state in STATE_NAMES {
 			let _ = writeln!(out, "{state}.label {state}");
 			let _ = writeln!(out, "{state}.type GAUGE");
+			let _ = writeln!(out, "{state}.draw AREASTACK");
 		}
-		out.push_str("total.label total\n");
-		out.push_str("total.type GAUGE\n");
+		let _ = writeln!(out, "total.label total");
+		let _ = writeln!(out, "total.type GAUGE");
+		let _ = writeln!(out, "total.draw LINE1");
 	} else {
 		for (state, count) in snapshot.counts.by_state() {
 			let _ = writeln!(out, "{state}.value {count}");
@@ -204,26 +236,44 @@ pub fn render_munin(
 		let _ = writeln!(out, "total.value {}", snapshot.counts.total());
 	}
 
-	// Per-check graphs, one multigraph per check, in first-seen order.
-	let mut order: Vec<&str> = Vec::new();
-	let mut by_check: std::collections::HashMap<&str, Vec<&Stat>> =
+	// One multigraph per (check, group), in first-seen order — a metric with no
+	// explicit group forms its own graph. A check's unrelated metrics — a count,
+	// a percentage, a duration, a per-code breakdown — would otherwise share a
+	// single graph's Y axis, which is meaningless; and metrics that differ only
+	// by name while sharing a label value (e.g. several btrfs gauges all tagged
+	// `mount=/`) would render as indistinguishable same-labelled fields. A check
+	// groups metrics that share a unit and are read together; label-dimensioned
+	// series of one metric become the fields of its graph.
+	let mut order: Vec<(&str, &str)> = Vec::new();
+	let mut by_group: std::collections::HashMap<(&str, &str), Vec<&Stat>> =
 		std::collections::HashMap::new();
 	for (check, stat) in &snapshot.stats {
-		by_check
-			.entry(check)
+		let check: &str = check;
+		// A metric with no explicit group forms its own graph, named for it.
+		let group = stat.group.unwrap_or(stat.name);
+		by_group
+			.entry((check, group))
 			.or_insert_with(|| {
-				order.push(check);
+				order.push((check, group));
 				Vec::new()
 			})
 			.push(stat);
 	}
 
-	for check in order {
-		let _ = write!(out, "\nmultigraph {PREFIX}_{check}\n");
-		let stats = &by_check[check];
+	for (check, group) in order {
+		let _ = writeln!(
+			out,
+			"\nmultigraph {PREFIX}_{check}_{}",
+			munin_field_segment(group)
+		);
+		let stats = &by_group[&(check, group)];
 		if config {
-			let _ = writeln!(out, "graph_title {check}");
-			out.push_str("graph_category bestool\n");
+			let _ = writeln!(out, "graph_title {check} {group}");
+			let _ = writeln!(out, "graph_category bestool");
+			// The metrics of one group share a description; use it as the graph's.
+			if let Some(help) = stats.iter().find_map(|s| s.help.as_deref()) {
+				let _ = writeln!(out, "graph_info {}", help.replace('\n', " "));
+			}
 			for stat in stats {
 				let field = munin_field(stat);
 				let _ = writeln!(out, "{field}.label {}", munin_field_label(stat));
@@ -276,9 +326,13 @@ mod tests {
 	}
 
 	#[test]
-	fn prometheus_census_and_families() {
-		let out = render_prometheus(&snapshot());
-		assert!(out.contains("bes_alertd_last_sweep_unix 1690000000"));
+	fn prometheus_liveness_census_and_families() {
+		// now is 50s after both the last activity and the sweep.
+		let out = render_prometheus(Some(&snapshot()), 1_690_000_050, 1_690_000_000);
+		// Liveness is reported as an age, not a raw timestamp.
+		assert!(out.contains("bes_alertd_last_activity_age_seconds 50"));
+		assert!(out.contains("bes_alertd_last_sweep_age_seconds 50"));
+		assert!(!out.contains("_unix"));
 		assert!(out.contains("bes_alertd_checks{state=\"passing\"} 30"));
 		assert!(out.contains("bes_alertd_checks{state=\"failing\"} 1"));
 		// Scalar stat.
@@ -299,10 +353,12 @@ mod tests {
 	#[test]
 	fn munin_values() {
 		let s = snapshot();
-		let out = render_munin(Some(&s), 1_690_000_100, false);
+		// now is 10s after the last activity and 100s after the sweep.
+		let out = render_munin(Some(&s), 1_690_000_100, 1_690_000_090, false);
 		assert!(out.contains("multigraph bes_alertd_daemon"));
-		assert!(out.contains("last_activity.value 1690000100"));
-		assert!(out.contains("last_sweep.value 1690000000"));
+		// Liveness values are ages, not raw timestamps.
+		assert!(out.contains("last_activity.value 10"));
+		assert!(out.contains("last_sweep.value 100"));
 		assert!(out.contains("multigraph bes_alertd_checks"));
 		assert!(out.contains("passing.value 30"));
 		assert!(out.contains("total.value 38"));
@@ -316,9 +372,12 @@ mod tests {
 	#[test]
 	fn munin_config() {
 		let s = snapshot();
-		let out = render_munin(Some(&s), 0, true);
+		let out = render_munin(Some(&s), 0, 0, true);
 		assert!(out.contains("multigraph bes_alertd_checks"));
 		assert!(out.contains("graph_title Doctor checks by outcome"));
+		// The census is a stacked area with the total overlaid as a line.
+		assert!(out.contains("passing.draw AREASTACK"));
+		assert!(out.contains("total.draw LINE1"));
 		assert!(out.contains("passing.type GAUGE"));
 		assert!(out.contains("multigraph bes_alertd_fhir_jobs"));
 		assert!(out.contains("graph_category bestool"));
@@ -329,13 +388,72 @@ mod tests {
 	}
 
 	#[test]
+	fn munin_splits_a_check_into_per_name_graphs() {
+		// Two metrics of one check that share a label value must not collapse
+		// into one graph of indistinguishable fields — each metric name gets
+		// its own graph, titled distinctly.
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![
+				(
+					"btrfs",
+					Stat::gauge("device_unallocated_bytes", 1.0)
+						.label("mount", "/")
+						.help("Unallocated btrfs space"),
+				),
+				(
+					"btrfs",
+					Stat::gauge("metadata_percent", 2.0)
+						.label("mount", "/")
+						.help("btrfs metadata chunk usage, percent"),
+				),
+			],
+		};
+		let out = render_munin(Some(&s), 0, 0, true);
+		assert!(out.contains("multigraph bes_alertd_btrfs_device_unallocated_bytes"));
+		assert!(out.contains("multigraph bes_alertd_btrfs_metadata_percent"));
+		assert!(out.contains("graph_title btrfs device_unallocated_bytes"));
+		assert!(out.contains("graph_title btrfs metadata_percent"));
+	}
+
+	#[test]
+	fn munin_can_group_metrics_of_a_check() {
+		// Two metrics sharing an explicit group render as fields of one graph.
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![
+				(
+					"memory",
+					Stat::gauge("used_bytes", 1.0)
+						.group("bytes")
+						.help("Memory in use"),
+				),
+				(
+					"memory",
+					Stat::gauge("total_bytes", 2.0)
+						.group("bytes")
+						.help("Total memory"),
+				),
+			],
+		};
+		let out = render_munin(Some(&s), 0, 0, true);
+		assert!(out.contains("multigraph bes_alertd_memory_bytes"));
+		assert!(!out.contains("multigraph bes_alertd_memory_used_bytes"));
+		assert!(out.contains("used_bytes.label Memory in use"));
+		assert!(out.contains("total_bytes.label Total memory"));
+	}
+
+	#[test]
 	fn munin_without_snapshot_is_liveness_only() {
-		let values = render_munin(None, 42, false);
-		assert!(values.contains("last_activity.value 42"));
+		// now is 2s after the last activity.
+		let values = render_munin(None, 44, 42, false);
+		assert!(values.contains("last_activity.value 2"));
 		assert!(!values.contains("multigraph bes_alertd_checks"));
 		assert!(!values.contains("last_sweep"));
 
-		let config = render_munin(None, 0, true);
+		let config = render_munin(None, 0, 0, true);
 		assert!(config.contains("multigraph bes_alertd_daemon"));
 		assert!(!config.contains("last_sweep"));
 	}
@@ -348,8 +466,9 @@ mod tests {
 			stats: vec![("http_errors", Stat::counter("requests_total", 9.0))],
 		};
 		assert!(
-			render_prometheus(&s).contains("# TYPE bes_alertd_http_errors_requests_total counter")
+			render_prometheus(Some(&s), 0, 0)
+				.contains("# TYPE bes_alertd_http_errors_requests_total counter")
 		);
-		assert!(render_munin(Some(&s), 0, true).contains("requests_total.type COUNTER"));
+		assert!(render_munin(Some(&s), 0, 0, true).contains("requests_total.type COUNTER"));
 	}
 }

--- a/crates/alertd/src/metrics.rs
+++ b/crates/alertd/src/metrics.rs
@@ -1,59 +1,22 @@
-//! Prometheus metrics for the alertd daemon.
+//! Daemon liveness tracking.
 //!
-//! Tracks the following metrics:
-//! - `bes_alertd_last_activity_unix`: Unix timestamp of the last activity (gauge)
+//! Records the wall-clock second of the last activity so `/health` and the
+//! watchdog can tell how stale the daemon is, and so `/metrics` can report the
+//! age at scrape time. The `/metrics` renderer computes the age from this and
+//! the scrape time; nothing exposes the raw timestamp as a metric.
 
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use jiff::Timestamp;
-use miette::{IntoDiagnostic, Result};
-use prometheus::{Encoder, IntGauge, Registry, TextEncoder};
 
-static REGISTRY: OnceLock<Registry> = OnceLock::new();
-static LAST_ACTIVITY_GAUGE: OnceLock<IntGauge> = OnceLock::new();
 static LAST_ACTIVITY: AtomicI64 = AtomicI64::new(0);
 
-pub fn init_metrics() {
-	let registry = Registry::new();
-
-	let last_activity_gauge = IntGauge::new(
-		"bes_alertd_last_activity_unix",
-		"Unix timestamp of the last activity",
-	)
-	.expect("failed to create last_activity_gauge metric");
-
-	registry
-		.register(Box::new(last_activity_gauge.clone()))
-		.expect("failed to register last_activity_gauge metric");
-
-	REGISTRY.set(registry).expect("metrics already initialized");
-	LAST_ACTIVITY_GAUGE
-		.set(last_activity_gauge)
-		.expect("metrics already initialized");
-}
-
+/// Record that the daemon did something just now.
 pub fn record_activity() {
-	let now = Timestamp::now().as_second();
-	LAST_ACTIVITY.store(now, Ordering::Relaxed);
-	if let Some(metric) = LAST_ACTIVITY_GAUGE.get() {
-		metric.set(now);
-	}
+	LAST_ACTIVITY.store(Timestamp::now().as_second(), Ordering::Relaxed);
 }
 
+/// The unix second of the last recorded activity (`0` before the first).
 pub fn last_activity_timestamp() -> i64 {
 	LAST_ACTIVITY.load(Ordering::Relaxed)
-}
-
-pub fn gather_metrics() -> Result<String> {
-	let registry = REGISTRY
-		.get()
-		.ok_or_else(|| miette::miette!("metrics not initialized"))?;
-	let metric_families = registry.gather();
-	let encoder = TextEncoder::new();
-	let mut buffer = Vec::new();
-	encoder
-		.encode(&metric_families, &mut buffer)
-		.into_diagnostic()?;
-	String::from_utf8(buffer).into_diagnostic()
 }


### PR DESCRIPTION
🤖 A cleanup of the alertd `/metrics` surface, and the spec that should have been extracted when the metrics feature's plan was unplanned.

## Spec

Recovers the discarded metrics plan into a proper spec (`MET`): the endpoint and format negotiation, the daemon liveness, the check census, the Stat model, munin graph grouping, and the munin fact + plugin.

## Munin graph grouping

A `Stat` gains an optional **group**. Munin renders one graph per `(check, group)`; a metric with no group forms its own graph. This fixes two reported problems:

- **btrfs** (and inodes, caddy_certs): four mixed-unit gauges all tagged `mount=/` were crammed into one graph as four indistinguishable `/` fields. Each metric now gets its own graph.
- **http_errors**: a count, a percentage, a duration, and a per-code breakdown shared one meaningless axis. They now split by metric.

Checks that genuinely read metrics together declare a shared group: `used`+`total` (memory, disk), the load averages, warn+fail tiers (the sync/FHIR threshold checks), the pg_tuning RAM settings, http_errors `requests`+`server_errors`, and the sync-session phase durations. Prometheus is unaffected — it dimensions by name and labels natively.

## Liveness as age

The daemon activity/sweep are reported as an **age in seconds at scrape time**, not a raw timestamp (which graphs as an ever-rising line). The prometheus registry gauge is dropped in favour of an atomic store the watchdog reads and the renderer turns into an age. The checks-by-outcome census renders as a **stacked area** with the total overlaid as a line.

## Metric hygiene

- Dropped metrics that carried no signal: `window_seconds`, the `uptime` metric (already a status fact), `sessions_24h`, and the billing_tags metrics.
- Duration/size metrics name their unit — `oldest_active_age_secs` → `oldest_active_age_seconds`.
- **sync_sessions** now reports the snapshot, persist, and total phase durations of the most recently completed session (its grading is unchanged — metrics only).

Munin rendering uses `writeln!` throughout for consistency.
