### PR TITLE
feat(tamanu): report the Node.js version Tamanu runs under

### DIFF
--- a/.workhorse/specs/tamanu/node-version.md
+++ b/.workhorse/specs/tamanu/node-version.md
@@ -1,0 +1,22 @@
+---
+id: NODE
+---
+
+# Node.js version reporting
+
+The server facts gathered by the doctor and pushed by the alertd daemon carry the Node.js runtime version the Tamanu server runs under, reported as `nodeVersion`.
+This is the version of the runtime Tamanu actually executes under, not merely a runtime that happens to be installed on the host.
+
+The doctor renders these facts and includes them in its machine-readable payload (`tamanu/doctor.md`), and the alertd status push carries the same value to Canopy.
+
+## Source
+
+On a containerised deployment, the reported version is the Node.js version inside a running Tamanu server container.
+The host that runs the daemon need not have Node.js installed, and the container carries its own runtime, so the container is the only place the true running version can be observed.
+
+On a deployment driven by a process manager with a bundled Node.js runtime, the reported version is that bundled runtime's version.
+The runtime ships in a `runtime` directory at the deployment's server root, and the process manager launches the server with it, so its version is the version Tamanu runs under.
+
+When neither a running container nor a bundled runtime is found — for example on a developer machine or a partially provisioned host — the reported version falls back to the Node.js version found on the host's search path.
+
+When no Node.js runtime can be resolved by any of these means, `nodeVersion` is omitted from the reported facts.

--- a/crates/alertd/src/doctor/server_info.rs
+++ b/crates/alertd/src/doctor/server_info.rs
@@ -5,6 +5,7 @@ use std::{
 	collections::BTreeMap,
 	io,
 	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+	path::Path,
 	time::Duration,
 };
 
@@ -157,12 +158,18 @@ pub async fn gather(
 	let cpu_cores = sys.cpus().len();
 	let total_memory_bytes = sys.total_memory();
 
+	let node_version = detect_node_version(
+		facts.tamanu_root.as_deref().map(Path::new),
+		tamanu_version.as_deref(),
+	)
+	.await;
+
 	ServerInfo {
 		bestool_version: bestool_version.to_string(),
 		tamanu_version,
 		tamanu_root: facts.tamanu_root,
 		tamanu_server_kind: facts.tamanu_server_kind,
-		node_version: detect_node_version().await,
+		node_version,
 		hostname: System::host_name(),
 		canonical_url: facts.canonical_url,
 		current_sync_tick: facts.current_sync_tick,

--- a/crates/tamanu/src/server_info.rs
+++ b/crates/tamanu/src/server_info.rs
@@ -6,6 +6,7 @@
 use std::{
 	collections::BTreeMap,
 	path::{Path, PathBuf},
+	sync::{Mutex, OnceLock},
 };
 
 use miette::{IntoDiagnostic, Result, WrapErr as _};
@@ -401,12 +402,63 @@ pub async fn get_tailscale_info() -> (Option<String>, Option<String>) {
 	(ip, name)
 }
 
-/// Detect the host's installed Node.js version by running `node --version`.
+/// Detect the Node.js version the Tamanu server runs under.
 ///
-/// Returns `None` if node isn't on `PATH` or the command fails. The leading
-/// `v` that node prints (e.g. `v20.11.0`) is stripped, so the value is a bare
-/// version string.
-pub async fn detect_node_version() -> Option<String> {
+/// Reports the runtime Tamanu actually executes: on a containerised host, the
+/// version inside a running server container; on a host with a runtime bundled
+/// under the server root, that runtime. Falls back to the Node.js on the
+/// host's search path when neither is found, and yields `None` when no runtime
+/// can be resolved at all. `tamanu_root` is the discovered server root, used
+/// to locate a bundled runtime; pass `None` when it isn't known.
+///
+/// The Node.js version is fixed by the Tamanu version, so the resolved value
+/// is cached against `tamanu_version`: an unchanged version returns the cached
+/// value without re-probing a container or spawning node, and an upgrade (a
+/// changed version) re-probes so the report follows the new runtime. When the
+/// Tamanu version isn't known, the value is resolved afresh each time.
+// spec: NODE
+pub async fn detect_node_version(
+	tamanu_root: Option<&Path>,
+	tamanu_version: Option<&str>,
+) -> Option<String> {
+	static CACHE: OnceLock<Mutex<Option<(String, String)>>> = OnceLock::new();
+	let cache = CACHE.get_or_init(|| Mutex::new(None));
+	if let Some(version) = tamanu_version
+		&& let Some((cached_version, cached_node)) = cache.lock().ok().and_then(|g| g.clone())
+		&& cached_version == version
+	{
+		return Some(cached_node);
+	}
+
+	let resolved = resolve_node_version(tamanu_root).await;
+	if let Some(version) = tamanu_version
+		&& let Some(node) = &resolved
+		&& let Ok(mut guard) = cache.lock()
+	{
+		*guard = Some((version.to_string(), node.clone()));
+	}
+	resolved
+}
+
+async fn resolve_node_version(tamanu_root: Option<&Path>) -> Option<String> {
+	#[cfg(target_os = "linux")]
+	if let Some(version) = crate::versions::container_node_version().await {
+		return Some(version);
+	}
+
+	#[cfg(windows)]
+	if let Some(root) = tamanu_root
+		&& let Some(version) = windows_embedded_node_version(root).await
+	{
+		return Some(version);
+	}
+
+	let _ = tamanu_root; // consulted only by the bundled-runtime lookup above
+	host_node_version().await
+}
+
+/// Run `node --version` on the host's search path and parse the result.
+async fn host_node_version() -> Option<String> {
 	let output = tokio::process::Command::new("node")
 		.arg("--version")
 		.output()
@@ -420,9 +472,37 @@ pub async fn detect_node_version() -> Option<String> {
 	parse_node_version(&String::from_utf8_lossy(&output.stdout))
 }
 
+/// Read the version of the Node.js runtime bundled alongside a Windows Tamanu
+/// server, at `runtime\node.exe` under the server root — the runtime the
+/// process manager launches the server with.
+#[cfg(windows)]
+async fn windows_embedded_node_version(root: &Path) -> Option<String> {
+	let node = windows_embedded_node_path(root);
+	if !node.exists() {
+		return None;
+	}
+
+	let output = tokio::process::Command::new(&node)
+		.arg("--version")
+		.output()
+		.await
+		.ok()?;
+	if !output.status.success() {
+		debug!(status = %output.status, node = %node.display(), "embedded node --version failed");
+		return None;
+	}
+
+	parse_node_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(windows)]
+fn windows_embedded_node_path(root: &Path) -> PathBuf {
+	root.join("runtime").join("node.exe")
+}
+
 /// Parse the output of `node --version` (e.g. `v20.11.0\n`) into a bare version
 /// string. Returns `None` for empty/whitespace-only input.
-fn parse_node_version(raw: &str) -> Option<String> {
+pub(crate) fn parse_node_version(raw: &str) -> Option<String> {
 	let version = raw.trim().trim_start_matches('v');
 	if version.is_empty() {
 		None

--- a/crates/tamanu/src/versions.rs
+++ b/crates/tamanu/src/versions.rs
@@ -141,14 +141,7 @@ pub async fn running_versions_linux() -> Result<HashMap<String, String>, String>
 	// elevate via `sudo -n` rather than letting podman run rootless and see
 	// nothing or error; the alertd daemon already runs as root and invokes it
 	// directly. `-n` never blocks on a password prompt.
-	let mut command = if is_root() {
-		tokio::process::Command::new("podman")
-	} else {
-		let mut c = tokio::process::Command::new("sudo");
-		c.arg("-n").arg("podman");
-		c
-	};
-	let result = command
+	let result = podman_command()
 		.args([
 			"ps",
 			"--format",
@@ -203,6 +196,72 @@ pub async fn running_versions_linux() -> Result<HashMap<String, String>, String>
 #[cfg(target_os = "linux")]
 fn is_root() -> bool {
 	rustix::process::geteuid().is_root()
+}
+
+/// A `podman` command, elevated via `sudo -n` when this process isn't root.
+///
+/// The deployment runs rootful podman, so the containers are only visible to
+/// root. When we're not root (an interactive `tamanu status` / `doctor`), we
+/// elevate rather than letting podman run rootless and see nothing; the alertd
+/// daemon already runs as root and invokes podman directly. `-n` never blocks
+/// on a password prompt.
+#[cfg(target_os = "linux")]
+fn podman_command() -> tokio::process::Command {
+	if is_root() {
+		tokio::process::Command::new("podman")
+	} else {
+		let mut command = tokio::process::Command::new("sudo");
+		command.arg("-n").arg("podman");
+		command
+	}
+}
+
+/// The Node.js version the running Tamanu server executes under, read from a
+/// running server container.
+///
+/// The container carries its own runtime, so this is the only place the true
+/// running version can be observed on a containerised host. Returns `None`
+/// when no Tamanu server container is running or it can't be reached.
+// spec: NODE
+#[cfg(target_os = "linux")]
+pub async fn container_node_version() -> Option<String> {
+	let container = running_tamanu_container().await?;
+	let output = podman_command()
+		.args(["exec", &container, "node", "--version"])
+		.output()
+		.await
+		.ok()?;
+	if !output.status.success() {
+		debug!(status = %output.status, %container, "node --version in container failed");
+		return None;
+	}
+	crate::server_info::parse_node_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// The name of a running Tamanu server container, if one is up.
+#[cfg(target_os = "linux")]
+async fn running_tamanu_container() -> Option<String> {
+	let output = podman_command()
+		.args(["ps", "--format", "{{.Names}}"])
+		.output()
+		.await
+		.ok()?;
+	if !output.status.success() {
+		debug!(status = %output.status, "podman ps failed");
+		return None;
+	}
+	String::from_utf8_lossy(&output.stdout)
+		.lines()
+		.map(str::trim)
+		.find(|name| is_tamanu_server_container(name))
+		.map(str::to_string)
+}
+
+/// Whether a container name is a Tamanu server (central or facility).
+#[cfg(target_os = "linux")]
+fn is_tamanu_server_container(name: &str) -> bool {
+	name.strip_prefix("tamanu-")
+		.is_some_and(|rest| rest.starts_with("central-") || rest.starts_with("facility-"))
 }
 
 /// Parse a version string leniently, tolerating a leading `v` (image tags and
@@ -366,6 +425,17 @@ pub fn expected_for_supervisor(
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn tamanu_server_container_names() {
+		assert!(is_tamanu_server_container("tamanu-central-api"));
+		assert!(is_tamanu_server_container("tamanu-facility-tasks"));
+		assert!(!is_tamanu_server_container("tamanu-frontend-a"));
+		assert!(!is_tamanu_server_container("tamanu-web"));
+		assert!(!is_tamanu_server_container("postgres"));
+		assert!(!is_tamanu_server_container("central-api"));
+	}
 
 	#[test]
 	fn parse_env_file_picks_known_keys() {


### PR DESCRIPTION
🤖 Reports `nodeVersion` as the version of the Node.js runtime Tamanu actually runs under, rather than whatever `node` happens to be on the alertd host's search path.

The field already existed, but it was sourced from a bare host `node --version` — the wrong (or absent) runtime on both production platforms: Linux runs Tamanu in containers, and the Windows daemon runs as LocalSystem with no node on PATH.

Detection is now per deployment shape:

- Linux: the node inside a running Tamanu server container (`podman exec`, with the existing `sudo -n` elevation for non-root callers).
- Windows: the runtime bundled at `runtime\node.exe` under the server root — the interpreter the process manager launches the server with.
- Fallback: the host's `node` when neither is found (dev machines, partially provisioned hosts); omitted when nothing resolves.

The Node.js version is fixed by the Tamanu version, so the resolved value is cached against the Tamanu version: an unchanged version skips the re-probe, and an upgrade re-probes so the report follows the new runtime.

Behaviour is captured in the new `NODE` spec (`.workhorse/specs/tamanu/node-version.md`).
