### PR TITLE
fix(canopy): run backups and restores without a device key

### DIFF
--- a/.workhorse/specs/canopy/backup.md
+++ b/.workhorse/specs/canopy/backup.md
@@ -69,6 +69,7 @@ A method exposes a `prepare` step that produces the path kopia snapshots (plus a
 ## The control-plane contract
 
 The device authenticates to Canopy with the identity established at enrolment — the tailscale path where available, otherwise the device mTLS certificate.
+A registration that holds no device key still runs backups and restores over the tailscale path; only a host that has neither a device key nor a reachable tailnet fails, and it fails saying so.
 Four endpoints back the system:
 
 - **Register capabilities** — the device posts the set of backup types it can run.

--- a/crates/bestool/src/actions/canopy/backup.rs
+++ b/crates/bestool/src/actions/canopy/backup.rs
@@ -409,10 +409,6 @@ async fn backup_after_start(
 	let reg = load_registration(registration_dir)
 		.await?
 		.ok_or_else(|| miette!("not registered with canopy; run `bestool canopy register` first"))?;
-	let device_key = reg
-		.device_key
-		.clone()
-		.ok_or_else(|| miette!("registration has no device key"))?;
 	let server_id = reg
 		.server_id
 		.clone()
@@ -424,7 +420,7 @@ async fn backup_after_start(
 	// omit the tag otherwise.
 	let device_id = reg.device_id.clone();
 
-	let client = build_client(base_url_of(&reg)?, &device_key).await?;
+	let client = build_client(base_url_of(&reg)?, reg.device_key.as_deref()).await?;
 
 	let target = match TargetOutcome::from_result(client.backup_target().await)? {
 		TargetOutcome::Dormant => {
@@ -885,15 +881,23 @@ pub(super) fn base_url_of(reg: &Registration) -> Result<Url> {
 }
 
 /// Build a canopy client for an already-enrolled host (tailscale, then mTLS).
-pub(super) async fn build_client(base_url: Url, device_key: &str) -> Result<Arc<CanopyClient>> {
+///
+/// The device key is optional: a host on the tailnet authenticates by its
+/// tailscale identity, and only needs the key when the tailnet is out of reach.
+pub(super) async fn build_client(
+	base_url: Url,
+	device_key: Option<&str>,
+) -> Result<Arc<CanopyClient>> {
 	let tailscale_url = bestool_canopy::TAILSCALE_URL
 		.parse()
 		.into_diagnostic()
 		.wrap_err("parsing default canopy tailscale URL")?;
 	let client =
-		CanopyClient::with_urls(base_url, tailscale_url, Some(device_key), crate::http::client_builder)
+		CanopyClient::with_urls(base_url, tailscale_url, device_key, crate::http::client_builder)
 			.await?
-			.ok_or_else(|| miette!("could not build a canopy client (no auth path available)"))?;
+			.ok_or_else(|| {
+				miette!("could not build a canopy client: the tailnet is unreachable and the registration has no device key")
+			})?;
 	Ok(Arc::new(client))
 }
 

--- a/crates/bestool/src/actions/canopy/kopia.rs
+++ b/crates/bestool/src/actions/canopy/kopia.rs
@@ -74,15 +74,11 @@ pub async fn run(args: KopiaArgs, _ctx: Context) -> Result<()> {
 	let reg = load_registration(args.config.as_deref())
 		.await?
 		.ok_or_else(|| miette!("not registered with canopy; run `bestool canopy register` first"))?;
-	let device_key = reg
-		.device_key
-		.clone()
-		.ok_or_else(|| miette!("registration has no device key"))?;
 	let server_id = reg
 		.server_id
 		.clone()
 		.ok_or_else(|| miette!("registration has no server id"))?;
-	let client = build_client(base_url_of(&reg)?, &device_key).await?;
+	let client = build_client(base_url_of(&reg)?, reg.device_key.as_deref()).await?;
 
 	let target = match TargetOutcome::from_result(client.backup_target().await)? {
 		TargetOutcome::Ready(target) => target,

--- a/crates/bestool/src/actions/canopy/restore.rs
+++ b/crates/bestool/src/actions/canopy/restore.rs
@@ -77,15 +77,11 @@ pub async fn run(args: RestoreArgs, _ctx: Context) -> Result<()> {
 	let reg = load_registration(args.config.as_deref())
 		.await?
 		.ok_or_else(|| miette!("not registered with canopy; run `bestool canopy register` first"))?;
-	let device_key = reg
-		.device_key
-		.clone()
-		.ok_or_else(|| miette!("registration has no device key"))?;
 	let server_id = reg
 		.server_id
 		.clone()
 		.ok_or_else(|| miette!("registration has no server id"))?;
-	let client = build_client(base_url_of(&reg)?, &device_key).await?;
+	let client = build_client(base_url_of(&reg)?, reg.device_key.as_deref()).await?;
 
 	let target = match TargetOutcome::from_result(client.backup_target().await)? {
 		TargetOutcome::Ready(target) => target,

--- a/crates/canopy/src/client.rs
+++ b/crates/canopy/src/client.rs
@@ -790,6 +790,56 @@ fXLgamTYOa/w9n/Ta64fiYWmN54kEd0DgnflJDLtID321Zz6xswvK/VN
 		assert!(build_mtls_http(&test_factory(), "not a real PEM").is_err());
 	}
 
+	/// A loopback URL nothing is listening on, so a probe refuses immediately.
+	fn closed_url() -> String {
+		let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+		let addr = listener.local_addr().unwrap();
+		drop(listener);
+		format!("http://{addr}")
+	}
+
+	#[tokio::test]
+	async fn no_device_key_still_builds_over_tailscale() {
+		let (tailnet, _server) = serve_once("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n[]");
+		let client = CanopyClient::with_urls(
+			DEFAULT_CANOPY_URL.parse().unwrap(),
+			tailnet.parse().unwrap(),
+			None,
+			reqwest::Client::builder,
+		)
+		.await
+		.expect("keyless build should not error")
+		.expect("a reachable tailnet is an auth path in its own right");
+		assert!(client.is_tailscale().await);
+	}
+
+	#[tokio::test]
+	async fn no_device_key_and_no_tailnet_leaves_no_auth_path() {
+		let client = CanopyClient::with_urls(
+			DEFAULT_CANOPY_URL.parse().unwrap(),
+			closed_url().parse().unwrap(),
+			None,
+			reqwest::Client::builder,
+		)
+		.await
+		.expect("keyless build should not error");
+		assert!(client.is_none());
+	}
+
+	#[tokio::test]
+	async fn device_key_carries_the_call_when_the_tailnet_is_unreachable() {
+		let client = CanopyClient::with_urls(
+			DEFAULT_CANOPY_URL.parse().unwrap(),
+			closed_url().parse().unwrap(),
+			Some(TEST_DEVICE_KEY),
+			reqwest::Client::builder,
+		)
+		.await
+		.expect("mTLS build should not error")
+		.expect("a device key is an auth path when the tailnet is out of reach");
+		assert!(!client.is_tailscale().await);
+	}
+
 	#[tokio::test]
 	async fn renew_with_mtls_state_swaps_in_fresh_client() {
 		// Construct an mTLS-state client directly (no network probe) and renew it.


### PR DESCRIPTION
🤖 The `backup`, `restore`, and `kopia` entry points each loaded the registration and bailed with "registration has no device key" before a canopy client was ever built. The client itself prefers the tailscale path and only falls back to the device certificate, so a host on the tailnet was blocked by an identity it would never have used — including a host migrated from legacy per-file state that held only the server id, and the daemon-triggered runs that go through `run_backup`.

The key is now optional through `build_client`, and a run fails only when neither the tailnet nor a device key is available, with an error that says which.

This matches what the specs already describe: backup's control-plane contract says the device authenticates over "the tailscale path where available, otherwise the device mTLS certificate", and the registration healthcheck only *warns* on a missing key precisely because the host "depends on the tailscale path to carry its authentication".

Three tests in the canopy client cover the auth-selection ladder against a loopback probe target: keyless with a reachable tailnet, keyless with none, and a device key with the tailnet out of reach.
