### PR TITLE
fix(canopy): ride out a busy tree when swapping a restore into place

### DIFF
--- a/crates/bestool/src/actions/canopy/backup/method.rs
+++ b/crates/bestool/src/actions/canopy/backup/method.rs
@@ -9,10 +9,14 @@
 use std::{
 	collections::BTreeMap,
 	path::{Path, PathBuf},
+	time::{Duration, Instant},
 };
 
 use miette::{Result, bail};
 use serde::Deserialize;
+use tracing::debug;
+
+mod holders;
 
 /// A source ready for kopia to snapshot, produced by [`Method::prepare`].
 #[derive(Debug)]
@@ -220,18 +224,64 @@ pub(super) async fn replace_dir(staging: &Path, target: &Path) -> Result<()> {
 				.into_diagnostic()
 				.wrap_err_with(|| format!("removing stale {}", backup.display()))?;
 		}
-		tokio::fs::rename(target, &backup)
-			.await
-			.into_diagnostic()
-			.wrap_err_with(|| format!("moving {} aside to {}", target.display(), backup.display()))?;
+		rename_when_free(target, &backup).await.wrap_err_with(|| {
+			format!(
+				"moving {} aside to {}{}",
+				target.display(),
+				backup.display(),
+				holders::describe_holders(target)
+			)
+		})?;
 	}
 	if let Some(parent) = target.parent() {
 		tokio::fs::create_dir_all(parent).await.ok();
 	}
-	tokio::fs::rename(staging, target)
+	rename_when_free(staging, target)
 		.await
-		.into_diagnostic()
 		.wrap_err_with(|| format!("moving restored data into {}", target.display()))
+}
+
+/// How long to keep retrying a rename that fails because the tree is still busy.
+/// A service that has just been told to stop lets go of its files in well under
+/// a second; past this it's a holder the operator has to clear.
+const BUSY_RETRY_FOR: Duration = Duration::from_secs(10);
+
+/// Rename `from` to `to`, riding out a tree that is busy but about to be free.
+///
+/// Windows reports a directory rename blocked by an open handle or a running
+/// image as a flat access denial, and the block is often momentary: the Service
+/// Control Manager calls a service stopped before its last child process has
+/// finished exiting, and the executables those children ran stay locked a beat
+/// longer — for a whole-install postgres restore, inside the very directory
+/// being renamed. Other errors (a missing source, a cross-device move) never
+/// clear on their own, so they return at once.
+async fn rename_when_free(from: &Path, to: &Path) -> Result<()> {
+	use miette::IntoDiagnostic as _;
+
+	let deadline = Instant::now() + BUSY_RETRY_FOR;
+	let mut backoff = Duration::from_millis(100);
+	loop {
+		match tokio::fs::rename(from, to).await {
+			Ok(()) => return Ok(()),
+			Err(err) if is_busy(&err) && Instant::now() + backoff < deadline => {
+				debug!("{} is busy ({err}); retrying in {backoff:?}", from.display());
+				tokio::time::sleep(backoff).await;
+				backoff = (backoff * 2).min(Duration::from_secs(1));
+			}
+			Err(err) => return Err(err).into_diagnostic(),
+		}
+	}
+}
+
+/// Whether a rename failed for a reason that may clear by itself: on Windows, a
+/// sharing violation or the access denial an open handle in the tree produces.
+/// Nothing on Unix, where a rename doesn't care who has the files open.
+fn is_busy(err: &std::io::Error) -> bool {
+	cfg!(windows)
+		&& matches!(
+			err.raw_os_error(),
+			Some(5 /* ERROR_ACCESS_DENIED */ | 32 /* ERROR_SHARING_VIOLATION */)
+		)
 }
 
 /// `/a/b` + `old` → `/a/b.old`.
@@ -285,6 +335,25 @@ mod tests {
 			with_extension_suffix(Path::new("/var/lib/postgresql/16/main"), "old"),
 			PathBuf::from("/var/lib/postgresql/16/main.old")
 		);
+	}
+
+	#[test]
+	fn only_windows_busy_errors_are_worth_retrying() {
+		let denied = std::io::Error::from_raw_os_error(5);
+		let missing = std::io::Error::from_raw_os_error(2);
+		assert_eq!(is_busy(&denied), cfg!(windows));
+		assert!(!is_busy(&missing));
+		assert!(!is_busy(&std::io::Error::other("no os code")));
+	}
+
+	#[tokio::test]
+	async fn a_hopeless_rename_fails_without_burning_the_retry_budget() {
+		let tmp = tempfile::tempdir().unwrap();
+		let started = Instant::now();
+		rename_when_free(&tmp.path().join("absent"), &tmp.path().join("dest"))
+			.await
+			.unwrap_err();
+		assert!(started.elapsed() < BUSY_RETRY_FOR);
 	}
 
 	#[tokio::test]

--- a/crates/bestool/src/actions/canopy/backup/method/holders.rs
+++ b/crates/bestool/src/actions/canopy/backup/method/holders.rs
@@ -1,0 +1,159 @@
+//! Find out what is keeping a directory tree busy.
+//!
+//! Windows refuses to rename a directory while a process is running an
+//! executable from inside it, or has its working directory there, and the error
+//! it hands back — "access is denied" — names nothing an operator can act on.
+//! That bites a whole-install postgres restore in particular: the tree being
+//! swapped holds `bin\postgres.exe`, whose image file stays locked until the
+//! process object is torn down, which outlasts the service reporting stopped.
+
+use std::{
+	fmt,
+	path::{Path, PathBuf},
+};
+
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+/// A process using a tree, and what ties it there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Holder {
+	pub pid: u32,
+	pub name: String,
+	pub reason: Reason,
+	/// The path that put it in the list (its executable or working directory).
+	pub path: PathBuf,
+}
+
+/// Why a process counts as using a tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reason {
+	/// It's running an executable from inside the tree.
+	Running,
+	/// Its working directory is inside the tree.
+	WorkingDirectory,
+}
+
+impl fmt::Display for Holder {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let Self {
+			pid, name, path, ..
+		} = self;
+		match self.reason {
+			Reason::Running => write!(f, "{name} (pid {pid}) running {}", path.display()),
+			Reason::WorkingDirectory => {
+				write!(f, "{name} (pid {pid}) working in {}", path.display())
+			}
+		}
+	}
+}
+
+/// The processes running from, or sitting in, `dir`.
+///
+/// Best-effort and inherently racy — a process can come or go between the scan
+/// and whatever the caller does next — and blind to a process that merely holds
+/// an open handle from elsewhere (an antivirus scan, a backup agent). An empty
+/// result means "none found", not "none".
+pub fn holders_of(dir: &Path) -> Vec<Holder> {
+	let mut sys = System::new();
+	sys.refresh_processes_specifics(
+		ProcessesToUpdate::All,
+		true,
+		ProcessRefreshKind::nothing()
+			.with_exe(UpdateKind::Always)
+			.with_cwd(UpdateKind::Always),
+	);
+
+	let mut out: Vec<Holder> = sys
+		.processes()
+		.iter()
+		.filter_map(|(pid, proc)| {
+			let name = proc.name().to_string_lossy().into_owned();
+			let (reason, path) = match (proc.exe(), proc.cwd()) {
+				(Some(exe), _) if is_under(exe, dir) => (Reason::Running, exe),
+				(_, Some(cwd)) if is_under(cwd, dir) => (Reason::WorkingDirectory, cwd),
+				_ => return None,
+			};
+			Some(Holder {
+				pid: pid.as_u32(),
+				name,
+				reason,
+				path: path.to_path_buf(),
+			})
+		})
+		.collect();
+	out.sort_by_key(|holder| holder.pid);
+	out
+}
+
+/// A one-line description of what's holding `dir`, to append to the error from a
+/// failed swap. Falls back to pointing at the tools that find the holders this
+/// can't see.
+pub fn describe_holders(dir: &Path) -> String {
+	let holders = holders_of(dir);
+	if holders.is_empty() {
+		return "\nnothing was found running from it: look for an open handle \
+			(Sysinternals handle64.exe, or Resource Monitor's associated-handles \
+			search) and check this is running elevated"
+			.into();
+	}
+
+	let list = holders
+		.iter()
+		.map(|holder| format!("\n  - {holder}"))
+		.collect::<String>();
+	format!("\nstill in use by:{list}")
+}
+
+/// Whether `path` is `dir` or below it, matching the way the filesystem compares
+/// them (Windows paths are case-insensitive).
+fn is_under(path: &Path, dir: &Path) -> bool {
+	if cfg!(windows) {
+		let path = path.to_string_lossy().to_lowercase();
+		let dir = dir.to_string_lossy().to_lowercase();
+		Path::new(&path).starts_with(Path::new(&dir))
+	} else {
+		path.starts_with(dir)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn under_matches_the_tree_but_not_a_name_prefix() {
+		let dir = Path::new("/srv/pg/16");
+		assert!(is_under(Path::new("/srv/pg/16"), dir));
+		assert!(is_under(Path::new("/srv/pg/16/bin/postgres"), dir));
+		assert!(!is_under(Path::new("/srv/pg/166/bin/postgres"), dir));
+		assert!(!is_under(Path::new("/srv/pg"), dir));
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn under_ignores_case_on_windows() {
+		assert!(is_under(
+			Path::new(r"c:\program files\postgresql\12\bin\postgres.exe"),
+			Path::new(r"C:\Program Files\PostgreSQL\12")
+		));
+	}
+
+	#[test]
+	fn this_process_holds_its_own_executable() {
+		let exe = std::env::current_exe().unwrap();
+		let dir = exe.parent().unwrap();
+		let me = std::process::id();
+		let holders = holders_of(dir);
+		assert!(
+			holders.iter().any(|holder| holder.pid == me),
+			"expected pid {me} among {holders:?}"
+		);
+	}
+
+	#[test]
+	fn an_unused_tree_has_no_holders_and_describes_the_next_step() {
+		let tmp = tempfile::tempdir().unwrap();
+		assert!(holders_of(tmp.path()).is_empty());
+		assert!(describe_holders(tmp.path()).contains("handle64"));
+	}
+}

--- a/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
+++ b/crates/bestool/src/actions/canopy/backup/postgresql/resolve.rs
@@ -305,6 +305,12 @@ pub fn installed_server_versions() -> Vec<String> {
 }
 
 /// The `<version>` dirs (with a `bin` subdirectory) directly under `base`, sorted.
+///
+/// Only version-shaped names count. On Windows a restore stages into
+/// `<base>\.bestool-restore.<pid>`, and a whole-install snapshot puts a full
+/// server tree — `bin` included — inside it; without the name check that staging
+/// tree reads as an installed version, and quiescing "other versions" then goes
+/// looking for a service named after it.
 fn versions_under(base: &Path) -> Vec<String> {
 	let mut out: Vec<String> = std::fs::read_dir(base)
 		.into_iter()
@@ -312,9 +318,23 @@ fn versions_under(base: &Path) -> Vec<String> {
 		.flatten()
 		.filter(|entry| entry.path().join("bin").is_dir())
 		.filter_map(|entry| entry.file_name().into_string().ok())
+		.filter(|name| is_version_name(name))
 		.collect();
 	out.sort();
 	out
+}
+
+/// Whether `name` looks like a postgres major-version directory: `18`, or `9.6`
+/// under the pre-10 scheme.
+fn is_version_name(name: &str) -> bool {
+	let mut parts = name.split('.');
+	let major = parts.next().unwrap_or_default();
+	let minor = parts.next();
+	parts.next().is_none() && is_number(major) && minor.is_none_or(is_number)
+}
+
+fn is_number(part: &str) -> bool {
+	!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 /// Error unless server binaries for major `wanted` are installed. A data-only
@@ -552,7 +572,21 @@ mod tests {
 		std::fs::create_dir_all(tmp.path().join("18").join("bin")).unwrap();
 		// No bin: not a server install.
 		std::fs::create_dir_all(tmp.path().join("junk")).unwrap();
+		// A whole-install restore stages a full server tree — bin and all — beside
+		// the installs it's about to replace; it isn't an installed version.
+		std::fs::create_dir_all(tmp.path().join(".bestool-restore.2152").join("bin")).unwrap();
+		std::fs::create_dir_all(tmp.path().join("18.old").join("bin")).unwrap();
 		assert_eq!(versions_under(tmp.path()), vec!["16".to_owned(), "18".to_owned()]);
+	}
+
+	#[test]
+	fn version_names_are_numeric() {
+		assert!(is_version_name("18"));
+		assert!(is_version_name("9.6"));
+		assert!(!is_version_name(""));
+		assert!(!is_version_name("18.old"));
+		assert!(!is_version_name(".bestool-restore.2152"));
+		assert!(!is_version_name("pgAdmin 4"));
 	}
 
 	#[test]


### PR DESCRIPTION
A Windows restore failed at the swap step:

```
2026-07-27T23:51:20.208844Z  INFO ...::service::win: stopped the postgres service postgresql-x64-12
2026-07-27T23:51:20.236934Z  WARN ...::service: could not quiesce the postgres service postgresql-x64-.bestool-restore.2152: [SC] OpenService FAILED 1060
2026-07-27T23:51:20.241539Z  WARN bestool::interactive: moving the restored data into place failed: moving C:\Program Files\PostgreSQL\12 aside to C:\Program Files\PostgreSQL\12.old

  x moving C:\Program Files\PostgreSQL\12 aside to C:\Program Files\PostgreSQL\12.old
  `-> Access is denied. (os error 5)
```

## What's going on

**The swap.** A whole-install restore replaces `PostgreSQL\<version>` — the directory holding the postgres binaries that were running 33 ms earlier. The Service Control Manager reports a service `STOPPED` before its last child process is gone, and Windows keeps an executable's image file locked until the process object is torn down, so the rename hits a flat `ERROR_ACCESS_DENIED` that says nothing about who. Not a permissions problem: kopia had just written 29.5 GB into the same parent directory.

**The bogus service name.** `versions_under` treats any directory with a `bin` subdirectory as an installed server. A whole-install snapshot stages a complete server tree into `<base>\.bestool-restore.<pid>`, so the staging directory read as a version and `quiesce_other_versions` went looking for `postgresql-x64-.bestool-restore.2152`.

## Changes

- `rename_when_free` retries a rename blocked by `ERROR_ACCESS_DENIED` or `ERROR_SHARING_VIOLATION` for up to 10s with exponential backoff. Windows only — on Unix a rename doesn't care who has the files open, and `EACCES` there won't clear by itself. Any other error returns immediately, so a hopeless rename doesn't burn the budget.
- New `method/holders.rs`: when the swap still fails, the error names the processes running from, or sitting in, the tree (via `sysinfo`, already a dependency) instead of leaving the operator with a bare OS error. When it finds nothing, it points at the tools that catch holders it can't see (Sysinternals `handle64`, Resource Monitor) and at elevation.
- `versions_under` only accepts version-shaped directory names (`18`, `9.6`), so the restore's own staging tree stops reading as an installed version.

## Testing

`cargo test -p bestool --features canopy-backup` passes (73 tests). Clippy and fmt clean on both the host target and `x86_64-pc-windows-gnu`.

New tests cover: busy-error classification is Windows-gated; a hopeless rename fails without waiting out the retry budget; `is_under` matches a subtree but not a name prefix, case-insensitively on Windows; the current process shows up as a holder of its own executable's directory; an unused tree reports no holders; version-name filtering rejects `.bestool-restore.2152` and `18.old`.

The race itself isn't reproducible off Windows, so the retry path is verified by construction and by its error-classification tests rather than end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01THxURQSyT9TouLepcKsH9Q)_