### PR TITLE
feat(alertd): publish http traffic as cumulative counters

### DIFF
--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -44,9 +44,12 @@ A check declares typed metrics. Each metric carries:
 A metric's unit lives in its name by convention — `_seconds`, `_bytes`, `_ms` — and a metric that measures a duration or a size always names its unit, so no metric reads as a bare unitless number when it is really a quantity.
 In munin a graph labels its axis with the unit read from its metrics' names, and a byte graph scales in powers of 1024, so an operator reads seconds, bytes, or a percentage off the axis directly.
 
-A check that measures a flow of events publishes the underlying cumulative total as a counter, named `_total`, rather than a count over whatever window the check itself uses to reach its verdict.
+A check that measures a flow of events publishes a cumulative total as a counter, named `_total`, rather than a count over whatever window the check itself uses to reach its verdict.
 A scrape then derives the rate over its own interval, and a reader interprets the number without needing to know the check's window.
-A check whose window is worth reporting reports it to Canopy as a fact, not as a metric.
+
+Where the source already keeps a cumulative total, the check publishes that, and reports its own window to Canopy as a fact rather than as a metric.
+Where the source can only be sampled a window at a time, the daemon accumulates the sampled windows into a running total, which starts again from zero when the daemon restarts.
+Where neither is available cheaply, the metric keeps its window and names it in its description, so the span a number covers stays on the metrics surface.
 
 Metrics are named under their check by default, but a check whose name would misrepresent its telemetry may declare a namespace that replaces the check name in the metric's name.
 The error-rate `http_errors` check publishes its request telemetry — which counts successful responses too — under `http`, so a reader isn't misled into thinking a request count is an error count.

--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -35,7 +35,7 @@ A check declares typed metrics. Each metric carries:
 
 - a name in `snake_case` that is a valid prometheus name and munin field;
 - a value;
-- a kind — a gauge that rises and falls, or a counter that only increases;
+- a kind — a gauge that rises and falls, or a counter that only increases until whatever produces it restarts;
 - optional labels: dimensions with a fixed key and a per-series value, such as a mount point, an HTTP status code, or a percentile;
 - a human description;
 - an optional group (see below);
@@ -62,6 +62,9 @@ Metrics of different units are never placed in the same graph, so no graph mixes
 The label-dimensioned series of a single metric — one per mount, per status code, per percentile — are the fields of that metric's graph.
 
 Munin plots a counter as a rate, so a graph whose metrics are all counters labels its axis per graph period, and an operator reads events per second off the axis rather than a cumulative total that would climb off the top of the graph.
+
+A counter reaches munin as a derived field floored at zero rather than as a munin counter, because munin's counter type reads any decrease as a hardware counter wrapping and corrects for it: the reset that follows a restart of whatever produces the metric would graph as an astronomical spike, and the graph's automatic scale would stay wrecked for as long as it is retained.
+Floored derivation instead reads a reset as the gap in knowledge it is.
 
 ## Sync session durations
 

--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -44,6 +44,10 @@ A check declares typed metrics. Each metric carries:
 A metric's unit lives in its name by convention — `_seconds`, `_bytes`, `_ms` — and a metric that measures a duration or a size always names its unit, so no metric reads as a bare unitless number when it is really a quantity.
 In munin a graph labels its axis with the unit read from its metrics' names, and a byte graph scales in powers of 1024, so an operator reads seconds, bytes, or a percentage off the axis directly.
 
+A check that measures a flow of events publishes the underlying cumulative total as a counter, named `_total`, rather than a count over whatever window the check itself uses to reach its verdict.
+A scrape then derives the rate over its own interval, and a reader interprets the number without needing to know the check's window.
+A check whose window is worth reporting reports it to Canopy as a fact, not as a metric.
+
 Metrics are named under their check by default, but a check whose name would misrepresent its telemetry may declare a namespace that replaces the check name in the metric's name.
 The error-rate `http_errors` check publishes its request telemetry — which counts successful responses too — under `http`, so a reader isn't misled into thinking a request count is an error count.
 
@@ -56,6 +60,8 @@ There is one graph per group; a metric with no explicit group forms its own grap
 Metrics that share a unit and a comparable scale and are read together — a warn tier beside its fail tier, used beside total — declare a shared group and share a graph.
 Metrics of different units are never placed in the same graph, so no graph mixes scales on one axis; and a total that dwarfs the components it sums stays on its own graph, so the components' variation isn't flattened against it.
 The label-dimensioned series of a single metric — one per mount, per status code, per percentile — are the fields of that metric's graph.
+
+Munin plots a counter as a rate, so a graph whose metrics are all counters labels its axis per graph period, and an operator reads events per second off the axis rather than a cumulative total that would climb off the top of the graph.
 
 ## Sync session durations
 

--- a/crates/alertd/src/doctor/checks/http_errors.rs
+++ b/crates/alertd/src/doctor/checks/http_errors.rs
@@ -195,24 +195,15 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 	};
 
 	if total == 0 {
-		return Check::pass(
-			"http_errors",
-			format!("no requests in last {window_label} ({source_label})"),
-		)
-		.with_detail("total_requests", 0u64)
-		.with_detail("window_seconds", window.as_secs())
-		.with_detail("baseline_source", source_label)
-		.with_stat(
-			Stat::gauge("requests", 0.0)
-				.namespace("http")
-				.group("traffic")
-				.help("Requests in the window"),
-		)
-		.with_stat(
-			Stat::gauge("server_errors", 0.0)
-				.namespace("http")
-				.group("traffic")
-				.help("5xx responses in the window"),
+		return with_traffic_stats(
+			Check::pass(
+				"http_errors",
+				format!("no requests in last {window_label} ({source_label})"),
+			)
+			.with_detail("total_requests", 0u64)
+			.with_detail("window_seconds", window.as_secs())
+			.with_detail("baseline_source", source_label),
+			&current.counts,
 		);
 	}
 
@@ -242,35 +233,56 @@ fn build_check(baseline: &Snapshot, current: &Snapshot, source: BaselineSource) 
 		by_code.insert(code.clone(), Value::from(*n));
 	}
 
+	with_traffic_stats(
+		check
+			.with_detail("total_requests", total)
+			.with_detail("server_error_requests", errored)
+			.with_detail("server_error_rate_pct", pct)
+			.with_detail("window_seconds", window.as_secs())
+			.with_detail("baseline_source", source_label)
+			.with_detail("by_code", Value::Object(by_code)),
+		&current.counts,
+	)
+	.with_stat(
+		Stat::gauge("server_error_rate_pct", pct)
+			.namespace("http")
+			.help("5xx rate, percent"),
+	)
+}
+
+/// Attach Caddy's cumulative request counters to a check.
+///
+/// The verdict above comes from a delta over a window whose length varies with
+/// what history is on disk, but a metric that carried that window would be
+/// uninterpretable without it. So the published metrics are the raw cumulative
+/// totals and a scrape derives its own rate over its own interval; the window
+/// stays a fact reported to canopy.
+fn with_traffic_stats(check: Check, counts: &BTreeMap<String, u64>) -> Check {
+	let total: u64 = counts.values().sum();
+	let errored: u64 = counts
+		.iter()
+		.filter(|(code, _)| code.starts_with('5'))
+		.map(|(_, n)| n)
+		.sum();
+
 	check
-		.with_detail("total_requests", total)
-		.with_detail("server_error_requests", errored)
-		.with_detail("server_error_rate_pct", pct)
-		.with_detail("window_seconds", window.as_secs())
-		.with_detail("baseline_source", source_label)
-		.with_detail("by_code", Value::Object(by_code))
 		.with_stat(
-			Stat::gauge("requests", total as f64)
+			Stat::counter("requests_total", total as f64)
 				.namespace("http")
 				.group("traffic")
-				.help("Requests in the window"),
+				.help("Requests served"),
 		)
 		.with_stat(
-			Stat::gauge("server_errors", errored as f64)
+			Stat::counter("server_errors_total", errored as f64)
 				.namespace("http")
 				.group("traffic")
-				.help("5xx responses in the window"),
+				.help("5xx responses"),
 		)
-		.with_stat(
-			Stat::gauge("server_error_rate_pct", pct)
-				.namespace("http")
-				.help("5xx rate, percent"),
-		)
-		.with_stats(deltas.iter().map(|(code, n)| {
-			Stat::gauge("requests_by_code", *n as f64)
+		.with_stats(counts.iter().map(|(code, n)| {
+			Stat::counter("requests_by_code_total", *n as f64)
 				.namespace("http")
 				.label("code", code.clone())
-				.help("Requests in the window by HTTP status code")
+				.help("Requests served by HTTP status code")
 		}))
 }
 
@@ -452,27 +464,53 @@ other_metric{foo=\"bar\"} 7
 	}
 
 	#[test]
-	fn build_check_emits_stats() {
+	fn build_check_emits_cumulative_counters() {
+		use crate::doctor::StatKind;
+
 		let baseline = snap(0, &[("200", 100), ("500", 0), ("502", 0)]);
 		let current = snap(60, &[("200", 190), ("500", 5), ("502", 5)]);
 		let check = build_check(&baseline, &current, BaselineSource::History);
 
-		let scalar = |name: &str| check.stats.iter().find(|s| s.name == name).map(|s| s.value);
-		// delta: 90 + 5 + 5 requests, 10 server errors
-		assert_eq!(scalar("requests"), Some(100.0));
-		assert_eq!(scalar("server_errors"), Some(10.0));
+		let stat = |name: &str| check.stats.iter().find(|s| s.name == name).expect(name);
+		// The window delta is 90 + 5 + 5 requests; the metrics are Caddy's totals.
+		assert_eq!(stat("requests_total").value, 200.0);
+		assert_eq!(stat("server_errors_total").value, 10.0);
+		assert_eq!(stat("requests_total").kind, StatKind::Counter);
+		assert_eq!(stat("server_errors_total").kind, StatKind::Counter);
 
-		// dimensioned by-code stats carry the code label
+		// the verdict's own number stays a percentage over the window
+		assert_eq!(stat("server_error_rate_pct").value, 10.0);
+
+		// dimensioned by-code stats carry the code label, and are cumulative too
 		let by_code: Vec<_> = check
 			.stats
 			.iter()
-			.filter(|s| s.name == "requests_by_code")
+			.filter(|s| s.name == "requests_by_code_total")
 			.collect();
 		assert!(
 			by_code
 				.iter()
-				.any(|s| { s.labels == vec![("code", "502".to_string())] && s.value == 5.0 })
+				.any(|s| { s.labels == vec![("code", "200".to_string())] && s.value == 190.0 })
 		);
+		assert!(by_code.iter().all(|s| s.kind == StatKind::Counter));
+	}
+
+	#[test]
+	fn quiet_window_still_publishes_totals() {
+		// A window with no traffic doesn't reset Caddy's counters, so the totals
+		// keep reporting where they are rather than dropping to zero.
+		let counts: &[(&str, u64)] = &[("200", 4200), ("502", 7)];
+		let check = build_check(
+			&snap(0, counts),
+			&snap(600, counts),
+			BaselineSource::History,
+		);
+
+		let scalar = |name: &str| check.stats.iter().find(|s| s.name == name).map(|s| s.value);
+		assert_eq!(scalar("requests_total"), Some(4207.0));
+		assert_eq!(scalar("server_errors_total"), Some(7.0));
+		// with no requests in the window there is no error rate to report
+		assert_eq!(scalar("server_error_rate_pct"), None);
 	}
 
 	#[test]

--- a/crates/alertd/src/doctor/stat.rs
+++ b/crates/alertd/src/doctor/stat.rs
@@ -14,8 +14,8 @@ use jiff::Timestamp;
 pub enum StatKind {
 	/// A value that can rise and fall (prometheus gauge, munin `GAUGE`).
 	Gauge,
-	/// A monotonically increasing cumulative total (prometheus counter, munin
-	/// `COUNTER`).
+	/// A cumulative total that only increases until whatever produces it
+	/// restarts (prometheus counter, munin `DERIVE` floored at zero).
 	Counter,
 }
 
@@ -29,10 +29,26 @@ impl StatKind {
 	}
 
 	/// The munin field `.type` token.
+	///
+	/// A counter renders as `DERIVE`, not `COUNTER`: rrdtool's `COUNTER` reads a
+	/// value below its predecessor as hardware counter wrap and corrects for it
+	/// against 32- then 64-bit bounds, turning the reset that follows a Caddy or
+	/// worker restart into an astronomical rate spike that wrecks the graph's
+	/// autoscale for as long as the RRA keeps it. `DERIVE` takes the plain
+	/// difference, so paired with a zero floor (see [`Self::munin_min`]) a reset
+	/// reads as the gap it is.
 	pub fn munin(self) -> &'static str {
 		match self {
 			StatKind::Gauge => "GAUGE",
-			StatKind::Counter => "COUNTER",
+			StatKind::Counter => "DERIVE",
+		}
+	}
+
+	/// The munin field `.min`, where the kind needs one.
+	pub fn munin_min(self) -> Option<&'static str> {
+		match self {
+			StatKind::Gauge => None,
+			StatKind::Counter => Some("0"),
 		}
 	}
 }
@@ -238,6 +254,15 @@ mod tests {
 		assert_eq!(StatKind::Gauge.prometheus(), "gauge");
 		assert_eq!(StatKind::Counter.prometheus(), "counter");
 		assert_eq!(StatKind::Gauge.munin(), "GAUGE");
-		assert_eq!(StatKind::Counter.munin(), "COUNTER");
+		// DERIVE, not COUNTER: rrdtool reads a COUNTER's decrease as hardware
+		// wrap and fabricates an enormous rate for the interval.
+		assert_eq!(StatKind::Counter.munin(), "DERIVE");
+	}
+
+	#[test]
+	fn a_counter_is_floored_at_zero() {
+		// Without the floor a DERIVE would graph the negative jump a reset makes.
+		assert_eq!(StatKind::Counter.munin_min(), Some("0"));
+		assert_eq!(StatKind::Gauge.munin_min(), None);
 	}
 }

--- a/crates/alertd/src/http_server/metrics_render.rs
+++ b/crates/alertd/src/http_server/metrics_render.rs
@@ -8,7 +8,7 @@
 
 use std::fmt::Write as _;
 
-use crate::doctor::{MetricsSnapshot, Stat};
+use crate::doctor::{MetricsSnapshot, Stat, StatKind};
 
 /// Common prefix for every metric this daemon exposes.
 const PREFIX: &str = "bes_alertd";
@@ -79,6 +79,10 @@ fn prom_name(check: &str, stat: &Stat) -> String {
 /// Munin axis label and optional `graph_args`, derived from the unit a metric
 /// carries in its name (the spec keeps a metric's unit in its name). A group
 /// shares a unit, so this reads the first stat's name.
+///
+/// A group of counters falls through to a rate: munin plots a counter as its
+/// per-period derivative, so `${graph_period}` — which munin expands to
+/// `second` unless a graph says otherwise — is what the axis actually shows.
 fn munin_unit(stats: &[&Stat]) -> Option<(&'static str, Option<&'static str>)> {
 	let name = stats.first()?.name;
 	if name.ends_with("_bytes") {
@@ -89,6 +93,8 @@ fn munin_unit(stats: &[&Stat]) -> Option<(&'static str, Option<&'static str>)> {
 		Some(("milliseconds", None))
 	} else if name.ends_with("_pct") || name.ends_with("_percent") {
 		Some(("%", None))
+	} else if stats.iter().all(|s| s.kind == StatKind::Counter) {
+		Some(("per ${graph_period}", None))
 	} else {
 		None
 	}
@@ -421,21 +427,21 @@ mod tests {
 			stats: vec![
 				(
 					"http_errors",
-					Stat::gauge("requests", 5.0)
+					Stat::counter("requests_total", 5.0)
 						.namespace("http")
 						.group("traffic"),
 				),
 				(
 					"http_errors",
-					Stat::gauge("requests_by_code", 2.0)
+					Stat::counter("requests_by_code_total", 2.0)
 						.namespace("http")
 						.label("code", "200"),
 				),
 			],
 		};
 		let prom = render_prometheus(Some(&s), 0, 0);
-		assert!(prom.contains("bes_alertd_http_requests 5"));
-		assert!(prom.contains("bes_alertd_http_requests_by_code{code=\"200\"} 2"));
+		assert!(prom.contains("bes_alertd_http_requests_total 5"));
+		assert!(prom.contains("bes_alertd_http_requests_by_code_total{code=\"200\"} 2"));
 		assert!(!prom.contains("http_errors_requests"));
 
 		let cfg = render_munin(Some(&s), 0, 0, true);
@@ -468,6 +474,36 @@ mod tests {
 		assert!(cfg.contains("multigraph bes_alertd_sync_snapshot_tables_sizes"));
 		assert!(cfg.contains("graph_vlabel bytes"));
 		assert!(cfg.contains("graph_args --base 1024"));
+	}
+
+	#[test]
+	fn munin_labels_a_counter_graph_as_a_rate() {
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![
+				(
+					"http_errors",
+					Stat::counter("requests_total", 5.0)
+						.namespace("http")
+						.group("traffic"),
+				),
+				(
+					"http_errors",
+					Stat::counter("server_errors_total", 1.0)
+						.namespace("http")
+						.group("traffic"),
+				),
+				(
+					"http_errors",
+					Stat::gauge("server_error_rate_pct", 20.0).namespace("http"),
+				),
+			],
+		};
+		let cfg = render_munin(Some(&s), 0, 0, true);
+		assert!(cfg.contains("graph_vlabel per ${graph_period}"));
+		// a gauge group keeps the unit read from its name
+		assert!(cfg.contains("graph_vlabel %"));
 	}
 
 	#[test]

--- a/crates/alertd/src/http_server/metrics_render.rs
+++ b/crates/alertd/src/http_server/metrics_render.rs
@@ -310,6 +310,9 @@ pub fn render_munin(
 				let field = munin_field(stat);
 				let _ = writeln!(out, "{field}.label {}", munin_field_label(stat));
 				let _ = writeln!(out, "{field}.type {}", stat.kind.munin());
+				if let Some(min) = stat.kind.munin_min() {
+					let _ = writeln!(out, "{field}.min {min}");
+				}
 				if let Some(help) = &stat.help {
 					let _ = writeln!(out, "{field}.info {}", help.replace('\n', " "));
 				}
@@ -588,6 +591,18 @@ mod tests {
 			render_prometheus(Some(&s), 0, 0)
 				.contains("# TYPE bes_alertd_http_errors_requests_total counter")
 		);
-		assert!(render_munin(Some(&s), 0, 0, true).contains("requests_total.type COUNTER"));
+		let cfg = render_munin(Some(&s), 0, 0, true);
+		assert!(cfg.contains("requests_total.type DERIVE"));
+		assert!(cfg.contains("requests_total.min 0"));
+	}
+
+	#[test]
+	fn a_gauge_declares_no_min() {
+		let s = MetricsSnapshot {
+			computed_at: jiff::Timestamp::from_second(0).unwrap(),
+			counts: StatusCounts::default(),
+			stats: vec![("load", Stat::gauge("one_min", 0.5))],
+		};
+		assert!(!render_munin(Some(&s), 0, 0, true).contains(".min"));
 	}
 }


### PR DESCRIPTION
🤖 The `http_errors` check published its request telemetry as gauges holding the delta over its own baseline window. That window's length varies — normally ~9–10 minutes with the 60s sweep, but a cold start, a wiped cache, or a Caddy restart drops it to a 10-second in-run sample — and nothing on the metrics surface carried it. `window_seconds` goes only into the canopy details, so a scrape couldn't tell what interval the number covered, and munin plotted an overlapping window count sampled every 5 minutes as if it were a level.

Publish Caddy's cumulative totals as counters instead, and let the scrape derive its own rate:

| metric | kind |
| --- | --- |
| `bes_alertd_http_requests_total` | counter |
| `bes_alertd_http_server_errors_total` | counter |
| `bes_alertd_http_requests_by_code_total{code}` | counter |
| `bes_alertd_http_server_error_rate_pct` | gauge |

The window still drives the verdict, the summary line, and the `window_seconds` / `baseline_source` / `by_code` facts posted to canopy. It just no longer shapes any published number.

Munin plots a counter as its per-period derivative, so `munin_unit` gains a final arm labelling an all-counter graph's axis `per ${graph_period}` — without it the traffic graph had no vlabel at all while RRD silently plotted a rate. The arm sits after the unit-suffix arms, so a name that carries its own unit keeps it.

The second commit fixes a bug in the first. `StatKind::Counter` mapped to munin `COUNTER`, and rrdtool's `COUNTER` reads any decrease as a hardware counter wrapping — it corrects against 32- then 64-bit bounds, so the counter reset after a Caddy restart would have landed as an astronomical rate spike and left the graph's autoscale wrecked for as long as the RRA retained it. Counters now render as `DERIVE` with `.min 0`: the plain difference, with the negative jump becoming an unknown, so a reset reads as the gap it is. Prometheus was never affected — `rate()` handles resets natively.

The quiet-window branch previously hardcoded zeroed gauges, which is right for a window delta and wrong for a cumulative counter: a counter dropping to zero reads as a counter reset. Both branches now share `with_traffic_stats`, so one place decides what the counters say.

Also worth knowing: `requests_total` and `server_errors_total` still share the `traffic` graph, so 5xx is flattened against total traffic on one axis — which MET's own grouping rule argues against. Pre-existing, left alone here.

Spec: `.workhorse/specs/tamanu/metrics.md` gains that a check measuring a flow of events publishes the underlying cumulative total as a `_total` counter rather than a count over its own verdict window, and that a munin graph of counters labels its axis per graph period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
