### PR TITLE
feat(alertd): metrics presentation polish — namespace, munin units, size split

### DIFF
--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -38,9 +38,14 @@ A check declares typed metrics. Each metric carries:
 - a kind — a gauge that rises and falls, or a counter that only increases;
 - optional labels: dimensions with a fixed key and a per-series value, such as a mount point, an HTTP status code, or a percentile;
 - a human description;
-- an optional group (see below).
+- an optional group (see below);
+- an optional namespace.
 
 A metric's unit lives in its name by convention — `_seconds`, `_bytes`, `_ms` — and a metric that measures a duration or a size always names its unit, so no metric reads as a bare unitless number when it is really a quantity.
+In munin a graph labels its axis with the unit read from its metrics' names, and a byte graph scales in powers of 1024, so an operator reads seconds, bytes, or a percentage off the axis directly.
+
+Metrics are named under their check by default, but a check whose name would misrepresent its telemetry may declare a namespace that replaces the check name in the metric's name.
+The error-rate `http_errors` check publishes its request telemetry — which counts successful responses too — under `http`, so a reader isn't misled into thinking a request count is an error count.
 
 ## Grouping into munin graphs
 
@@ -48,11 +53,16 @@ Prometheus models dimensioned metrics with labels natively: one metric family pe
 
 Munin has no labels, so a check's metrics are grouped into graphs.
 There is one graph per group; a metric with no explicit group forms its own graph, named for the metric.
-Metrics that share a unit and are read together — a total and its components, a warn tier beside its fail tier, used beside total — declare a shared group and share a graph.
-Metrics of different units are never placed in the same graph, so no graph mixes scales on one axis.
+Metrics that share a unit and a comparable scale and are read together — a warn tier beside its fail tier, used beside total — declare a shared group and share a graph.
+Metrics of different units are never placed in the same graph, so no graph mixes scales on one axis; and a total that dwarfs the components it sums stays on its own graph, so the components' variation isn't flattened against it.
 The label-dimensioned series of a single metric — one per mount, per status code, per percentile — are the fields of that metric's graph.
 
 ## Sync session durations
 
 The sync-sessions check reports the number of currently active sync sessions, and, for the most recently completed session, the duration in seconds of each phase of the sync: the snapshot phase, the persist phase, and the session overall.
 The phase durations share one graph.
+
+## Sync snapshot table sizes
+
+The sync-snapshot-tables check reports the p50 and p99 of the leftover snapshot tables' sizes in bytes, as two series of one percentile graph, alongside the count of tables and recent sessions.
+The total size of all snapshot tables is a separate graph: it dwarfs the percentiles, so sharing an axis would flatten their variation.

--- a/crates/alertd/src/doctor/checks/http_errors.rs
+++ b/crates/alertd/src/doctor/checks/http_errors.rs
@@ -204,11 +204,13 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		.with_detail("baseline_source", source_label)
 		.with_stat(
 			Stat::gauge("requests", 0.0)
+				.namespace("http")
 				.group("traffic")
 				.help("Requests in the window"),
 		)
 		.with_stat(
 			Stat::gauge("server_errors", 0.0)
+				.namespace("http")
 				.group("traffic")
 				.help("5xx responses in the window"),
 		);
@@ -249,17 +251,24 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		.with_detail("by_code", Value::Object(by_code))
 		.with_stat(
 			Stat::gauge("requests", total as f64)
+				.namespace("http")
 				.group("traffic")
 				.help("Requests in the window"),
 		)
 		.with_stat(
 			Stat::gauge("server_errors", errored as f64)
+				.namespace("http")
 				.group("traffic")
 				.help("5xx responses in the window"),
 		)
-		.with_stat(Stat::gauge("server_error_rate_pct", pct).help("5xx rate, percent"))
+		.with_stat(
+			Stat::gauge("server_error_rate_pct", pct)
+				.namespace("http")
+				.help("5xx rate, percent"),
+		)
 		.with_stats(deltas.iter().map(|(code, n)| {
 			Stat::gauge("requests_by_code", *n as f64)
+				.namespace("http")
 				.label("code", code.clone())
 				.help("Requests in the window by HTTP status code")
 		}))

--- a/crates/alertd/src/doctor/checks/sync_snapshot_tables.rs
+++ b/crates/alertd/src/doctor/checks/sync_snapshot_tables.rs
@@ -98,10 +98,10 @@ pub async fn run(ctx: CheckContext) -> Check {
 		);
 	}
 	if let Some(total) = total_bytes {
+		// Its own graph, not the `sizes` group: the total dwarfs the p50/p99
+		// percentiles and would flatten their variation on a shared axis.
 		check = check.with_stat(
-			Stat::gauge("total_size_bytes", total)
-				.group("sizes")
-				.help("Total size of all snapshot tables"),
+			Stat::gauge("total_size_bytes", total).help("Total size of all snapshot tables"),
 		);
 	}
 	check

--- a/crates/alertd/src/doctor/stat.rs
+++ b/crates/alertd/src/doctor/stat.rs
@@ -59,6 +59,11 @@ pub struct Stat {
 	/// it. Only meaningful for munin; prometheus dimensions everything by name
 	/// and labels regardless.
 	pub group: Option<&'static str>,
+	/// Metric namespace overriding the check name in the prometheus metric name
+	/// and munin graph. `None` uses the check name. Set when the check name
+	/// would mislead — e.g. the error-rate check `http_errors` publishing its
+	/// request telemetry (which counts 2xx responses too) under `http`.
+	pub namespace: Option<&'static str>,
 }
 
 impl Stat {
@@ -70,6 +75,7 @@ impl Stat {
 			labels: Vec::new(),
 			help: None,
 			group: None,
+			namespace: None,
 		}
 	}
 
@@ -81,6 +87,7 @@ impl Stat {
 			labels: Vec::new(),
 			help: None,
 			group: None,
+			namespace: None,
 		}
 	}
 
@@ -102,6 +109,21 @@ impl Stat {
 	pub fn group(mut self, group: &'static str) -> Self {
 		self.group = Some(group);
 		self
+	}
+
+	/// Publish this metric under `namespace` instead of the check's name. See
+	/// [`Self::namespace`].
+	pub fn namespace(mut self, namespace: &'static str) -> Self {
+		self.namespace = Some(namespace);
+		self
+	}
+
+	/// The metric namespace: the override if set, else the check name.
+	pub fn namespace_or<'a>(&self, check: &'a str) -> &'a str {
+		match self.namespace {
+			Some(ns) => ns,
+			None => check,
+		}
 	}
 }
 
@@ -194,6 +216,20 @@ mod tests {
 		assert_eq!(
 			Stat::gauge("used_bytes", 1.0).group("bytes").group,
 			Some("bytes")
+		);
+	}
+
+	#[test]
+	fn namespace_defaults_to_check_and_overrides() {
+		assert_eq!(
+			Stat::gauge("x", 1.0).namespace_or("http_errors"),
+			"http_errors"
+		);
+		assert_eq!(
+			Stat::gauge("x", 1.0)
+				.namespace("http")
+				.namespace_or("http_errors"),
+			"http"
 		);
 	}
 

--- a/crates/alertd/src/http_server/metrics_render.rs
+++ b/crates/alertd/src/http_server/metrics_render.rs
@@ -73,7 +73,25 @@ fn munin_field_label(stat: &Stat) -> String {
 
 /// The prometheus metric name for a stat within a check's namespace.
 fn prom_name(check: &str, stat: &Stat) -> String {
-	format!("{PREFIX}_{check}_{}", stat.name)
+	format!("{PREFIX}_{}_{}", stat.namespace_or(check), stat.name)
+}
+
+/// Munin axis label and optional `graph_args`, derived from the unit a metric
+/// carries in its name (the spec keeps a metric's unit in its name). A group
+/// shares a unit, so this reads the first stat's name.
+fn munin_unit(stats: &[&Stat]) -> Option<(&'static str, Option<&'static str>)> {
+	let name = stats.first()?.name;
+	if name.ends_with("_bytes") {
+		Some(("bytes", Some("--base 1024")))
+	} else if name.ends_with("_seconds") || name.ends_with("_secs") {
+		Some(("seconds", None))
+	} else if name.ends_with("_ms") {
+		Some(("milliseconds", None))
+	} else if name.ends_with("_pct") || name.ends_with("_percent") {
+		Some(("%", None))
+	} else {
+		None
+	}
 }
 
 /// Render the prometheus body: daemon liveness (as an age), and — when a sweep
@@ -249,27 +267,35 @@ pub fn render_munin(
 		std::collections::HashMap::new();
 	for (check, stat) in &snapshot.stats {
 		let check: &str = check;
-		// A metric with no explicit group forms its own graph, named for it.
+		// The metric's namespace (its own name override, else the check) prefixes
+		// the graph; a metric with no explicit group forms its own graph.
+		let namespace = stat.namespace_or(check);
 		let group = stat.group.unwrap_or(stat.name);
 		by_group
-			.entry((check, group))
+			.entry((namespace, group))
 			.or_insert_with(|| {
-				order.push((check, group));
+				order.push((namespace, group));
 				Vec::new()
 			})
 			.push(stat);
 	}
 
-	for (check, group) in order {
+	for (namespace, group) in order {
 		let _ = writeln!(
 			out,
-			"\nmultigraph {PREFIX}_{check}_{}",
+			"\nmultigraph {PREFIX}_{namespace}_{}",
 			munin_field_segment(group)
 		);
-		let stats = &by_group[&(check, group)];
+		let stats = &by_group[&(namespace, group)];
 		if config {
-			let _ = writeln!(out, "graph_title {check} {group}");
+			let _ = writeln!(out, "graph_title {namespace} {group}");
 			let _ = writeln!(out, "graph_category bestool");
+			if let Some((vlabel, args)) = munin_unit(stats) {
+				let _ = writeln!(out, "graph_vlabel {vlabel}");
+				if let Some(args) = args {
+					let _ = writeln!(out, "graph_args {args}");
+				}
+			}
 			// The metrics of one group share a description; use it as the graph's.
 			if let Some(help) = stats.iter().find_map(|s| s.help.as_deref()) {
 				let _ = writeln!(out, "graph_info {}", help.replace('\n', " "));
@@ -385,6 +411,63 @@ mod tests {
 		assert!(out.contains("jobs_queued.type GAUGE"));
 		// No values in config mode.
 		assert!(!out.contains(".value "));
+	}
+
+	#[test]
+	fn namespace_overrides_the_check_prefix() {
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![
+				(
+					"http_errors",
+					Stat::gauge("requests", 5.0)
+						.namespace("http")
+						.group("traffic"),
+				),
+				(
+					"http_errors",
+					Stat::gauge("requests_by_code", 2.0)
+						.namespace("http")
+						.label("code", "200"),
+				),
+			],
+		};
+		let prom = render_prometheus(Some(&s), 0, 0);
+		assert!(prom.contains("bes_alertd_http_requests 5"));
+		assert!(prom.contains("bes_alertd_http_requests_by_code{code=\"200\"} 2"));
+		assert!(!prom.contains("http_errors_requests"));
+
+		let cfg = render_munin(Some(&s), 0, 0, true);
+		assert!(cfg.contains("multigraph bes_alertd_http_traffic"));
+		assert!(cfg.contains("graph_title http traffic"));
+		assert!(!cfg.contains("bes_alertd_http_errors_"));
+	}
+
+	#[test]
+	fn munin_labels_axis_with_the_unit() {
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![
+				(
+					"sync_sessions",
+					Stat::gauge("total_duration_seconds", 3.0).group("durations"),
+				),
+				(
+					"sync_snapshot_tables",
+					Stat::gauge("table_size_bytes", 9.0)
+						.group("sizes")
+						.label("quantile", "0.5"),
+				),
+			],
+		};
+		let cfg = render_munin(Some(&s), 0, 0, true);
+		assert!(cfg.contains("multigraph bes_alertd_sync_sessions_durations"));
+		assert!(cfg.contains("graph_vlabel seconds"));
+		assert!(cfg.contains("multigraph bes_alertd_sync_snapshot_tables_sizes"));
+		assert!(cfg.contains("graph_vlabel bytes"));
+		assert!(cfg.contains("graph_args --base 1024"));
 	}
 
 	#[test]


### PR DESCRIPTION
🤖 Three presentation follow-ups to the alertd metrics work (#745), all telemetry-only — no verdict, summary, or Canopy payload changes.

## `sync_snapshot_tables` sizes: total on its own graph

p50, p99, and total previously shared the `sizes` group, so on one munin graph the total's magnitude flattened the p50/p99 curve. The total now graphs on its own; the percentiles keep their shared graph and scale.

## `http_errors` metrics publish under `http`

The metric prefix was the check name, but `http_errors` emits total requests and a by-code breakdown (200s included), so `bes_alertd_http_errors_requests` read as an error count. A new `Stat::namespace()` lets a check publish metrics under a name other than its own; `http_errors` keeps its Canopy check name (it *is* an error-rate check) but its telemetry now publishes under `http` — `bes_alertd_http_requests`, `bes_alertd_http_requests_by_code{code="200"}`, etc.

## Munin graphs label their axis with the unit

Durations, sizes, and rates carried their unit in the metric name (`_seconds`, `_bytes`, `_pct`) but munin graphs had no axis label. The renderer now derives `graph_vlabel` from the metric name (and `graph_args --base 1024` for bytes), so an operator reads seconds, bytes, or a percentage straight off the axis.

The metrics spec is updated to match.
