### PR TITLE
feat(alertd): FHIR worker liveness check and metrics

### DIFF
--- a/.workhorse/specs/tamanu/fhir-workers.md
+++ b/.workhorse/specs/tamanu/fhir-workers.md
@@ -1,0 +1,40 @@
+---
+id: CHK-FWK
+---
+
+# FHIR job worker healthcheck
+
+The Tamanu doctor runs a check that verifies a central's FHIR materialisation workers are alive and heartbeating. Tamanu's FHIR workers register a row in `fhir.job_workers` and update its `updated_at` on a periodic heartbeat; job grabbing, completion, and stuck-job reclamation all gate on that heartbeat being recent, so a worker that has silently stopped heartbeating stalls FHIR materialisation even while its service process looks up. This check surfaces that condition, which neither the service-up check nor the jobs-backlog check catches on its own.
+
+It is one of the healthchecks described by `tamanu/healthchecks.md` and follows the shared outcome model in `tamanu/doctor.md` (pass, skip, warning, fail, broken).
+The numeric telemetry it declares is specified in `tamanu/metrics.md`.
+
+## Applicability
+
+The check only applies to a central server whose FHIR worker is enabled.
+
+- It skips on a facility server.
+- It skips when the FHIR worker is not enabled in the deployment's configuration.
+- It skips when `fhir.job_workers` is absent, as on a Tamanu version that predates the table.
+
+A skip carries a reason naming which precondition was not met.
+
+## Liveness model
+
+A worker's liveness is read the same way Tamanu itself reads it: a worker is live when its heartbeat is recent, where "recent" is the deployment's `fhir.worker.assumeDroppedAfter` setting, defaulting to 10 minutes when the setting is absent.
+
+- A row is a **live** worker when it is not soft-deleted (`deleted_at` is null) and its `updated_at` is within the window.
+- A row is a **dropped** worker when it is not soft-deleted but its `updated_at` is older than the window — a worker that crashed or was killed without deregistering, so its row lingers with a frozen heartbeat.
+- A soft-deleted row (`deleted_at` set) is a worker that shut down gracefully and is not counted as either live or dropped.
+
+The window is read from the setting so it tracks the deployment rather than a value baked into the check.
+
+## Outcomes
+
+For a central server with the FHIR worker enabled:
+
+- [ ] The check fails when no worker is live.
+- [ ] The check warns when at least one worker is live but one or more dropped workers are present.
+- [ ] The check passes when at least one worker is live and no dropped workers are present.
+
+A count of live workers cannot be asserted against a fixed expectation: the number of worker rows is emergent from deployment topology (a running server registers a `refresh` and a `resolver` worker, multiplied by however many server processes run), so the check grades the presence of liveness, not a specific worker count.

--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -66,3 +66,11 @@ The phase durations share one graph.
 
 The sync-snapshot-tables check reports the p50 and p99 of the leftover snapshot tables' sizes in bytes, as two series of one percentile graph, alongside the count of tables and recent sessions.
 The total size of all snapshot tables is a separate graph: it dwarfs the percentiles, so sharing an axis would flatten their variation.
+
+## FHIR workers
+
+The FHIR-workers check ([CHK-FWK](fhir-workers.md)) reports the health of a central's FHIR materialisation workers, read from their heartbeats.
+
+It reports the count of live workers beside the count of dropped workers — those that stopped heartbeating without deregistering — as the two components of one graph.
+It reports the age in seconds of the oldest live worker's heartbeat, so an operator sees how close the least-fresh worker is to the drop window, on its own graph.
+It reports the number of jobs the live workers have completed successfully and the number they have failed, summed across the live workers as one metric dimensioned by outcome; because a worker's identity is fresh each time its process starts, these are aggregate throughput rather than a per-worker or monotonic series.

--- a/crates/alertd/src/doctor/checks.rs
+++ b/crates/alertd/src/doctor/checks.rs
@@ -33,6 +33,7 @@ pub mod fhir_config;
 pub mod fhir_job_errors;
 pub mod fhir_jobs;
 pub mod fhir_service_requests_unresolved;
+pub mod fhir_workers;
 pub mod http_errors;
 pub mod inodes;
 pub mod ips;
@@ -362,6 +363,7 @@ pub fn all() -> Vec<CheckEntry> {
 		// Config-derived: the FHIR API and worker toggles must agree.
 		entry!("fhir_config", fhir_config),
 		entry!("fhir_jobs", fhir_jobs),
+		entry!("fhir_workers", fhir_workers),
 		entry!(
 			"certificate_notification_errors",
 			certificate_notification_errors

--- a/crates/alertd/src/doctor/checks/fhir_workers.rs
+++ b/crates/alertd/src/doctor/checks/fhir_workers.rs
@@ -1,0 +1,198 @@
+//! FHIR materialisation worker liveness.
+//!
+//! Tamanu's FHIR workers register a row in `fhir.job_workers` and update its
+//! `updated_at` on a periodic heartbeat; job grabbing, completion, and
+//! stuck-job reclamation all gate on that heartbeat being within
+//! `fhir.worker.assumeDroppedAfter` (default 10 minutes). A worker that stops
+//! heartbeating stalls materialisation even while its service process looks up,
+//! which neither `tamanu_service` (process up) nor `fhir_jobs` (backlog) catches.
+//!
+//! A live worker is one whose row isn't soft-deleted and whose heartbeat is
+//! within the window; a dropped worker is one that isn't soft-deleted but whose
+//! heartbeat has gone stale — it crashed or was killed without deregistering. A
+//! gracefully stopped worker has `deleted_at` set and counts as neither.
+
+use bestool_tamanu::ApiServerKind;
+
+use super::{CheckContext, query_error_check};
+use crate::doctor::Stat;
+use crate::doctor::check::Check;
+
+const NAME: &str = "fhir_workers";
+
+/// Live and dropped counts read against Tamanu's own liveness window
+/// (`fhir.worker.assumeDroppedAfter`, 10-minute fallback), plus the oldest live
+/// heartbeat's age and the live workers' job counters summed from `metadata`.
+const SQL: &str = "\
+	SELECT
+		count(*) FILTER (WHERE alive) AS live,
+		count(*) FILTER (WHERE NOT alive) AS dropped,
+		extract(epoch FROM now() - min(updated_at) FILTER (WHERE alive))::float8 AS oldest_heartbeat_age_s,
+		coalesce(sum((metadata->>'successfulJobs')::numeric) FILTER (WHERE alive), 0)::float8 AS jobs_success,
+		coalesce(sum((metadata->>'failedJobs')::numeric) FILTER (WHERE alive), 0)::float8 AS jobs_failure
+	FROM (
+		SELECT updated_at, metadata,
+			updated_at > now() - (
+				SELECT coalesce(
+					(setting_get('fhir.worker.assumeDroppedAfter')->>0)::interval,
+					interval '10 minutes')
+			) AS alive
+		FROM fhir.job_workers
+		WHERE deleted_at IS NULL
+	) t";
+
+pub async fn run(ctx: CheckContext) -> Check {
+	if ctx.kind != ApiServerKind::Central {
+		return Check::skip(
+			NAME,
+			"not applicable on facility server",
+			"central-only check",
+		);
+	}
+	if !ctx.config.fhir_worker_enabled() {
+		return Check::skip(
+			NAME,
+			"FHIR worker not enabled",
+			"integrations.fhir.worker.enabled is false, so no worker is expected to heartbeat",
+		);
+	}
+	let Some(client) = ctx.db.as_ref() else {
+		return Check::fail(NAME, "no DB connection", "db_connect failed");
+	};
+
+	let row = match client.query_one(SQL, &[]).await {
+		Ok(r) => r,
+		Err(err) => {
+			if let Some(db) = err.as_db_error()
+				&& (db.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE
+					|| db.code() == &tokio_postgres::error::SqlState::INVALID_SCHEMA_NAME)
+			{
+				return Check::skip(NAME, "fhir.job_workers table not present", "table absent");
+			}
+			return query_error_check(NAME, &err);
+		}
+	};
+
+	let live: i64 = row.try_get("live").unwrap_or(0);
+	let dropped: i64 = row.try_get("dropped").unwrap_or(0);
+	let oldest_age: Option<f64> = row.try_get("oldest_heartbeat_age_s").unwrap_or(None);
+	let jobs_success: f64 = row.try_get("jobs_success").unwrap_or(0.0);
+	let jobs_failure: f64 = row.try_get("jobs_failure").unwrap_or(0.0);
+
+	let summary = format!("{live} live, {dropped} dropped");
+	let check = match classify(live, dropped) {
+		Verdict::Fail => Check::fail(NAME, summary, "no live FHIR worker is heartbeating"),
+		Verdict::Warn => Check::warning(
+			NAME,
+			summary,
+			format!("{dropped} worker(s) stopped heartbeating without deregistering"),
+		),
+		Verdict::Pass => Check::pass(NAME, summary),
+	};
+
+	let mut check = check
+		.with_detail("live", live)
+		.with_detail("dropped", dropped)
+		.with_stat(
+			Stat::gauge("live", live as f64)
+				.group("workers")
+				.help("Live FHIR workers"),
+		)
+		.with_stat(
+			Stat::gauge("dropped", dropped as f64)
+				.group("workers")
+				.help("FHIR workers with a stale heartbeat"),
+		)
+		.with_stat(
+			Stat::gauge("jobs", jobs_success)
+				.label("result", "success")
+				.help("Jobs processed by live workers, by outcome"),
+		)
+		.with_stat(
+			Stat::gauge("jobs", jobs_failure)
+				.label("result", "failure")
+				.help("Jobs processed by live workers, by outcome"),
+		);
+	if let Some(age) = oldest_age {
+		check = check.with_stat(
+			Stat::gauge("oldest_heartbeat_age_seconds", age)
+				.help("Age of the oldest live worker's heartbeat"),
+		);
+	}
+	check
+}
+
+enum Verdict {
+	Pass,
+	Warn,
+	Fail,
+}
+
+/// Grade worker liveness: no live worker fails, a dropped (crashed) worker
+/// warns, otherwise pass.
+fn classify(live: i64, dropped: i64) -> Verdict {
+	if live == 0 {
+		Verdict::Fail
+	} else if dropped > 0 {
+		Verdict::Warn
+	} else {
+		Verdict::Pass
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::doctor::check::CheckStatus;
+	use crate::doctor::checks::test_support::{central_ctx, facility_ctx};
+
+	fn verdict(live: i64, dropped: i64) -> &'static str {
+		match classify(live, dropped) {
+			Verdict::Pass => "pass",
+			Verdict::Warn => "warn",
+			Verdict::Fail => "fail",
+		}
+	}
+
+	#[test]
+	fn no_live_worker_fails() {
+		assert_eq!(verdict(0, 0), "fail");
+		assert_eq!(verdict(0, 2), "fail");
+	}
+
+	#[test]
+	fn dropped_worker_warns_when_some_are_live() {
+		assert_eq!(verdict(1, 1), "warn");
+		assert_eq!(verdict(2, 3), "warn");
+	}
+
+	#[test]
+	fn all_live_passes() {
+		assert_eq!(verdict(1, 0), "pass");
+		assert_eq!(verdict(2, 0), "pass");
+	}
+
+	#[tokio::test]
+	async fn skips_on_facility() {
+		let check = super::run(facility_ctx()).await;
+		assert!(check.status.is_skip());
+	}
+
+	#[tokio::test]
+	async fn runs_against_central() {
+		let Some(ctx) = central_ctx().await else {
+			return;
+		};
+		let check = super::run(ctx).await;
+		assert_eq!(check.name, "fhir_workers");
+		// Enabled or not, the outcome is a real grade or a skip — never a panic.
+		assert!(matches!(
+			check.status,
+			CheckStatus::Pass
+				| CheckStatus::Warning(_)
+				| CheckStatus::Fail(_)
+				| CheckStatus::Skip(_)
+				| CheckStatus::Broken(_)
+		));
+	}
+}


### PR DESCRIPTION
🤖 New alertd healthcheck that reads FHIR materialisation *worker* liveness from the database — distinct from `fhir_jobs` (backlog) and `tamanu_service` (process up).

## What it checks

Tamanu's FHIR workers register a row in `fhir.job_workers` and bump `updated_at` on a periodic heartbeat; job grabbing, completion, and stuck-job reclamation all gate on that heartbeat being recent. A worker that silently stops heartbeating stalls materialisation even while its service process still looks up — nothing else catches that.

The `fhir_workers` check (central-only) grades liveness exactly as Tamanu's own `fhir.job_worker_is_alive` does:

- **live** — `deleted_at IS NULL` and `updated_at` within `fhir.worker.assumeDroppedAfter` (read from the setting, 10-min fallback).
- **dropped** — not soft-deleted but heartbeat gone stale: crashed or killed without deregistering.
- a gracefully stopped worker (`deleted_at` set) counts as neither.

**Verdict:** fail when no worker is live; warn when any dropped; pass otherwise. Skips on facility, when the FHIR worker is disabled in config, and when `fhir.job_workers` is absent (older Tamanu).

## Metrics

- `live` and `dropped` (one shared graph)
- `oldest_heartbeat_age_seconds` — how close the least-fresh live worker is to the drop window (own graph, seconds axis)
- `jobs{result="success|failure"}` — completed/failed job counts summed across live workers. Aggregate, not per-worker: a worker's row UUID is fresh per process start, so per-worker series would churn and reset; the aggregate is munin-stable.

## Notes

- The single aggregate query was validated against a live local central (empty `fhir.job_workers` → `live=0, dropped=0`), and the `setting_get('fhir.worker.assumeDroppedAfter')` window resolves to `00:10:00` — the same expression Tamanu's `is_alive` uses.
- Specs: `.workhorse/specs/tamanu/fhir-workers.md` (CHK-FWK) and a FHIR-workers section in `metrics.md`.
- No self-heal action in this PR (worker recovery overlaps `tamanu_service` / the existing fhir_jobs healer); can be a follow-up if wanted.
