### PR TITLE
feat(seedling): use the host's Seedling identity, elevating to read it

### DIFF
--- a/.workhorse/specs/seedling/overview.md
+++ b/.workhorse/specs/seedling/overview.md
@@ -22,11 +22,29 @@ A command reaches the daemon over its operator interface, rather than by driving
 The interface is a versioned contract with typed requests and responses; a CLI's arguments and rendered output are a human-facing surface that can be rearranged without notice, so depending on them would make a command's correctness rest on how another tool chooses to print things.
 
 Both ends authenticate by public key.
-A command presents the identity of the operator who invoked it, the same identity that operator already uses to reach the daemon, so it needs no identity of its own and nothing has to be authorised for it: an operator who can already operate the host can run these commands, and one who cannot is refused by the daemon rather than by us.
-That keeps a command's authority equal to the authority of the person running it, so a command cannot reach a daemon its operator could not reach directly.
+A command presents the identity of the operator who invoked it wherever that operator has one, the same identity that operator already uses to reach the daemon.
+That keeps a command's authority equal to the authority of the person running it, and keeps the daemon's record of who acted naming them.
+
+An operator who has no identity of their own is not asked to obtain one.
+A Seedling installation authorises one identity for us on the host it is installed on, at `/etc/bestool/seedling.key`, and a command falls back to that.
+This is what lets the operational commands work on a freshly provisioned host, where nothing has been configured for any operator yet.
+Acting under it, a command names the invoking operator to the daemon anyway, so the record of who acted is a person rather than the host.
+
+The host identity is readable only by root, so using it is confined to privileged invocations: it grants no authority that root on that host does not already hold, since root can authorise any key it likes.
+The daemon's own state, including the identity it publishes, is likewise root-only.
+An unprivileged invocation that needs either of them runs itself again elevated rather than failing, so an operator does not have to discover that these commands need privileges on a Seedling host.
+Where the operator's own identity is refused and the host carries one that would be accepted, the refusal says so, rather than leaving the operator to work out that elevating is what is missing.
+
+An operator with no identity of their own, on a host with none either, is told how to obtain access rather than silently acting as no-one.
 
 A command verifies the daemon it connects to against the identity the daemon publishes in its data directory for processes on the same host.
 Because a command runs beside the daemon, it can read that identity directly and needs neither a first-connection prompt nor a store of previously seen daemons.
+
+## Advertising the host identity
+
+A host's Seedling identity is unreadable to an unprivileged process, so a co-located tool cannot tell by itself whether elevating would gain it a working one.
+The local alert daemon's API answers that: its `/seedling` endpoint reports whether the host carries an identity, as `host_identity` on a JSON object.
+It reports presence only and never discloses the identity, so asking is safe from anywhere the API is reachable.
 
 ## Choosing where to act
 

--- a/crates/alertd/src/http_server.rs
+++ b/crates/alertd/src/http_server.rs
@@ -63,6 +63,7 @@ pub async fn start_server(
 		.route("/metrics", get(handle_metrics))
 		.route("/status", get(handle_status))
 		.route("/health", get(handle_health))
+		.route("/seedling", get(handle_seedling))
 		.route("/reload", post(handle_reload))
 		.route("/restart", post(handle_restart))
 		.route("/tasks/{task}/{endpoint}", get(handle_task_endpoint))

--- a/crates/alertd/src/http_server/endpoints.rs
+++ b/crates/alertd/src/http_server/endpoints.rs
@@ -2,6 +2,7 @@ mod control;
 mod health;
 mod index;
 mod metrics;
+mod seedling;
 mod status;
 mod tasks;
 
@@ -9,5 +10,6 @@ pub use control::{handle_reload, handle_restart};
 pub use health::handle_health;
 pub use index::handle_index;
 pub use metrics::handle_metrics;
+pub use seedling::handle_seedling;
 pub use status::handle_status;
 pub use tasks::handle_task_endpoint;

--- a/crates/alertd/src/http_server/endpoints/index.rs
+++ b/crates/alertd/src/http_server/endpoints/index.rs
@@ -24,6 +24,11 @@ pub async fn handle_index() -> impl IntoResponse {
 		},
 		{
 			"method": "GET",
+			"path": "/seedling",
+			"description": "Whether this host carries a Seedling identity for bestool"
+		},
+		{
+			"method": "GET",
 			"path": "/tasks/{task}/{endpoint}",
 			"description": "Invoke an endpoint exposed by a registered background task"
 		}

--- a/crates/alertd/src/http_server/endpoints/seedling.rs
+++ b/crates/alertd/src/http_server/endpoints/seedling.rs
@@ -1,0 +1,60 @@
+use axum::{Json, response::IntoResponse};
+use bestool_tamanu::seedling::{HostIdentity, host_identity};
+
+use crate::http_server::types::SeedlingResponse;
+
+/// Report whether this host carries a Seedling identity for bestool.
+///
+/// The identity itself is root-only, so an unprivileged tool cannot tell by
+/// itself whether elevating would gain it one. This answers that without
+/// disclosing anything: presence, never the key.
+///
+/// spec: SEED#advertising-the-host-identity
+pub async fn handle_seedling() -> impl IntoResponse {
+	Json(report(host_identity()))
+}
+
+fn report(identity: HostIdentity) -> SeedlingResponse {
+	SeedlingResponse {
+		host_identity: identity.present(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+
+	use axum::{http::StatusCode, response::IntoResponse};
+
+	use super::*;
+
+	#[test]
+	fn an_identity_this_daemon_can_read_is_present() {
+		let key = PathBuf::from("/etc/bestool/seedling.key");
+		assert!(report(HostIdentity::Readable(key)).host_identity);
+	}
+
+	#[test]
+	fn an_identity_out_of_this_process_reach_is_still_present() {
+		// The answer is about the host, not about the asking process: a tool
+		// that would have to elevate still needs to know one exists.
+		let key = PathBuf::from("/etc/bestool/seedling.key");
+		assert!(report(HostIdentity::NeedsElevation(key)).host_identity);
+	}
+
+	#[test]
+	fn no_identity_reports_absent() {
+		assert!(!report(HostIdentity::Absent).host_identity);
+	}
+
+	#[tokio::test]
+	async fn the_endpoint_answers_with_the_documented_shape() {
+		let response = handle_seedling().await.into_response();
+		assert_eq!(response.status(), StatusCode::OK);
+		let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+			.await
+			.unwrap();
+		// The value depends on the host this runs on; the shape does not.
+		serde_json::from_slice::<SeedlingResponse>(&body).unwrap();
+	}
+}

--- a/crates/alertd/src/http_server/types.rs
+++ b/crates/alertd/src/http_server/types.rs
@@ -16,6 +16,16 @@ pub struct StatusResponse {
 	pub backups_configured: Vec<String>,
 }
 
+/// The `/seedling` response: what a co-located tool needs to know about this
+/// host's Seedling access.
+#[derive(Serialize, Deserialize)]
+pub struct SeedlingResponse {
+	/// Whether the host carries a Seedling identity for bestool, which a
+	/// privileged process can use to reach the daemon. Never the identity
+	/// itself: a tool asks this to learn that elevating will get it one.
+	pub host_identity: bool,
+}
+
 /// The `/health` response: the watchdog's view of the daemon's liveness.
 #[derive(Serialize, Deserialize)]
 pub struct HealthResponse {

--- a/crates/tamanu/src/lib.rs
+++ b/crates/tamanu/src/lib.rs
@@ -12,7 +12,6 @@ pub mod config;
 pub mod connection_url;
 pub mod pm2;
 pub mod roots;
-#[cfg(feature = "seedling")]
 pub mod seedling;
 pub mod server_info;
 pub mod services;

--- a/crates/tamanu/src/seedling.rs
+++ b/crates/tamanu/src/seedling.rs
@@ -4,704 +4,223 @@
 //! Seedling app rather than a set of units or pm2 processes, so the lifecycle,
 //! log, and database commands act through the daemon.
 //!
-//! They speak the daemon's operator interface, presenting the identity of the
-//! operator who invoked them. That keeps a command's authority equal to the
-//! authority of the person running it, and means nothing here needs an identity
-//! of its own or anything authorised for it.
+//! Everything that speaks the interface itself lives in [`oi`], behind the
+//! `seedling` feature. What stays here is the part of a Seedling host that
+//! needs no protocol client to observe: where its state lives, and whether it
+//! carries an identity for us.
 //!
 //! spec: SEED
 
 use std::{
-	net::{IpAddr, Ipv6Addr, SocketAddr},
+	io,
 	path::{Path, PathBuf},
 };
 
-use miette::{IntoDiagnostic, Result, bail, miette};
-use seedling_protocol::{
-	actor::Actor,
-	client::{ClientAuth, OiClient},
-	keys::ClientIdentity,
-};
-use serde::Deserialize;
-use serde_json::{Value, json};
-use tracing::debug;
+use miette::{Report, miette};
+use tracing::{debug, info, warn};
 
-use crate::systemd;
+#[cfg(feature = "seedling")]
+mod oi;
+#[cfg(feature = "seedling")]
+pub use oi::*;
 
 /// The daemon's service unit, installed and enabled by the Seedling package.
-const DAEMON_UNIT: &str = "seedling.service";
+pub const DAEMON_UNIT: &str = "seedling.service";
 
-/// Where the Seedling package keeps the daemon's state.
-const DATA_DIR: &str = "/var/lib/seedling";
+/// Where the Seedling package keeps the daemon's state. Root-only, so an
+/// unprivileged process can read neither the daemon's published identity nor
+/// the authorised keys it holds.
+pub const DATA_DIR: &str = "/var/lib/seedling";
 
-/// The daemon publishes its own interface identity here for processes on the
-/// same host, so a co-located client needs no probe and no store of previously
-/// seen daemons.
-const FINGERPRINT_FILE: &str = "oi.fingerprint";
+/// The identity the Seedling package generates for us and authorises with the
+/// daemon, so these commands work on a freshly provisioned host with nothing
+/// configured for any operator.
+///
+/// The file is owned by root and readable by nobody else, which is what keeps
+/// it from handing daemon access to every local user.
+const HOST_KEY: &str = "/etc/bestool/seedling.key";
 
-/// The port the daemon's operator interface listens on for local clients.
-const OI_PORT: u16 = 7891;
+/// Environment variable relocating the host identity. Set by tests, and
+/// honoured for ad-hoc relocation.
+const KEY_ENV: &str = "BESTOOL_SEEDLING_KEY";
 
-/// Which runtime owns Tamanu on this host.
-pub enum Reach {
-	/// No Seedling here: act through the host service manager.
-	Host,
-	/// A Seedling host, connected to its daemon.
-	Seedling(Box<Oi>),
-	/// A Seedling host whose daemon cannot be reached, and why.
-	///
-	/// Callers must report this and stop. Falling back to the host service
-	/// manager would act on services that aren't the ones the operator means,
-	/// reporting success while leaving the running system untouched.
-	Unreachable(String),
+/// This host's Seedling identity for us, and whether this process can use it.
+///
+/// spec: SEED#speaking-the-operator-interface
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostIdentity {
+	/// The host carries no identity for us: only an operator's own key can
+	/// reach the daemon.
+	Absent,
+	/// Present, and this process can read it.
+	Readable(PathBuf),
+	/// Present, but reading it needs privileges this process does not have.
+	NeedsElevation(PathBuf),
 }
 
-/// Resolve which runtime owns Tamanu on this host.
+impl HostIdentity {
+	/// Whether the host carries an identity for us at all, regardless of
+	/// whether this process can read it.
+	pub fn present(&self) -> bool {
+		!matches!(self, Self::Absent)
+	}
+
+	/// Whether reaching this identity requires running elevated.
+	pub fn needs_elevation(&self) -> bool {
+		matches!(self, Self::NeedsElevation(_))
+	}
+}
+
+/// Where the host identity lives.
+pub fn host_key_path() -> PathBuf {
+	std::env::var_os(KEY_ENV)
+		.map(PathBuf::from)
+		.unwrap_or_else(|| PathBuf::from(HOST_KEY))
+}
+
+/// Classify this host's identity for us.
 ///
-/// Recognition keys off the daemon's installed service rather than off reaching
-/// the daemon, so a host whose daemon is stopped or broken is still recognised
-/// as a Seedling host.
-pub async fn reach() -> Reach {
-	if !systemd::unit_file_exists(DAEMON_UNIT)
+/// Readability is settled by opening the file rather than by reading its mode:
+/// ownership, mode bits, ACLs, and the capabilities of the running process all
+/// bear on the answer, and only the kernel knows all of them.
+pub fn host_identity() -> HostIdentity {
+	let path = host_key_path();
+	let probe = std::fs::File::open(&path).map(drop);
+	let identity = classify(path, probe, privileged());
+	debug!(?identity, "resolved the host's Seedling identity");
+	identity
+}
+
+fn classify(path: PathBuf, probe: io::Result<()>, privileged: bool) -> HostIdentity {
+	match probe {
+		Ok(()) => HostIdentity::Readable(path),
+		Err(err) if err.kind() == io::ErrorKind::NotFound => HostIdentity::Absent,
+		// Privileged and still refused: elevating again would not help, so
+		// treat it as no identity rather than looping through sudo.
+		Err(err) if err.kind() == io::ErrorKind::PermissionDenied && !privileged => {
+			HostIdentity::NeedsElevation(path)
+		}
+		Err(err) => {
+			warn!(?path, %err, "cannot read the host's Seedling identity");
+			HostIdentity::Absent
+		}
+	}
+}
+
+/// Re-run this command elevated, exiting with the status it returns.
+///
+/// A Seedling host keeps both the daemon's published identity and our own
+/// identity under root-only paths, so an unprivileged invocation of a
+/// Seedling-aware command cannot get far. Rather than telling the operator to
+/// run it again themselves, run it for them, the same way the host service
+/// manager path elevates itself before touching rootful podman.
+///
+/// Returns only when sudo could not be run at all, hence the error return.
+///
+/// spec: SEED#speaking-the-operator-interface
+pub async fn elevate(reason: &str) -> Report {
+	if !cfg!(unix) {
+		return miette!("{reason}, and this platform cannot elevate to reach it");
+	}
+
+	info!(reason, "re-running elevated");
+	let args: Vec<String> = std::env::args().collect();
+	match tokio::process::Command::new("sudo")
+		.args(args)
+		.status()
 		.await
-		.unwrap_or(false)
 	{
-		debug!("{DAEMON_UNIT} not installed, using the host service manager");
-		return Reach::Host;
-	}
-
-	match Oi::open(Path::new(DATA_DIR)).await {
-		Ok(oi) => Reach::Seedling(Box::new(oi)),
-		Err(err) => Reach::Unreachable(format!("{err}")),
+		Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+		Err(err) => miette!("{reason}, and elevating to reach it failed: {err}"),
 	}
 }
 
-/// A connection to the daemon's operator interface.
-pub struct Oi {
-	client: OiClient,
+/// Whether this process is running as root.
+#[cfg(target_os = "linux")]
+fn privileged() -> bool {
+	rustix::process::geteuid().is_root()
 }
 
-impl Oi {
-	/// Connect as the invoking operator, verifying the daemon against the
-	/// identity it published in its data directory.
-	pub async fn open(data_dir: &Path) -> Result<Self> {
-		let fingerprint_path = data_dir.join(FINGERPRINT_FILE);
-		let fingerprint = std::fs::read_to_string(&fingerprint_path)
-			.map_err(|err| {
-				miette!(
-					"cannot read the Seedling daemon's published identity at {}: {err}",
-					fingerprint_path.display()
-				)
-			})?
-			.trim()
-			.to_owned();
-
-		let key_path = ClientIdentity::default_path();
-		let (identity, is_new) = ClientIdentity::load_or_generate(&key_path).map_err(|err| {
-			miette!(
-				"cannot load your Seedling identity from {}: {err}",
-				key_path.display()
-			)
-		})?;
-		if is_new {
-			// A freshly generated key is one the daemon has never seen.
-			// Authorising it is the operator's own step: a command that quietly
-			// minted itself access would not be acting with their authority.
-			bail!(
-				"no Seedling identity existed at {}, so the daemon has nothing to recognise; authorise the new one with `seedling-ctl user add`",
-				key_path.display()
-			);
-		}
-
-		// bestool links both aws-lc-rs and ring, so rustls cannot pick a
-		// provider by itself and panics on first use. Installing is idempotent
-		// and only the first caller wins, which is why the result is dropped.
-		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
-		let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), OI_PORT);
-		let client = OiClient::connect(
-			addr,
-			ClientAuth::Fingerprint(fingerprint),
-			&identity,
-			actor(),
-		)
-		.await
-		.map_err(|err| miette!("cannot reach the Seedling daemon at {addr}: {err}"))?;
-
-		Ok(Self { client })
-	}
-
-	async fn request(&self, method: &str, params: Value) -> Result<Value> {
-		debug!(method, %params, "operator interface request");
-		self.client
-			.request(method, params)
-			.await
-			.map_err(|err| miette!("the Seedling daemon rejected {method}: {err}"))
-	}
-
-	/// The underlying client, for callers that need a stream rather than a
-	/// request and response.
-	pub fn client(&self) -> &OiClient {
-		&self.client
-	}
-
-	/// Every app the daemon manages.
-	pub async fn apps(&self) -> Result<Vec<App>> {
-		serde_json::from_value(self.request("/apps/list", json!({})).await?).into_diagnostic()
-	}
-
-	/// Everything the daemon knows about one app, including its resources.
-	pub async fn show(&self, app: &str) -> Result<Show> {
-		serde_json::from_value(self.request("/apps/show", json!({ "app": app })).await?)
-			.into_diagnostic()
-	}
-
-	/// Bring every stopped resource of an app back to its desired state.
-	pub async fn unstop(&self, app: &str) -> Result<()> {
-		self.request("/apps/unstop", json!({ "app": app }))
-			.await
-			.map(drop)
-	}
-
-	/// Stop one resource, leaving it where [`Oi::unstop`] can bring it back.
-	///
-	/// A stop is built from these rather than from uninstalling the app: an
-	/// uninstalled app is recovered by installing it again, and an install takes
-	/// the parameters the app was installed with, which a stop has no business
-	/// knowing or re-supplying.
-	pub async fn stop_resource(&self, app: &str, kind: &str, name: &str) -> Result<()> {
-		self.request(
-			"/apps/resource/stop",
-			json!({ "app": app, "kind": kind, "name": name }),
-		)
-		.await
-		.map(drop)
-	}
-
-	/// Bring one stopped resource back to its desired state.
-	pub async fn unstop_resource(&self, app: &str, kind: &str, name: &str) -> Result<()> {
-		self.request(
-			"/apps/resource/unstop",
-			json!({ "app": app, "kind": kind, "name": name }),
-		)
-		.await
-		.map(drop)
-	}
-
-	/// Roll one deployment, following the update strategy it declares.
-	pub async fn restart(&self, app: &str, deployment: &str) -> Result<()> {
-		self.request(
-			"/apps/restart",
-			json!({ "app": app, "deployment": deployment }),
-		)
-		.await
-		.map(drop)
-	}
-
-	/// Subscribe to a log stream.
-	///
-	/// The request and its response ride one bidirectional stream; the entries
-	/// then arrive on a unidirectional stream the daemon opens in reply.
-	pub async fn log_stream(&self, params: Value) -> Result<LogStream> {
-		let (mut send, mut recv) = self
-			.client
-			.open_bi()
-			.await
-			.map_err(|err| miette!("cannot open a stream to the Seedling daemon: {err}"))?;
-
-		let request = serde_json::to_vec(&json!({ "method": "/logs/stream", "params": params }))
-			.into_diagnostic()?;
-		send.write_all(&request)
-			.await
-			.map_err(|err| miette!("cannot send the log request: {err}"))?;
-		let _ = send.finish();
-
-		let response = recv
-			.read_to_end(64 * 1024)
-			.await
-			.map_err(|err| miette!("cannot read the log response: {err}"))?;
-		if let Ok(value) = serde_json::from_slice::<Value>(&response)
-			&& let Some(error) = value.get("error")
-		{
-			let code = error
-				.get("code")
-				.and_then(Value::as_str)
-				.unwrap_or("unknown");
-			let message = error
-				.get("message")
-				.and_then(Value::as_str)
-				.unwrap_or("unknown error");
-			bail!("the Seedling daemon refused the log request: [{code}] {message}");
-		}
-
-		let stream = self
-			.client
-			.accept_uni()
-			.await
-			.map_err(|err| miette!("the Seedling daemon opened no log stream: {err}"))?;
-		Ok(LogStream {
-			stream,
-			buffer: Vec::new(),
-		})
-	}
-
-	/// Every volume an app exports for other things to use.
-	pub async fn exported_volumes(&self) -> Result<Vec<ExportedVolume>> {
-		serde_json::from_value(self.request("/volumes/exported/list", json!({})).await?)
-			.into_diagnostic()
-	}
+#[cfg(not(target_os = "linux"))]
+fn privileged() -> bool {
+	false
 }
 
-/// How this command identifies itself in the daemon's event feed, so an operator
-/// reading it can tell which tool acted.
-fn actor() -> Actor {
-	Actor {
-		kind: Some("bestool".into()),
-		id: None,
-		display: Some(concat!("bestool ", env!("CARGO_PKG_VERSION")).into()),
-		session: None,
-	}
-}
-
-/// One entry of the daemon's app list.
-#[derive(Debug, Clone, Deserialize)]
-pub struct App {
-	pub name: String,
-	pub status: String,
-	/// Active, uncleared faults filed against the app.
-	#[serde(default)]
-	pub fault_count: u64,
-	/// Whether any of the app's resources are stopped, which is what a start has
-	/// to undo.
-	#[serde(default)]
-	pub has_stopped_resources: bool,
-	#[serde(default)]
-	pub description: Option<String>,
-}
-
-impl App {
-	/// Whether the app is in a steady state with everything at its desired
-	/// lifecycle state.
-	///
-	/// An app's status arrives lower-cased and underscored (`not_installed`)
-	/// while a resource instance's lifecycle arrives capitalised (`Running`), so
-	/// this compares without regard to case rather than picking one of the two
-	/// spellings and being wrong about the other.
-	pub fn running(&self) -> bool {
-		self.status.eq_ignore_ascii_case("running")
-	}
-}
-
-/// What the daemon knows about one app.
-///
-/// Only the fields the commands report on are modelled; a resource's full
-/// definition is left alone.
-#[derive(Debug, Clone, Deserialize)]
-pub struct Show {
-	pub status: String,
-	/// Faults not tied to any one resource, such as script evaluation errors.
-	#[serde(default)]
-	pub faults: Vec<Value>,
-	#[serde(default)]
-	pub resources: Vec<Resource>,
-	#[serde(default)]
-	pub params: Vec<Param>,
-}
-
-/// One of an app's parameters.
-#[derive(Debug, Clone, Deserialize)]
-pub struct Param {
-	pub name: String,
-	/// The stored value, absent when the parameter is unset or secret.
-	#[serde(default)]
-	pub value: Option<String>,
-	#[serde(default)]
-	pub default_value: Option<String>,
-}
-
-/// One resource of an app: a deployment, job, ingress, service, or volume.
-#[derive(Debug, Clone, Deserialize)]
-pub struct Resource {
-	pub name: String,
-	#[serde(rename = "type")]
-	pub kind: String,
-	#[serde(default)]
-	pub instances: Vec<Instance>,
-	#[serde(default)]
-	pub faults: Vec<Value>,
-}
-
-/// A volume one app exports for other things to use, and where it lives on the
-/// host so a co-located tool can address its contents.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ExportedVolume {
-	pub app: String,
-	pub volume_name: String,
-	pub host_path: PathBuf,
-	#[serde(default)]
-	pub description: Option<String>,
-}
-
-/// One instance of a resource.
-#[derive(Debug, Clone, Deserialize)]
-pub struct Instance {
-	pub display_name: String,
-	pub lifecycle: String,
-}
-
-/// A subscription to the daemon's log stream, yielding one entry at a time.
-pub struct LogStream {
-	stream: quinn::RecvStream,
-	buffer: Vec<u8>,
-}
-
-impl LogStream {
-	/// The next entry, or `None` once the daemon closes the stream.
-	///
-	/// Entries are newline-delimited, so a read can land mid-entry and the
-	/// remainder is held until the rest arrives.
-	pub async fn next(&mut self) -> Result<Option<LogEntry>> {
-		let mut chunk = [0u8; 4096];
-		loop {
-			if let Some(end) = self.buffer.iter().position(|&b| b == b'\n') {
-				let line: Vec<u8> = self.buffer.drain(..=end).collect();
-				let line = &line[..line.len() - 1];
-				if line.is_empty() {
-					continue;
-				}
-				return serde_json::from_slice(line)
-					.map(Some)
-					.into_diagnostic()
-					.map_err(|err| err.wrap_err("cannot read a log entry"));
-			}
-
-			match self
-				.stream
-				.read(&mut chunk)
-				.await
-				.map_err(|err| miette!("cannot read the log stream: {err}"))?
-			{
-				Some(read) => self.buffer.extend_from_slice(&chunk[..read]),
-				None => return Ok(None),
-			}
-		}
-	}
-}
-
-/// One entry of a log stream.
-#[derive(Debug, Clone, Deserialize)]
-pub struct LogEntry {
-	pub timestamp: String,
-	pub message: String,
-	pub unit: String,
-}
-
-impl LogEntry {
-	/// The emitting unit as the daemon names the thing itself, rather than as
-	/// the service wrapping it.
-	pub fn source(&self) -> &str {
-		self.unit
-			.strip_prefix("seedling-")
-			.unwrap_or(&self.unit)
-			.strip_suffix(".service")
-			.unwrap_or_else(|| self.unit.strip_prefix("seedling-").unwrap_or(&self.unit))
-	}
-}
-
-/// The resource type that carries a scale and an update strategy, and so is the
-/// unit a restart rolls.
-const DEPLOYMENT: &str = "deployment";
-
-/// Resource kinds the daemon can stop and bring back. Services and volumes carry
-/// no lifecycle of their own to stop.
-const STOPPABLE: [&str; 3] = [DEPLOYMENT, "job", "ingress"];
-
-impl Show {
-	/// The app's deployments, which are what a restart rolls: jobs, ingresses,
-	/// services, and volumes have no update strategy to follow.
-	pub fn deployments(&self) -> impl Iterator<Item = &Resource> {
-		self.resources.iter().filter(|r| r.kind == DEPLOYMENT)
-	}
-
-	/// A parameter's effective value: what is stored, or the default it falls
-	/// back to. A secret reads as absent, since the daemon does not return one.
-	pub fn param(&self, name: &str) -> Option<&str> {
-		let param = self.params.iter().find(|p| p.name == name)?;
-		param.value.as_deref().or(param.default_value.as_deref())
-	}
-
-	/// The resources a stop acts on, which are those the daemon can later bring
-	/// back where it left them.
-	pub fn stoppable(&self) -> impl Iterator<Item = &Resource> {
-		self.resources
-			.iter()
-			.filter(|r| STOPPABLE.contains(&r.kind.as_str()))
-	}
-}
-
-/// Pick the app a command acts on.
-///
-/// A named app must exist. Without a name, exactly one Tamanu app must be
-/// present: none leaves nothing to act on, and several are ambiguous enough that
-/// guessing could act on the wrong deployment.
-///
-/// spec: SEED#targeting-an-application
-pub fn target<'a>(apps: &'a [App], named: Option<&str>) -> Result<&'a App> {
-	if let Some(name) = named {
-		return apps.iter().find(|app| app.name == name).ok_or_else(|| {
-			miette!(
-				"the Seedling daemon manages no app named {name}{}",
-				listing(apps)
-			)
-		});
-	}
-
-	let mut tamanu = apps.iter().filter(|app| app.name.contains("tamanu"));
-	match (tamanu.next(), tamanu.next()) {
-		(Some(only), None) => Ok(only),
-		(None, _) => bail!("the Seedling daemon manages no Tamanu app{}", listing(apps)),
-		(Some(one), Some(two)) => bail!(
-			"the Seedling daemon manages more than one Tamanu app ({}, {}); name the one to act on",
-			one.name,
-			two.name
-		),
-	}
-}
-
-fn listing(apps: &[App]) -> String {
-	if apps.is_empty() {
-		return ", and manages no apps at all".into();
-	}
-	format!(
-		"; it manages: {}",
-		apps.iter()
-			.map(|a| a.name.as_str())
-			.collect::<Vec<_>>()
-			.join(", ")
-	)
+/// The daemon's published identity, which a co-located client pins instead of
+/// prompting or keeping a store of previously seen daemons.
+pub fn fingerprint_path(data_dir: &Path) -> PathBuf {
+	data_dir.join("oi.fingerprint")
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 
-	fn app(name: &str) -> App {
-		App {
-			name: name.into(),
-			status: "running".into(),
-			fault_count: 0,
-			has_stopped_resources: false,
-			description: None,
-		}
+	fn path() -> PathBuf {
+		PathBuf::from("/etc/bestool/seedling.key")
 	}
 
 	#[test]
-	fn picks_the_only_tamanu_app() {
-		let apps = [app("tamanu"), app("caddy")];
-		assert_eq!(target(&apps, None).unwrap().name, "tamanu");
+	fn a_readable_key_is_usable_as_is() {
+		let id = classify(path(), Ok(()), false);
+		assert_eq!(id, HostIdentity::Readable(path()));
+		assert!(id.present());
+		assert!(!id.needs_elevation());
 	}
 
 	#[test]
-	fn picks_a_prefixed_tamanu_app() {
-		let apps = [app("tamanu-central"), app("grafana")];
-		assert_eq!(target(&apps, None).unwrap().name, "tamanu-central");
+	fn a_missing_key_is_absent() {
+		let id = classify(path(), Err(io::Error::from(io::ErrorKind::NotFound)), false);
+		assert_eq!(id, HostIdentity::Absent);
+		assert!(!id.present());
+		assert!(!id.needs_elevation());
 	}
 
 	#[test]
-	fn no_tamanu_app_lists_what_is_there() {
-		let apps = [app("caddy"), app("grafana")];
-		let err = format!("{}", target(&apps, None).unwrap_err());
-		assert!(err.contains("no Tamanu app"), "{err}");
-		assert!(err.contains("caddy"), "{err}");
+	fn a_refused_key_needs_elevation_when_unprivileged() {
+		let id = classify(
+			path(),
+			Err(io::Error::from(io::ErrorKind::PermissionDenied)),
+			false,
+		);
+		assert_eq!(id, HostIdentity::NeedsElevation(path()));
+		assert!(id.present(), "the host does carry an identity for us");
+		assert!(id.needs_elevation());
 	}
 
 	#[test]
-	fn no_apps_at_all_says_so() {
-		let err = format!("{}", target(&[], None).unwrap_err());
-		assert!(err.contains("no apps at all"), "{err}");
+	fn a_refused_key_is_absent_when_already_privileged() {
+		// Elevating again would land in the same place, so this must not
+		// report as elevatable or the command would loop through sudo.
+		let id = classify(
+			path(),
+			Err(io::Error::from(io::ErrorKind::PermissionDenied)),
+			true,
+		);
+		assert_eq!(id, HostIdentity::Absent);
+		assert!(!id.needs_elevation());
 	}
 
 	#[test]
-	fn several_tamanu_apps_require_a_name() {
-		let apps = [app("tamanu-central"), app("tamanu-facility")];
-		let err = format!("{}", target(&apps, None).unwrap_err());
-		assert!(err.contains("more than one"), "{err}");
-		assert!(err.contains("name the one"), "{err}");
+	fn an_unreadable_key_for_any_other_reason_is_absent() {
+		let id = classify(
+			path(),
+			Err(io::Error::from(io::ErrorKind::InvalidData)),
+			false,
+		);
+		assert_eq!(id, HostIdentity::Absent);
 	}
 
 	#[test]
-	fn several_tamanu_apps_resolve_once_named() {
-		let apps = [app("tamanu-central"), app("tamanu-facility")];
+	fn a_real_file_reads_as_readable() {
+		let dir = tempfile::tempdir().unwrap();
+		let key = dir.path().join("seedling.key");
+		std::fs::write(&key, b"not really a key").unwrap();
+
+		let probe = std::fs::File::open(&key).map(drop);
 		assert_eq!(
-			target(&apps, Some("tamanu-facility")).unwrap().name,
-			"tamanu-facility"
+			classify(key.clone(), probe, false),
+			HostIdentity::Readable(key)
 		);
-	}
-
-	#[test]
-	fn a_named_app_need_not_look_like_tamanu() {
-		let apps = [app("tamanu"), app("caddy")];
-		assert_eq!(target(&apps, Some("caddy")).unwrap().name, "caddy");
-	}
-
-	#[test]
-	fn an_absent_name_is_an_error() {
-		let apps = [app("tamanu")];
-		let err = format!("{}", target(&apps, Some("nope")).unwrap_err());
-		assert!(err.contains("no app named nope"), "{err}");
-		assert!(err.contains("tamanu"), "{err}");
-	}
-
-	#[test]
-	fn show_parses_the_daemon_shape_and_picks_deployments() {
-		let show: Show = serde_json::from_value(serde_json::json!({
-			"status": "degraded",
-			"faults": [],
-			"resources": [
-				{
-					"name": "api",
-					"type": "deployment",
-					"scale": 2,
-					"instances": [
-						{ "id": "1", "display_name": "api-1", "lifecycle": "Running" },
-						{ "id": "2", "display_name": "api-2", "lifecycle": "Terminating" },
-					],
-					"faults": [],
-					"def": { "container": { "image": "tamanu:latest" } },
-				},
-				{ "name": "migrate", "type": "job", "instances": [], "faults": [] },
-				{ "name": "web", "type": "ingress", "instances": [], "faults": [] },
-			],
-			"params": [{ "name": "db-name", "value": "tamanu", "is_set": true, "secret": false }],
-		}))
-		.unwrap();
-
-		assert_eq!(show.status, "degraded");
-		let deployments: Vec<&str> = show.deployments().map(|r| r.name.as_str()).collect();
-		assert_eq!(deployments, vec!["api"], "jobs and ingresses aren't rolled");
-		assert_eq!(show.param("db-name"), Some("tamanu"));
-
-		let api = show.deployments().next().unwrap();
-		assert_eq!(api.instances.len(), 2);
-		assert_eq!(api.instances[0].display_name, "api-1");
-		assert_eq!(api.instances[1].lifecycle, "Terminating");
-	}
-
-	#[test]
-	fn param_falls_back_to_its_default() {
-		let show: Show = serde_json::from_value(serde_json::json!({
-			"status": "running",
-			"params": [
-				{ "name": "db-user", "value": null, "default_value": "tamanu" },
-				{ "name": "auth-secret", "value": null, "default_value": null },
-			],
-		}))
-		.unwrap();
-		assert_eq!(show.param("db-user"), Some("tamanu"));
-		assert_eq!(show.param("auth-secret"), None, "a secret reads as absent");
-		assert_eq!(show.param("absent"), None);
-	}
-
-	#[test]
-	fn stoppable_covers_the_kinds_with_a_lifecycle() {
-		let show: Show = serde_json::from_value(serde_json::json!({
-			"status": "running",
-			"resources": [
-				{ "name": "api", "type": "deployment" },
-				{ "name": "migrate", "type": "job" },
-				{ "name": "web", "type": "ingress" },
-				{ "name": "api-svc", "type": "service" },
-				{ "name": "data", "type": "volume" },
-			],
-		}))
-		.unwrap();
-
-		let stoppable: Vec<&str> = show.stoppable().map(|r| r.name.as_str()).collect();
-		assert_eq!(
-			stoppable,
-			vec!["api", "migrate", "web"],
-			"services and volumes have no lifecycle to stop"
-		);
-	}
-
-	#[test]
-	fn show_tolerates_an_app_with_no_resources() {
-		let show: Show =
-			serde_json::from_value(serde_json::json!({ "status": "not_installed" })).unwrap();
-		assert!(show.resources.is_empty());
-		assert_eq!(show.deployments().count(), 0);
-	}
-
-	#[test]
-	fn app_list_parses_the_daemon_shape() {
-		// Statuses as the daemon sends them: lower-cased and underscored, unlike
-		// the capitalised lifecycle on a resource instance.
-		let apps: Vec<App> = serde_json::from_value(serde_json::json!([
-			{ "name": "postgres", "status": "installing", "has_stopped_resources": false,
-			  "fault_count": 2, "description": "PostgreSQL database server" },
-			{ "name": "tamanu-facility", "status": "not_installed",
-			  "has_stopped_resources": true, "fault_count": 0, "description": "Tamanu facility" },
-			{ "name": "tamanu-central", "status": "running", "fault_count": 0 },
-		]))
-		.unwrap();
-		assert_eq!(apps.len(), 3);
-		assert!(!apps[0].running());
-		assert!(!apps[1].running());
-		assert!(apps[2].running());
-		assert_eq!(apps[0].fault_count, 2);
-		assert!(apps[1].has_stopped_resources);
-		assert_eq!(
-			apps[0].description.as_deref(),
-			Some("PostgreSQL database server")
-		);
-		assert!(
-			!apps[2].has_stopped_resources,
-			"an absent field defaults rather than failing the parse"
-		);
-	}
-
-	#[test]
-	fn running_ignores_the_casing_difference() {
-		let mut app = app("tamanu");
-		app.status = "running".into();
-		assert!(app.running(), "the daemon lower-cases an app's status");
-		app.status = "Running".into();
-		assert!(app.running(), "an instance lifecycle is capitalised");
-		app.status = "degraded".into();
-		assert!(!app.running());
-	}
-
-	#[test]
-	fn log_entry_names_the_thing_not_its_unit() {
-		let entry = |unit: &str| LogEntry {
-			timestamp: "t".into(),
-			message: "m".into(),
-			unit: unit.into(),
-		};
-		assert_eq!(
-			entry("seedling-postgres-postgres-7c47d6e8.service").source(),
-			"postgres-postgres-7c47d6e8"
-		);
-		assert_eq!(entry("seedling-caddy-blue.service").source(), "caddy-blue");
-		assert_eq!(
-			entry("postgres").source(),
-			"postgres",
-			"left alone when it carries neither"
-		);
-	}
-
-	#[test]
-	fn log_entry_parses_the_stream_shape() {
-		let entry: LogEntry = serde_json::from_value(serde_json::json!({
-			"timestamp": "2026-07-28T09:35:10.123456Z",
-			"message": "database system is ready to accept connections",
-			"unit": "postgres-postgres-7c47d6e8",
-			"stream": "stdout",
-			"app": "postgres",
-			"resource_kind": "deployment",
-		}))
-		.unwrap();
-		assert_eq!(entry.unit, "postgres-postgres-7c47d6e8");
-		assert!(entry.message.contains("ready to accept"));
 	}
 }

--- a/crates/tamanu/src/seedling/oi.rs
+++ b/crates/tamanu/src/seedling/oi.rs
@@ -1,0 +1,768 @@
+//! Speaking a Seedling host's operator interface.
+//!
+//! On a host that runs the Seedling application orchestrator, Tamanu is a
+//! Seedling app rather than a set of units or pm2 processes, so the lifecycle,
+//! log, and database commands act through the daemon.
+//!
+//! They present the identity of the operator who invoked them where that
+//! operator has one, so a command's authority is the authority of the person
+//! running it. Where they don't, they fall back to the identity the Seedling
+//! installation authorised for this host, which is what lets them work on a
+//! freshly provisioned host with nothing configured for any operator.
+//!
+//! spec: SEED
+
+use std::{
+	io,
+	net::{IpAddr, Ipv6Addr, SocketAddr},
+	path::{Path, PathBuf},
+};
+
+use miette::{IntoDiagnostic, Result, bail, miette};
+use seedling_protocol::{
+	actor::Actor,
+	client::{ClientAuth, OiClient},
+	keys::ClientIdentity,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::debug;
+
+use super::{
+	DAEMON_UNIT, DATA_DIR, HostIdentity, elevate, fingerprint_path, host_identity, host_key_path,
+};
+use crate::systemd;
+
+/// The port the daemon's operator interface listens on for local clients.
+const OI_PORT: u16 = 7891;
+
+/// Which runtime owns Tamanu on this host.
+pub enum Reach {
+	/// No Seedling here: act through the host service manager.
+	Host,
+	/// A Seedling host, connected to its daemon.
+	Seedling(Box<Oi>),
+	/// A Seedling host whose daemon cannot be reached, and why.
+	///
+	/// Callers must report this and stop. Falling back to the host service
+	/// manager would act on services that aren't the ones the operator means,
+	/// reporting success while leaving the running system untouched.
+	Unreachable(String),
+}
+
+/// Resolve which runtime owns Tamanu on this host.
+///
+/// Recognition keys off the daemon's installed service rather than off reaching
+/// the daemon, so a host whose daemon is stopped or broken is still recognised
+/// as a Seedling host.
+pub async fn reach() -> Reach {
+	if !systemd::unit_file_exists(DAEMON_UNIT)
+		.await
+		.unwrap_or(false)
+	{
+		debug!("{DAEMON_UNIT} not installed, using the host service manager");
+		return Reach::Host;
+	}
+
+	match Oi::open(Path::new(DATA_DIR)).await {
+		Ok(oi) => Reach::Seedling(Box::new(oi)),
+		Err(err) => Reach::Unreachable(format!("{err}")),
+	}
+}
+
+/// A connection to the daemon's operator interface.
+pub struct Oi {
+	client: OiClient,
+}
+
+impl Oi {
+	/// Connect to the daemon, verifying it against the identity it published in
+	/// its data directory.
+	pub async fn open(data_dir: &Path) -> Result<Self> {
+		let host = host_identity();
+
+		let fingerprint_path = fingerprint_path(data_dir);
+		let fingerprint = match std::fs::read_to_string(&fingerprint_path) {
+			Ok(published) => published.trim().to_owned(),
+			// The daemon's data directory is root-only, so an unprivileged
+			// invocation cannot even learn which daemon to trust. Elevating
+			// reaches both this and the host identity in one step.
+			Err(err) if err.kind() == io::ErrorKind::PermissionDenied && host.needs_elevation() => {
+				return Err(elevate(&format!(
+					"the Seedling daemon's published identity at {} is not readable unprivileged",
+					fingerprint_path.display()
+				))
+				.await);
+			}
+			Err(err) => {
+				return Err(miette!(
+					"cannot read the Seedling daemon's published identity at {}: {err}",
+					fingerprint_path.display()
+				));
+			}
+		};
+
+		let (identity, as_host) = Self::identity(&host).await?;
+
+		// bestool links both aws-lc-rs and ring, so rustls cannot pick a
+		// provider by itself and panics on first use. Installing is idempotent
+		// and only the first caller wins, which is why the result is dropped.
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+		let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), OI_PORT);
+		let client = OiClient::connect(
+			addr,
+			ClientAuth::Fingerprint(fingerprint),
+			&identity,
+			actor(as_host.then(invoking_operator).flatten()),
+		)
+		.await
+		.map_err(|err| refusal(err, &host, as_host))?;
+
+		Ok(Self { client })
+	}
+
+	/// The key this command presents to the daemon.
+	///
+	/// An operator who has an identity of their own presents it, so the
+	/// daemon's record of who acted names them rather than the host, and their
+	/// authority is exactly the authority the daemon already grants them.
+	/// The host identity is the fallback that needs no operator setup at all.
+	async fn identity(host: &HostIdentity) -> Result<(ClientIdentity, bool)> {
+		let operator = ClientIdentity::default_path();
+		if operator.exists() {
+			return load(&operator).map(|identity| (identity, false));
+		}
+
+		match host {
+			HostIdentity::Readable(path) => load(path).map(|identity| (identity, true)),
+			HostIdentity::NeedsElevation(path) => Err(elevate(&format!(
+				"this host's Seedling identity at {} is not readable unprivileged",
+				path.display()
+			))
+			.await),
+			HostIdentity::Absent => bail!(
+				"no Seedling identity to present: you have none at {}, and this host has none at {}; \
+				 generate yours with `seedling-ctl client fingerprint` and authorise it with `seedling-ctl user add`",
+				operator.display(),
+				host_key_path().display(),
+			),
+		}
+	}
+
+	async fn request(&self, method: &str, params: Value) -> Result<Value> {
+		debug!(method, %params, "operator interface request");
+		self.client
+			.request(method, params)
+			.await
+			.map_err(|err| miette!("the Seedling daemon rejected {method}: {err}"))
+	}
+
+	/// The underlying client, for callers that need a stream rather than a
+	/// request and response.
+	pub fn client(&self) -> &OiClient {
+		&self.client
+	}
+
+	/// Every app the daemon manages.
+	pub async fn apps(&self) -> Result<Vec<App>> {
+		serde_json::from_value(self.request("/apps/list", json!({})).await?).into_diagnostic()
+	}
+
+	/// Everything the daemon knows about one app, including its resources.
+	pub async fn show(&self, app: &str) -> Result<Show> {
+		serde_json::from_value(self.request("/apps/show", json!({ "app": app })).await?)
+			.into_diagnostic()
+	}
+
+	/// Bring every stopped resource of an app back to its desired state.
+	pub async fn unstop(&self, app: &str) -> Result<()> {
+		self.request("/apps/unstop", json!({ "app": app }))
+			.await
+			.map(drop)
+	}
+
+	/// Stop one resource, leaving it where [`Oi::unstop`] can bring it back.
+	///
+	/// A stop is built from these rather than from uninstalling the app: an
+	/// uninstalled app is recovered by installing it again, and an install takes
+	/// the parameters the app was installed with, which a stop has no business
+	/// knowing or re-supplying.
+	pub async fn stop_resource(&self, app: &str, kind: &str, name: &str) -> Result<()> {
+		self.request(
+			"/apps/resource/stop",
+			json!({ "app": app, "kind": kind, "name": name }),
+		)
+		.await
+		.map(drop)
+	}
+
+	/// Bring one stopped resource back to its desired state.
+	pub async fn unstop_resource(&self, app: &str, kind: &str, name: &str) -> Result<()> {
+		self.request(
+			"/apps/resource/unstop",
+			json!({ "app": app, "kind": kind, "name": name }),
+		)
+		.await
+		.map(drop)
+	}
+
+	/// Roll one deployment, following the update strategy it declares.
+	pub async fn restart(&self, app: &str, deployment: &str) -> Result<()> {
+		self.request(
+			"/apps/restart",
+			json!({ "app": app, "deployment": deployment }),
+		)
+		.await
+		.map(drop)
+	}
+
+	/// Subscribe to a log stream.
+	///
+	/// The request and its response ride one bidirectional stream; the entries
+	/// then arrive on a unidirectional stream the daemon opens in reply.
+	pub async fn log_stream(&self, params: Value) -> Result<LogStream> {
+		let (mut send, mut recv) = self
+			.client
+			.open_bi()
+			.await
+			.map_err(|err| miette!("cannot open a stream to the Seedling daemon: {err}"))?;
+
+		let request = serde_json::to_vec(&json!({ "method": "/logs/stream", "params": params }))
+			.into_diagnostic()?;
+		send.write_all(&request)
+			.await
+			.map_err(|err| miette!("cannot send the log request: {err}"))?;
+		let _ = send.finish();
+
+		let response = recv
+			.read_to_end(64 * 1024)
+			.await
+			.map_err(|err| miette!("cannot read the log response: {err}"))?;
+		if let Ok(value) = serde_json::from_slice::<Value>(&response)
+			&& let Some(error) = value.get("error")
+		{
+			let code = error
+				.get("code")
+				.and_then(Value::as_str)
+				.unwrap_or("unknown");
+			let message = error
+				.get("message")
+				.and_then(Value::as_str)
+				.unwrap_or("unknown error");
+			bail!("the Seedling daemon refused the log request: [{code}] {message}");
+		}
+
+		let stream = self
+			.client
+			.accept_uni()
+			.await
+			.map_err(|err| miette!("the Seedling daemon opened no log stream: {err}"))?;
+		Ok(LogStream {
+			stream,
+			buffer: Vec::new(),
+		})
+	}
+
+	/// Every volume an app exports for other things to use.
+	pub async fn exported_volumes(&self) -> Result<Vec<ExportedVolume>> {
+		serde_json::from_value(self.request("/volumes/exported/list", json!({})).await?)
+			.into_diagnostic()
+	}
+}
+
+/// Load an identity from a key file that is already known to exist.
+fn load(path: &Path) -> Result<ClientIdentity> {
+	ClientIdentity::load_or_generate(path)
+		.map(|(identity, _)| identity)
+		.map_err(|err| {
+			miette!(
+				"cannot load the Seedling identity at {}: {err}",
+				path.display()
+			)
+		})
+}
+
+/// Explain a connection the daemon would not accept.
+///
+/// A refusal of the operator's own key on a host that carries an identity for
+/// us is the one case with an obvious remedy the operator can't be expected to
+/// guess: the daemon would accept the host identity, and reaching it only takes
+/// running the same command elevated.
+fn refusal(err: impl std::fmt::Display, host: &HostIdentity, as_host: bool) -> miette::Report {
+	let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), OI_PORT);
+	if !as_host && host.needs_elevation() {
+		miette!(
+			"cannot reach the Seedling daemon at {addr} as you: {err}\n\
+			 this host has an identity for bestool at {}, which a privileged run would use",
+			host_key_path().display()
+		)
+	} else {
+		miette!("cannot reach the Seedling daemon at {addr}: {err}")
+	}
+}
+
+/// How this command identifies itself in the daemon's event feed, so an operator
+/// reading it can tell which tool acted.
+///
+/// Acting under the host identity, the key itself says nothing about who ran
+/// the command, so the invoking operator is named here instead: the feed should
+/// read as the person who acted rather than as the host.
+fn actor(operator: Option<String>) -> Actor {
+	Actor {
+		kind: Some("bestool".into()),
+		id: operator,
+		display: Some(concat!("bestool ", env!("CARGO_PKG_VERSION")).into()),
+		session: None,
+	}
+}
+
+/// Who ran this command, as the shell that elevated it recorded them.
+fn invoking_operator() -> Option<String> {
+	["SUDO_USER", "USER", "USERNAME"]
+		.into_iter()
+		.find_map(|var| std::env::var(var).ok().filter(|user| !user.is_empty()))
+}
+
+/// One entry of the daemon's app list.
+#[derive(Debug, Clone, Deserialize)]
+pub struct App {
+	pub name: String,
+	pub status: String,
+	/// Active, uncleared faults filed against the app.
+	#[serde(default)]
+	pub fault_count: u64,
+	/// Whether any of the app's resources are stopped, which is what a start has
+	/// to undo.
+	#[serde(default)]
+	pub has_stopped_resources: bool,
+	#[serde(default)]
+	pub description: Option<String>,
+}
+
+impl App {
+	/// Whether the app is in a steady state with everything at its desired
+	/// lifecycle state.
+	///
+	/// An app's status arrives lower-cased and underscored (`not_installed`)
+	/// while a resource instance's lifecycle arrives capitalised (`Running`), so
+	/// this compares without regard to case rather than picking one of the two
+	/// spellings and being wrong about the other.
+	pub fn running(&self) -> bool {
+		self.status.eq_ignore_ascii_case("running")
+	}
+}
+
+/// What the daemon knows about one app.
+///
+/// Only the fields the commands report on are modelled; a resource's full
+/// definition is left alone.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Show {
+	pub status: String,
+	/// Faults not tied to any one resource, such as script evaluation errors.
+	#[serde(default)]
+	pub faults: Vec<Value>,
+	#[serde(default)]
+	pub resources: Vec<Resource>,
+	#[serde(default)]
+	pub params: Vec<Param>,
+}
+
+/// One of an app's parameters.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Param {
+	pub name: String,
+	/// The stored value, absent when the parameter is unset or secret.
+	#[serde(default)]
+	pub value: Option<String>,
+	#[serde(default)]
+	pub default_value: Option<String>,
+}
+
+/// One resource of an app: a deployment, job, ingress, service, or volume.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Resource {
+	pub name: String,
+	#[serde(rename = "type")]
+	pub kind: String,
+	#[serde(default)]
+	pub instances: Vec<Instance>,
+	#[serde(default)]
+	pub faults: Vec<Value>,
+}
+
+/// A volume one app exports for other things to use, and where it lives on the
+/// host so a co-located tool can address its contents.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExportedVolume {
+	pub app: String,
+	pub volume_name: String,
+	pub host_path: PathBuf,
+	#[serde(default)]
+	pub description: Option<String>,
+}
+
+/// One instance of a resource.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Instance {
+	pub display_name: String,
+	pub lifecycle: String,
+}
+
+/// A subscription to the daemon's log stream, yielding one entry at a time.
+pub struct LogStream {
+	stream: quinn::RecvStream,
+	buffer: Vec<u8>,
+}
+
+impl LogStream {
+	/// The next entry, or `None` once the daemon closes the stream.
+	///
+	/// Entries are newline-delimited, so a read can land mid-entry and the
+	/// remainder is held until the rest arrives.
+	pub async fn next(&mut self) -> Result<Option<LogEntry>> {
+		let mut chunk = [0u8; 4096];
+		loop {
+			if let Some(end) = self.buffer.iter().position(|&b| b == b'\n') {
+				let line: Vec<u8> = self.buffer.drain(..=end).collect();
+				let line = &line[..line.len() - 1];
+				if line.is_empty() {
+					continue;
+				}
+				return serde_json::from_slice(line)
+					.map(Some)
+					.into_diagnostic()
+					.map_err(|err| err.wrap_err("cannot read a log entry"));
+			}
+
+			match self
+				.stream
+				.read(&mut chunk)
+				.await
+				.map_err(|err| miette!("cannot read the log stream: {err}"))?
+			{
+				Some(read) => self.buffer.extend_from_slice(&chunk[..read]),
+				None => return Ok(None),
+			}
+		}
+	}
+}
+
+/// One entry of a log stream.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LogEntry {
+	pub timestamp: String,
+	pub message: String,
+	pub unit: String,
+}
+
+impl LogEntry {
+	/// The emitting unit as the daemon names the thing itself, rather than as
+	/// the service wrapping it.
+	pub fn source(&self) -> &str {
+		self.unit
+			.strip_prefix("seedling-")
+			.unwrap_or(&self.unit)
+			.strip_suffix(".service")
+			.unwrap_or_else(|| self.unit.strip_prefix("seedling-").unwrap_or(&self.unit))
+	}
+}
+
+/// The resource type that carries a scale and an update strategy, and so is the
+/// unit a restart rolls.
+const DEPLOYMENT: &str = "deployment";
+
+/// Resource kinds the daemon can stop and bring back. Services and volumes carry
+/// no lifecycle of their own to stop.
+const STOPPABLE: [&str; 3] = [DEPLOYMENT, "job", "ingress"];
+
+impl Show {
+	/// The app's deployments, which are what a restart rolls: jobs, ingresses,
+	/// services, and volumes have no update strategy to follow.
+	pub fn deployments(&self) -> impl Iterator<Item = &Resource> {
+		self.resources.iter().filter(|r| r.kind == DEPLOYMENT)
+	}
+
+	/// A parameter's effective value: what is stored, or the default it falls
+	/// back to. A secret reads as absent, since the daemon does not return one.
+	pub fn param(&self, name: &str) -> Option<&str> {
+		let param = self.params.iter().find(|p| p.name == name)?;
+		param.value.as_deref().or(param.default_value.as_deref())
+	}
+
+	/// The resources a stop acts on, which are those the daemon can later bring
+	/// back where it left them.
+	pub fn stoppable(&self) -> impl Iterator<Item = &Resource> {
+		self.resources
+			.iter()
+			.filter(|r| STOPPABLE.contains(&r.kind.as_str()))
+	}
+}
+
+/// Pick the app a command acts on.
+///
+/// A named app must exist. Without a name, exactly one Tamanu app must be
+/// present: none leaves nothing to act on, and several are ambiguous enough that
+/// guessing could act on the wrong deployment.
+///
+/// spec: SEED#targeting-an-application
+pub fn target<'a>(apps: &'a [App], named: Option<&str>) -> Result<&'a App> {
+	if let Some(name) = named {
+		return apps.iter().find(|app| app.name == name).ok_or_else(|| {
+			miette!(
+				"the Seedling daemon manages no app named {name}{}",
+				listing(apps)
+			)
+		});
+	}
+
+	let mut tamanu = apps.iter().filter(|app| app.name.contains("tamanu"));
+	match (tamanu.next(), tamanu.next()) {
+		(Some(only), None) => Ok(only),
+		(None, _) => bail!("the Seedling daemon manages no Tamanu app{}", listing(apps)),
+		(Some(one), Some(two)) => bail!(
+			"the Seedling daemon manages more than one Tamanu app ({}, {}); name the one to act on",
+			one.name,
+			two.name
+		),
+	}
+}
+
+fn listing(apps: &[App]) -> String {
+	if apps.is_empty() {
+		return ", and manages no apps at all".into();
+	}
+	format!(
+		"; it manages: {}",
+		apps.iter()
+			.map(|a| a.name.as_str())
+			.collect::<Vec<_>>()
+			.join(", ")
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn app(name: &str) -> App {
+		App {
+			name: name.into(),
+			status: "running".into(),
+			fault_count: 0,
+			has_stopped_resources: false,
+			description: None,
+		}
+	}
+
+	#[test]
+	fn picks_the_only_tamanu_app() {
+		let apps = [app("tamanu"), app("caddy")];
+		assert_eq!(target(&apps, None).unwrap().name, "tamanu");
+	}
+
+	#[test]
+	fn picks_a_prefixed_tamanu_app() {
+		let apps = [app("tamanu-central"), app("grafana")];
+		assert_eq!(target(&apps, None).unwrap().name, "tamanu-central");
+	}
+
+	#[test]
+	fn no_tamanu_app_lists_what_is_there() {
+		let apps = [app("caddy"), app("grafana")];
+		let err = format!("{}", target(&apps, None).unwrap_err());
+		assert!(err.contains("no Tamanu app"), "{err}");
+		assert!(err.contains("caddy"), "{err}");
+	}
+
+	#[test]
+	fn no_apps_at_all_says_so() {
+		let err = format!("{}", target(&[], None).unwrap_err());
+		assert!(err.contains("no apps at all"), "{err}");
+	}
+
+	#[test]
+	fn several_tamanu_apps_require_a_name() {
+		let apps = [app("tamanu-central"), app("tamanu-facility")];
+		let err = format!("{}", target(&apps, None).unwrap_err());
+		assert!(err.contains("more than one"), "{err}");
+		assert!(err.contains("name the one"), "{err}");
+	}
+
+	#[test]
+	fn several_tamanu_apps_resolve_once_named() {
+		let apps = [app("tamanu-central"), app("tamanu-facility")];
+		assert_eq!(
+			target(&apps, Some("tamanu-facility")).unwrap().name,
+			"tamanu-facility"
+		);
+	}
+
+	#[test]
+	fn a_named_app_need_not_look_like_tamanu() {
+		let apps = [app("tamanu"), app("caddy")];
+		assert_eq!(target(&apps, Some("caddy")).unwrap().name, "caddy");
+	}
+
+	#[test]
+	fn an_absent_name_is_an_error() {
+		let apps = [app("tamanu")];
+		let err = format!("{}", target(&apps, Some("nope")).unwrap_err());
+		assert!(err.contains("no app named nope"), "{err}");
+		assert!(err.contains("tamanu"), "{err}");
+	}
+
+	#[test]
+	fn show_parses_the_daemon_shape_and_picks_deployments() {
+		let show: Show = serde_json::from_value(serde_json::json!({
+			"status": "degraded",
+			"faults": [],
+			"resources": [
+				{
+					"name": "api",
+					"type": "deployment",
+					"scale": 2,
+					"instances": [
+						{ "id": "1", "display_name": "api-1", "lifecycle": "Running" },
+						{ "id": "2", "display_name": "api-2", "lifecycle": "Terminating" },
+					],
+					"faults": [],
+					"def": { "container": { "image": "tamanu:latest" } },
+				},
+				{ "name": "migrate", "type": "job", "instances": [], "faults": [] },
+				{ "name": "web", "type": "ingress", "instances": [], "faults": [] },
+			],
+			"params": [{ "name": "db-name", "value": "tamanu", "is_set": true, "secret": false }],
+		}))
+		.unwrap();
+
+		assert_eq!(show.status, "degraded");
+		let deployments: Vec<&str> = show.deployments().map(|r| r.name.as_str()).collect();
+		assert_eq!(deployments, vec!["api"], "jobs and ingresses aren't rolled");
+		assert_eq!(show.param("db-name"), Some("tamanu"));
+
+		let api = show.deployments().next().unwrap();
+		assert_eq!(api.instances.len(), 2);
+		assert_eq!(api.instances[0].display_name, "api-1");
+		assert_eq!(api.instances[1].lifecycle, "Terminating");
+	}
+
+	#[test]
+	fn param_falls_back_to_its_default() {
+		let show: Show = serde_json::from_value(serde_json::json!({
+			"status": "running",
+			"params": [
+				{ "name": "db-user", "value": null, "default_value": "tamanu" },
+				{ "name": "auth-secret", "value": null, "default_value": null },
+			],
+		}))
+		.unwrap();
+		assert_eq!(show.param("db-user"), Some("tamanu"));
+		assert_eq!(show.param("auth-secret"), None, "a secret reads as absent");
+		assert_eq!(show.param("absent"), None);
+	}
+
+	#[test]
+	fn stoppable_covers_the_kinds_with_a_lifecycle() {
+		let show: Show = serde_json::from_value(serde_json::json!({
+			"status": "running",
+			"resources": [
+				{ "name": "api", "type": "deployment" },
+				{ "name": "migrate", "type": "job" },
+				{ "name": "web", "type": "ingress" },
+				{ "name": "api-svc", "type": "service" },
+				{ "name": "data", "type": "volume" },
+			],
+		}))
+		.unwrap();
+
+		let stoppable: Vec<&str> = show.stoppable().map(|r| r.name.as_str()).collect();
+		assert_eq!(
+			stoppable,
+			vec!["api", "migrate", "web"],
+			"services and volumes have no lifecycle to stop"
+		);
+	}
+
+	#[test]
+	fn show_tolerates_an_app_with_no_resources() {
+		let show: Show =
+			serde_json::from_value(serde_json::json!({ "status": "not_installed" })).unwrap();
+		assert!(show.resources.is_empty());
+		assert_eq!(show.deployments().count(), 0);
+	}
+
+	#[test]
+	fn app_list_parses_the_daemon_shape() {
+		// Statuses as the daemon sends them: lower-cased and underscored, unlike
+		// the capitalised lifecycle on a resource instance.
+		let apps: Vec<App> = serde_json::from_value(serde_json::json!([
+			{ "name": "postgres", "status": "installing", "has_stopped_resources": false,
+			  "fault_count": 2, "description": "PostgreSQL database server" },
+			{ "name": "tamanu-facility", "status": "not_installed",
+			  "has_stopped_resources": true, "fault_count": 0, "description": "Tamanu facility" },
+			{ "name": "tamanu-central", "status": "running", "fault_count": 0 },
+		]))
+		.unwrap();
+		assert_eq!(apps.len(), 3);
+		assert!(!apps[0].running());
+		assert!(!apps[1].running());
+		assert!(apps[2].running());
+		assert_eq!(apps[0].fault_count, 2);
+		assert!(apps[1].has_stopped_resources);
+		assert_eq!(
+			apps[0].description.as_deref(),
+			Some("PostgreSQL database server")
+		);
+		assert!(
+			!apps[2].has_stopped_resources,
+			"an absent field defaults rather than failing the parse"
+		);
+	}
+
+	#[test]
+	fn running_ignores_the_casing_difference() {
+		let mut app = app("tamanu");
+		app.status = "running".into();
+		assert!(app.running(), "the daemon lower-cases an app's status");
+		app.status = "Running".into();
+		assert!(app.running(), "an instance lifecycle is capitalised");
+		app.status = "degraded".into();
+		assert!(!app.running());
+	}
+
+	#[test]
+	fn log_entry_names_the_thing_not_its_unit() {
+		let entry = |unit: &str| LogEntry {
+			timestamp: "t".into(),
+			message: "m".into(),
+			unit: unit.into(),
+		};
+		assert_eq!(
+			entry("seedling-postgres-postgres-7c47d6e8.service").source(),
+			"postgres-postgres-7c47d6e8"
+		);
+		assert_eq!(entry("seedling-caddy-blue.service").source(), "caddy-blue");
+		assert_eq!(
+			entry("postgres").source(),
+			"postgres",
+			"left alone when it carries neither"
+		);
+	}
+
+	#[test]
+	fn log_entry_parses_the_stream_shape() {
+		let entry: LogEntry = serde_json::from_value(serde_json::json!({
+			"timestamp": "2026-07-28T09:35:10.123456Z",
+			"message": "database system is ready to accept connections",
+			"unit": "postgres-postgres-7c47d6e8",
+			"stream": "stdout",
+			"app": "postgres",
+			"resource_kind": "deployment",
+		}))
+		.unwrap();
+		assert_eq!(entry.unit, "postgres-postgres-7c47d6e8");
+		assert!(entry.message.contains("ready to accept"));
+	}
+}


### PR DESCRIPTION
The bestool half of [beyondessential/seedling#126](https://github.com/beyondessential/seedling/pull/126), which makes the `seedling` package generate `/etc/bestool/seedling.key` and authorise it with the daemon under the label `bestool`.

Before this, `bestool tamanu <cmd>` on a Seedling host presented only the invoking operator's key, and bailed telling them to authorise a fresh one — so a freshly provisioned host worked for nobody until someone had done that per operator. Worse, the daemon's data directory is `0750 root:root`, so an unprivileged invocation could not even read `oi.fingerprint` to know which daemon to trust; the Seedling path resolves the host *before* `ensure_root_or_reexec`, so it never elevated on the way past.

## What it does

- **Identity precedence.** The operator's own key still comes first where they have one, so the daemon's record of who acted names them and their authority is exactly what the daemon already grants them. The host identity is the fallback when they have none.
- **Elevation.** When the host identity, or the daemon's published identity, is unreadable because we aren't privileged, the command re-runs itself under `sudo` and exits with its status — the same shape as `lifecycle::ensure_root_or_reexec`, which the host-service-manager path already uses before touching rootful podman. Because it hangs off `Oi::open`, every command that goes through `reach()` gets it: `start`, `stop`, `restart`, `status`, `logs`, `psql`.
- **Attribution.** Acting under the host identity, the key says nothing about who ran the command, so the invoking operator (`SUDO_USER`, else `USER`) is named to the daemon as the actor id. The event feed still reads as a person rather than as the host.
- **Better refusal.** If the operator's own key is refused on a host that carries an identity, the error says a privileged run would be accepted, instead of leaving them to work that out.
- **`GET /seedling` on the alertd API.** Reports `{"host_identity": bool}` — presence only, never the key — so a co-located tool can tell that elevating will get it a working identity rather than discovering that after elevating.
- **Module split.** `seedling.rs` keeps what needs no protocol client (paths, host-identity classification, elevation); `seedling/oi.rs` holds the interface client behind the `seedling` feature. This is what lets alertd answer the question without pulling `seedling-protocol` and `quinn` into `alertd`-only builds.

Readability is settled by opening the file, not by reading its mode — ownership, mode bits, ACLs, and the process's capabilities all bear on the answer and only the kernel knows all of them. Same reasoning as `canopy::registration_dir_writable`. A refusal while already privileged classifies as absent rather than elevatable, so a command can't loop through `sudo`.

## Spec

`SEED` said a command "needs no identity of its own and nothing has to be authorised for it". That is no longer true for the fallback, so the spec is updated first: identity precedence, the root-only confinement of the host identity and what it does and doesn't grant, elevation instead of failure, naming the operator when acting as the host, and the `/seedling` endpoint shape.

## Testing

`classify` is tested over every case — readable, missing, refused-while-unprivileged, refused-while-privileged, other errors — plus a real temp file through the same path. The endpoint's report is tested per `HostIdentity` variant, with one end-to-end assertion of the response shape; no env-var mutation, so nothing races between tests.

`cargo test -p bestool-tamanu --features seedling` passes (151 tests), the new alertd tests pass, `cargo check --workspace --all-targets` is clean, and `cargo clippy` on both crates reports only the pre-existing `large_enum_variant` in `doctor/checks/http_errors.rs`. `cargo fmt` applied. Note the sandbox needed rustc 1.97 to build this workspace at all (`sysinfo 0.39.6` requires 1.95).

**Still unverified on a real host:** the `sudo` re-exec path, and a live connection to a daemon under both identities. Everything above is unit-level plus CI; a run on a Seedling VM is the outstanding check before merge.