### PR TITLE
fix(alertd): count sync-session errors once per session

### DIFF
--- a/crates/alertd/src/doctor/checks/sync_session_errors.rs
+++ b/crates/alertd/src/doctor/checks/sync_session_errors.rs
@@ -3,6 +3,12 @@
 //!
 //! The window is a tight `updated_at > now() - interval '1 minute'`; the sweep
 //! runs every 60s, so this still catches each error once.
+//!
+//! Each query returns one row per session. The facility list rides along as the
+//! `facilityIds` array rather than being expanded into a row per facility: a
+//! set-returning function in the target list cross-joins, which would count a
+//! session spanning several facilities once per facility, and would drop a
+//! session whose `parameters` carry no `facilityIds` at all.
 
 use serde_json::Value;
 
@@ -16,7 +22,7 @@ const NAME: &str = "sync_session_errors";
 const FAIL_ERRORS: usize = 10;
 
 const MOBILE_SQL: &str = "SELECT id, errors::text, \
-	jsonb_array_elements_text(parameters->'facilityIds') AS facility_id, \
+	parameters->'facilityIds' AS facility_ids, \
 	created_at::text AS created, (completed_at - created_at)::text AS duration \
 	FROM sync_sessions \
 	WHERE updated_at > now() - interval '1 minute' \
@@ -27,7 +33,7 @@ const MOBILE_SQL: &str = "SELECT id, errors::text, \
 	ORDER BY created_at DESC";
 
 const SERVER_SQL: &str = "SELECT id, errors::text, \
-	jsonb_array_elements_text(parameters->'facilityIds') AS facility_id, \
+	parameters->'facilityIds' AS facility_ids, \
 	created_at::text AS created, (completed_at - created_at)::text AS duration \
 	FROM sync_sessions \
 	WHERE updated_at > now() - interval '1 minute' \
@@ -36,6 +42,24 @@ const SERVER_SQL: &str = "SELECT id, errors::text, \
 	AND errors <> ARRAY['could not serialize access due to concurrent update'] \
 	AND NOT (cardinality(errors) = 1 AND errors[1] LIKE '%snapshot-for-pushing%') \
 	ORDER BY created_at DESC";
+
+/// Errored sessions the verdict tiers on.
+///
+/// A truncated row set means there were more sessions than the report cap, well
+/// past [`FAIL_ERRORS`], so the total saturates there rather than reporting the
+/// cap as if it were the real figure.
+fn error_total(
+	mobile_n: usize,
+	mobile_truncated: bool,
+	server_n: usize,
+	server_truncated: bool,
+) -> usize {
+	if mobile_truncated || server_truncated {
+		FAIL_ERRORS
+	} else {
+		mobile_n + server_n
+	}
+}
 
 pub async fn run(ctx: CheckContext) -> Check {
 	if ctx.kind != ApiServerKind::Central {
@@ -71,12 +95,7 @@ pub async fn run(ctx: CheckContext) -> Check {
 	// Row vecs are capped at the report cap, so these saturate there on truncation.
 	let (mobile_n, server_n) = (mobile.rows.len(), server.rows.len());
 
-	// Truncation means well over FAIL_ERRORS rows, so saturate the total there.
-	let total = if mobile.truncated || server.truncated {
-		FAIL_ERRORS
-	} else {
-		mobile.rows.len() + server.rows.len()
-	};
+	let total = error_total(mobile_n, mobile_truncated, server_n, server_truncated);
 
 	let summary = format!("sync session errors: {mobile_count} mobile, {server_count} server");
 	let reason = "recent sync session error(s)";
@@ -102,7 +121,31 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 #[cfg(test)]
 mod tests {
+	use super::{FAIL_ERRORS, MOBILE_SQL, SERVER_SQL, error_total};
 	use crate::doctor::checks::test_support::{central_ctx, facility_ctx};
+
+	#[test]
+	fn queries_return_one_row_per_session() {
+		// Expanding facilityIds in the target list cross-joins, so a session
+		// would be counted once per facility and a session carrying no
+		// facilityIds would not appear at all.
+		for sql in [MOBILE_SQL, SERVER_SQL] {
+			assert!(!sql.contains("jsonb_array_elements"));
+			assert!(sql.contains("parameters->'facilityIds' AS facility_ids"));
+		}
+	}
+
+	#[test]
+	fn error_total_sums_both_streams() {
+		assert_eq!(error_total(0, false, 0, false), 0);
+		assert_eq!(error_total(3, false, 4, false), 7);
+	}
+
+	#[test]
+	fn error_total_saturates_when_either_stream_truncates() {
+		assert_eq!(error_total(100, true, 0, false), FAIL_ERRORS);
+		assert_eq!(error_total(0, false, 100, true), FAIL_ERRORS);
+	}
 
 	#[tokio::test]
 	async fn runs_against_central() {


### PR DESCRIPTION
🤖 Both queries in `sync_session_errors` selected `jsonb_array_elements_text(parameters->'facilityIds') AS facility_id`. A set-returning function in the target list cross-joins, so the query returned one row per facility per session — not one row per session.

Two consequences:

- A server session spanning several facilities was counted once per facility. The `FAIL_ERRORS >= 10` verdict tiers on that count, so five 2-facility sessions read as ten errors.
- A session whose `parameters` carry no `facilityIds` produced **no rows at all** and vanished from the report entirely. `parameters` defaults to `'"{}"'::jsonb`, on which `->'facilityIds'` is NULL, and the set-returning function yields nothing for NULL input. The server query matches on `isMobile IS DISTINCT FROM 'true'`, so such a session is in scope and was silently dropped.

Return the facility list as a `facilityIds` array on one row per session. The reported detail key changes from `facility_id` (a string) to `facility_ids` (an array); nothing in-tree reads it, and canopy takes check details as opaque JSON.

`sync_restart_loop` and `sync_facility_stale` use the same expansion correctly — both group or aggregate by `facility_id`, which is what the cross join is for. Only this check counted the expanded rows as if they were sessions.

The tiering logic moves into `error_total` so the truncation saturation is testable; the queries themselves aren't, as `test_support` builds a `db: None` context and there's no DB-backed harness for individual checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
