### PR TITLE
deps: bump prettyplease to 0.3 and syn to 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,13 +730,13 @@ dependencies = [
  "jiff",
  "machine-uid",
  "miette",
- "prettyplease",
+ "prettyplease 0.3.0",
  "rcgen",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
  "sysinfo",
  "tempfile",
  "time",
@@ -917,7 +917,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -940,7 +940,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -1124,7 +1124,7 @@ checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling",
  "ident_case",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5516,6 +5516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "primefield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5635,7 +5645,7 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.2.37",
  "prost 0.13.5",
  "prost-types",
  "regex",

--- a/crates/canopy/Cargo.toml
+++ b/crates/canopy/Cargo.toml
@@ -44,10 +44,10 @@ tempfile = "3.21.0"
 
 [build-dependencies]
 blake3 = "1.8.5"
-prettyplease = "0.2.37"
+prettyplease = "0.3.0"
 reqwest = { workspace = true, features = ["blocking"] }
 schemars = "0.8.22"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
-syn = "2.0.118"
+syn = "3.0.3"
 typify = "0.7.0"


### PR DESCRIPTION
🤖 Supersedes #752, which fails CI.

prettyplease 0.3 parses `syn` 3 types. The canopy build script parses typify's token stream with its own pinned `syn = "2"`, so `prettyplease::unparse` was handed a `syn::File` from the wrong major:

```
expected `syn::file::File`, found `syn::File`
note: there are multiple different versions of crate `syn` in the dependency graph
```

Bumping both build-dependencies together fixes it. No source changes were needed — `typify::to_stream()` returns a `proc_macro2::TokenStream`, which is unaffected.
