### PR TITLE
feat(alertd): publish flow metrics as counters

### DIFF
--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -73,4 +73,17 @@ The FHIR-workers check ([CHK-FWK](fhir-workers.md)) reports the health of a cent
 
 It reports the count of live workers beside the count of dropped workers — those that stopped heartbeating without deregistering — as the two components of one graph.
 It reports the age in seconds of the oldest live worker's heartbeat, so an operator sees how close the least-fresh worker is to the drop window, on its own graph.
-It reports the number of jobs the live workers have completed successfully and the number they have failed, summed across the live workers as one metric dimensioned by outcome; because a worker's identity is fresh each time its process starts, these are aggregate throughput rather than a per-worker or monotonic series.
+It reports the number of jobs the live workers have completed successfully and the number they have failed, summed across the live workers as one counter dimensioned by outcome, on one graph.
+A worker's counters run from the start of its process, so the sum only climbs while the same workers stay up and falls when one churns out of the live set; as a counter that fall reads as the reset it is, and an operator sees materialisation throughput rather than a lifetime tally that sawtooths.
+
+## Sync session errors
+
+The sync-session-errors check reads a one-minute window, which is what its verdict needs but far less than a scrape covers: a scrape reads only the latest sweep, so at munin's five-minute interval four minutes in five would go unseen.
+No index spans the sessions table for errored rows, so there is no cumulative total to read cheaply either.
+The daemon therefore accumulates each sweep's window into a running total per stream — mobile and server — published as one counter dimensioned by stream, the two sharing a graph.
+The totals start again from zero when the daemon restarts.
+
+## Error-stream row counts
+
+The error-stream checks report how many rows matched in their lookback window, counted exactly in the same query that fetches the rows to report, so the reported rows stay capped while the count they are counted from does not saturate.
+The metric's description names the window it covers, because a bare row count says nothing about the span that produced it.

--- a/crates/alertd/src/doctor/checks/certificate_notification_errors.rs
+++ b/crates/alertd/src/doctor/checks/certificate_notification_errors.rs
@@ -1,7 +1,5 @@
 //! Certificate notifications that errored within the lookback window.
 
-use jiff::{Timestamp, ToSpan};
-
 use super::{CheckContext, util::tiered_rows_check};
 use crate::doctor::check::Check;
 use bestool_tamanu::ApiServerKind;
@@ -25,14 +23,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 		return Check::skip(NAME, "no DB connection", "db unavailable");
 	};
 
-	let since = Timestamp::now() - LOOKBACK_HOURS.hours();
 	tiered_rows_check(
 		client,
 		"certificate_notification_errors",
 		"no recent certificate notification errors",
 		"certificate notification errors: ",
 		SQL,
-		&[&since],
+		LOOKBACK_HOURS,
 		1,
 		10,
 	)

--- a/crates/alertd/src/doctor/checks/fhir_job_errors.rs
+++ b/crates/alertd/src/doctor/checks/fhir_job_errors.rs
@@ -3,8 +3,6 @@
 //! Distinct from `fhir_jobs`, which measures live queue depth: this surfaces
 //! individual jobs that errored recently.
 
-use jiff::{Timestamp, ToSpan};
-
 use super::{CheckContext, util::tiered_rows_check};
 use crate::doctor::check::Check;
 use bestool_tamanu::ApiServerKind;
@@ -28,14 +26,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 		return Check::skip(NAME, "no DB connection", "db unavailable");
 	};
 
-	let since = Timestamp::now() - LOOKBACK_HOURS.hours();
 	tiered_rows_check(
 		client,
 		"fhir_job_errors",
 		"no recent FHIR job errors",
 		"FHIR job errors: ",
 		SQL,
-		&[&since],
+		LOOKBACK_HOURS,
 		1,
 		10,
 	)

--- a/crates/alertd/src/doctor/checks/fhir_workers.rs
+++ b/crates/alertd/src/doctor/checks/fhir_workers.rs
@@ -23,6 +23,12 @@ const NAME: &str = "fhir_workers";
 /// Live and dropped counts read against Tamanu's own liveness window
 /// (`fhir.worker.assumeDroppedAfter`, 10-minute fallback), plus the oldest live
 /// heartbeat's age and the live workers' job counters summed from `metadata`.
+///
+/// Each worker's job counters run from the moment its process started, so the
+/// sum over live workers only climbs while the same workers stay up and drops
+/// when one churns out of the live set. Published as a counter, that drop reads
+/// as the reset it is, and a scrape sees materialisation throughput rather than
+/// a lifetime tally that sawtooths.
 const SQL: &str = "\
 	SELECT
 		count(*) FILTER (WHERE alive) AS live,
@@ -104,13 +110,15 @@ pub async fn run(ctx: CheckContext) -> Check {
 				.help("FHIR workers with a stale heartbeat"),
 		)
 		.with_stat(
-			Stat::gauge("jobs", jobs_success)
+			Stat::counter("jobs_total", jobs_success)
 				.label("result", "success")
+				.group("jobs")
 				.help("Jobs processed by live workers, by outcome"),
 		)
 		.with_stat(
-			Stat::gauge("jobs", jobs_failure)
+			Stat::counter("jobs_total", jobs_failure)
 				.label("result", "failure")
+				.group("jobs")
 				.help("Jobs processed by live workers, by outcome"),
 		);
 	if let Some(age) = oldest_age {

--- a/crates/alertd/src/doctor/checks/ips_errors.rs
+++ b/crates/alertd/src/doctor/checks/ips_errors.rs
@@ -1,7 +1,5 @@
 //! IPS requests that errored within the lookback window.
 
-use jiff::{Timestamp, ToSpan};
-
 use super::{CheckContext, util::tiered_rows_check};
 use crate::doctor::check::Check;
 use bestool_tamanu::ApiServerKind;
@@ -24,14 +22,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 		return Check::skip(NAME, "no DB connection", "db unavailable");
 	};
 
-	let since = Timestamp::now() - LOOKBACK_HOURS.hours();
 	tiered_rows_check(
 		client,
 		"ips_errors",
 		"no recent IPS request errors",
 		"IPS request errors: ",
 		SQL,
-		&[&since],
+		LOOKBACK_HOURS,
 		1,
 		10,
 	)

--- a/crates/alertd/src/doctor/checks/patient_communication_errors.rs
+++ b/crates/alertd/src/doctor/checks/patient_communication_errors.rs
@@ -1,7 +1,5 @@
 //! Patient communications that errored within the lookback window.
 
-use jiff::{Timestamp, ToSpan};
-
 use super::{CheckContext, util::tiered_rows_check};
 use crate::doctor::check::Check;
 use bestool_tamanu::ApiServerKind;
@@ -25,14 +23,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 		return Check::skip(NAME, "no DB connection", "db unavailable");
 	};
 
-	let since = Timestamp::now() - LOOKBACK_HOURS.hours();
 	tiered_rows_check(
 		client,
 		"patient_communication_errors",
 		"no recent patient communication errors",
 		"patient communication errors: ",
 		SQL,
-		&[&since],
+		LOOKBACK_HOURS,
 		1,
 		10,
 	)

--- a/crates/alertd/src/doctor/checks/report_errors.rs
+++ b/crates/alertd/src/doctor/checks/report_errors.rs
@@ -1,7 +1,5 @@
 //! Report requests that errored within the lookback window.
 
-use jiff::{Timestamp, ToSpan};
-
 use super::{CheckContext, util::tiered_rows_check};
 use crate::doctor::check::Check;
 use bestool_tamanu::ApiServerKind;
@@ -25,14 +23,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 		return Check::skip(NAME, "no DB connection", "db unavailable");
 	};
 
-	let since = Timestamp::now() - LOOKBACK_HOURS.hours();
 	tiered_rows_check(
 		client,
 		"report_errors",
 		"no recent report errors",
 		"report errors: ",
 		SQL,
-		&[&since],
+		LOOKBACK_HOURS,
 		1,
 		10,
 	)

--- a/crates/alertd/src/doctor/checks/sync_session_errors.rs
+++ b/crates/alertd/src/doctor/checks/sync_session_errors.rs
@@ -4,11 +4,18 @@
 //! The window is a tight `updated_at > now() - interval '1 minute'`; the sweep
 //! runs every 60s, so this still catches each error once.
 //!
+//! That window suits a verdict but not a graph: a scrape reads only the latest
+//! sweep, so at munin's five-minute interval four minutes in five would never be
+//! seen. The published metric is therefore a running total the daemon
+//! accumulates a window at a time, which a scrape derives its own rate from.
+//!
 //! Each query returns one row per session. The facility list rides along as the
 //! `facilityIds` array rather than being expanded into a row per facility: a
 //! set-returning function in the target list cross-joins, which would count a
 //! session spanning several facilities once per facility, and would drop a
 //! session whose `parameters` carry no `facilityIds` at all.
+
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::Value;
 
@@ -43,22 +50,37 @@ const SERVER_SQL: &str = "SELECT id, errors::text, \
 	AND NOT (cardinality(errors) = 1 AND errors[1] LIKE '%snapshot-for-pushing%') \
 	ORDER BY created_at DESC";
 
-/// Errored sessions the verdict tiers on.
+/// Errors seen since this process started, one stream each.
 ///
-/// A truncated row set means there were more sessions than the report cap, well
-/// past [`FAIL_ERRORS`], so the total saturates there rather than reporting the
-/// cap as if it were the real figure.
-fn error_total(
-	mobile_n: usize,
-	mobile_truncated: bool,
-	server_n: usize,
-	server_truncated: bool,
-) -> usize {
-	if mobile_truncated || server_truncated {
-		FAIL_ERRORS
-	} else {
-		mobile_n + server_n
-	}
+/// Postgres can only be asked what happened in a window; there is no cheap
+/// cumulative total to read, since no index covers `errors IS NOT NULL` across
+/// the whole of `sync_sessions`. So the daemon does the accumulating: each
+/// sweep's window is added to a running total that a scrape derives its own rate
+/// from.
+static MOBILE_SEEN: AtomicU64 = AtomicU64::new(0);
+static SERVER_SEEN: AtomicU64 = AtomicU64::new(0);
+
+/// Add this sweep's count to a running total and read the total back.
+fn accumulate(seen: &AtomicU64, found: u64) -> u64 {
+	seen.fetch_add(found, Ordering::Relaxed) + found
+}
+
+/// Attach the running totals, which stand independent of the verdict: a sweep
+/// that finds nothing still reports every error counted before it.
+fn with_error_counters(check: Check, mobile_seen: u64, server_seen: u64) -> Check {
+	check
+		.with_stat(
+			Stat::counter("errors_total", mobile_seen as f64)
+				.label("stream", "mobile")
+				.group("errors")
+				.help("Sync-session errors seen"),
+		)
+		.with_stat(
+			Stat::counter("errors_total", server_seen as f64)
+				.label("stream", "server")
+				.group("errors")
+				.help("Sync-session errors seen"),
+		)
 }
 
 pub async fn run(ctx: CheckContext) -> Check {
@@ -82,20 +104,20 @@ pub async fn run(ctx: CheckContext) -> Check {
 		Err(err) => return super::query_error_check(NAME, &err),
 	};
 
+	let mobile_seen = accumulate(&MOBILE_SEEN, mobile.total);
+	let server_seen = accumulate(&SERVER_SEEN, server.total);
+
 	if mobile.is_empty() && server.is_empty() {
-		return Check::pass(NAME, "no recent sync session errors")
-			.with_stat(Stat::gauge("mobile_errors", 0.0).help("Recent mobile sync-session errors"))
-			.with_stat(
-				Stat::gauge("server_errors", 0.0).help("Recent server sync-session errors"),
-			);
+		return with_error_counters(
+			Check::pass(NAME, "no recent sync session errors"),
+			mobile_seen,
+			server_seen,
+		);
 	}
 
 	let (mobile_count, mobile_truncated) = (mobile.count(), mobile.truncated);
 	let (server_count, server_truncated) = (server.count(), server.truncated);
-	// Row vecs are capped at the report cap, so these saturate there on truncation.
-	let (mobile_n, server_n) = (mobile.rows.len(), server.rows.len());
-
-	let total = error_total(mobile_n, mobile_truncated, server_n, server_truncated);
+	let total = (mobile.total + server.total) as usize;
 
 	let summary = format!("sync session errors: {mobile_count} mobile, {server_count} server");
 	let reason = "recent sync session error(s)";
@@ -104,24 +126,24 @@ pub async fn run(ctx: CheckContext) -> Check {
 	} else {
 		Check::warning(NAME, summary, reason)
 	};
-	check
-		.with_detail("mobile", Value::Array(mobile.rows))
-		.with_detail("mobile_count", mobile_count)
-		.with_detail("mobile_truncated", mobile_truncated)
-		.with_detail("server", Value::Array(server.rows))
-		.with_detail("server_count", server_count)
-		.with_detail("server_truncated", server_truncated)
-		.with_stat(
-			Stat::gauge("mobile_errors", mobile_n as f64).help("Recent mobile sync-session errors"),
-		)
-		.with_stat(
-			Stat::gauge("server_errors", server_n as f64).help("Recent server sync-session errors"),
-		)
+	with_error_counters(
+		check
+			.with_detail("mobile", Value::Array(mobile.rows))
+			.with_detail("mobile_count", mobile_count)
+			.with_detail("mobile_truncated", mobile_truncated)
+			.with_detail("server", Value::Array(server.rows))
+			.with_detail("server_count", server_count)
+			.with_detail("server_truncated", server_truncated),
+		mobile_seen,
+		server_seen,
+	)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::{FAIL_ERRORS, MOBILE_SQL, SERVER_SQL, error_total};
+	use std::sync::atomic::AtomicU64;
+
+	use super::{MOBILE_SQL, SERVER_SQL, accumulate};
 	use crate::doctor::checks::test_support::{central_ctx, facility_ctx};
 
 	#[test]
@@ -136,15 +158,12 @@ mod tests {
 	}
 
 	#[test]
-	fn error_total_sums_both_streams() {
-		assert_eq!(error_total(0, false, 0, false), 0);
-		assert_eq!(error_total(3, false, 4, false), 7);
-	}
-
-	#[test]
-	fn error_total_saturates_when_either_stream_truncates() {
-		assert_eq!(error_total(100, true, 0, false), FAIL_ERRORS);
-		assert_eq!(error_total(0, false, 100, true), FAIL_ERRORS);
+	fn accumulate_sums_successive_windows() {
+		let seen = AtomicU64::new(0);
+		assert_eq!(accumulate(&seen, 3), 3);
+		assert_eq!(accumulate(&seen, 4), 7);
+		// a quiet window leaves the total where it was
+		assert_eq!(accumulate(&seen, 0), 7);
 	}
 
 	#[tokio::test]

--- a/crates/alertd/src/doctor/checks/util.rs
+++ b/crates/alertd/src/doctor/checks/util.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use jiff::{Timestamp, ToSpan};
 use serde_json::Value;
 use tokio_postgres::{Client as PgClient, types::ToSql};
 
@@ -20,30 +21,35 @@ const REPORT_CAP: usize = 100;
 const FETCH_CAP: usize = REPORT_CAP + 1;
 
 /// Wrap the check's SQL so Postgres hands back one JSONB column (`row`) per
-/// matching row, capped at [`FETCH_CAP`].
+/// matching row, capped at [`FETCH_CAP`], plus the exact number of matches.
+///
+/// `count(*) OVER ()` is evaluated across the whole subquery result before
+/// `LIMIT` truncates it, so the count stays exact however many rows matched —
+/// and it costs one query rather than a second round trip.
 fn wrap(sql: &str) -> String {
-	format!("SELECT to_jsonb(sub) AS row FROM ( {sql} ) sub LIMIT {FETCH_CAP}")
+	format!(
+		"SELECT to_jsonb(sub) AS row, count(*) OVER () AS total FROM ( {sql} ) sub LIMIT {FETCH_CAP}"
+	)
 }
 
-/// Outcome of running one wrapped query: the rows (capped at
-/// [`REPORT_CAP`]) and whether more existed than were reported.
+/// Outcome of running one wrapped query: the rows (capped at [`REPORT_CAP`]),
+/// whether more matched than were reported, and how many matched in total.
 pub struct RowSet {
 	pub rows: Vec<Value>,
+	/// Whether more rows matched than [`REPORT_CAP`] carries.
 	pub truncated: bool,
+	/// Every matching row, counted regardless of the report cap.
+	pub total: u64,
 }
 
 impl RowSet {
 	pub fn is_empty(&self) -> bool {
-		self.rows.is_empty()
+		self.total == 0
 	}
 
-	/// Number to report: the exact count, or `"100+"` when truncated.
+	/// Number to report.
 	pub fn count(&self) -> Value {
-		if self.truncated {
-			Value::from(format!("{REPORT_CAP}+"))
-		} else {
-			Value::from(self.rows.len())
-		}
+		Value::from(self.total)
 	}
 }
 
@@ -57,12 +63,20 @@ pub async fn fetch_rows(
 	let wrapped = wrap(sql);
 	let raw = client.query(&wrapped, params).await?;
 	let truncated = raw.len() > REPORT_CAP;
+	// Every row carries the same window-function total; no rows means no matches.
+	let total = raw
+		.first()
+		.map_or(0, |r| r.get::<_, i64>("total").max(0) as u64);
 	let rows = raw
 		.into_iter()
 		.take(REPORT_CAP)
 		.map(|r| r.get::<_, Value>("row"))
 		.collect();
-	Ok(RowSet { rows, truncated })
+	Ok(RowSet {
+		rows,
+		truncated,
+		total,
+	})
 }
 
 /// Run a single wrapped query and tier the outcome on the number of
@@ -72,8 +86,9 @@ pub async fn fetch_rows(
 /// `summary_pass` is the headline shown when nothing crosses `warn_min`;
 /// `summary_prefix` is prepended to the count for the WARN/FAIL summary.
 ///
-/// Rows are capped at [`REPORT_CAP`] (reported as `"100+"`), which is enough to
-/// distinguish the small WARN/FAIL boundaries the error-stream checks use.
+/// The query's `$1` is bound to the start of the lookback window. Reported rows
+/// are capped at [`REPORT_CAP`], but the count the verdict and the metric use is
+/// exact.
 #[expect(
 	clippy::too_many_arguments,
 	reason = "shared query helper; each parameter is a distinct knob the call sites set"
@@ -84,24 +99,20 @@ pub async fn tiered_rows_check(
 	summary_pass: &str,
 	summary_prefix: &str,
 	sql: &str,
-	params: &[&(dyn ToSql + Sync)],
+	lookback_hours: i64,
 	warn_min: usize,
 	fail_min: usize,
 ) -> Check {
-	match fetch_rows(client, sql, params).await {
+	let since = Timestamp::now() - lookback_hours.hours();
+	match fetch_rows(client, sql, &[&since]).await {
 		Ok(set) => {
-			// `truncated` means there were more than REPORT_CAP rows, which is
-			// well past any realistic fail_min, so treat it as the cap.
-			let n = if set.truncated {
-				REPORT_CAP + 1
-			} else {
-				set.rows.len()
-			};
+			let n = set.total as usize;
 			let count = set.count();
-			// Emit the count as a metric on every tier, including pass; the query
-			// caps at REPORT_CAP+1, so the gauge saturates at 101.
-			let count_stat =
-				Stat::gauge("count", n as f64).help("Matching error rows (capped at 101)");
+			// Emit the count as a metric on every tier, including pass. The window
+			// it covers goes in the description: it's the same every sweep, but a
+			// bare row count says nothing about what span produced it.
+			let count_stat = Stat::gauge("count", set.total as f64)
+				.help(format!("Error rows in the last {lookback_hours}h"));
 			if n < warn_min {
 				return Check::pass(name, summary_pass.to_string()).with_stat(count_stat);
 			}
@@ -143,5 +154,35 @@ mod tests {
 		assert_eq!(tier(9, 1, 10), "warning");
 		assert_eq!(tier(10, 1, 10), "fail");
 		assert_eq!(tier(100, 1, 10), "fail");
+	}
+
+	#[test]
+	fn wrap_counts_outside_the_row_cap() {
+		// The window function is evaluated across the subquery before LIMIT, so
+		// the count survives truncation of the rows that get reported.
+		let sql = super::wrap("SELECT 1");
+		assert!(sql.contains("count(*) OVER () AS total"));
+		assert!(sql.ends_with(&format!("LIMIT {}", super::FETCH_CAP)));
+	}
+
+	#[test]
+	fn a_truncated_row_set_still_counts_exactly() {
+		let set = super::RowSet {
+			rows: vec![serde_json::Value::from(1); super::REPORT_CAP],
+			truncated: true,
+			total: 4321,
+		};
+		assert_eq!(set.count(), serde_json::Value::from(4321u64));
+		assert!(!set.is_empty());
+	}
+
+	#[test]
+	fn a_row_set_with_no_matches_is_empty() {
+		let set = super::RowSet {
+			rows: Vec::new(),
+			truncated: false,
+			total: 0,
+		};
+		assert!(set.is_empty());
 	}
 }


### PR DESCRIPTION
🤖 Stacked on #782 — its exact-count change is what lets the saturation logic go. Base it back to `main` once that merges.

Follow-up to #781, which fixed the same defect in `http_errors`: a count of events over a window, published as a gauge, that a scrape can't interpret without knowing the window — and at munin's five-minute interval mostly can't see, since a scrape reads only the latest sweep.

**`fhir_workers`** summed each live worker's lifetime job counters (`metadata->>'successfulJobs'`) into a gauge. A worker's counters run from the start of its process, so the sum climbed indefinitely and sawtoothed whenever a worker churned out of the live set — there was no way to read throughput off it. Now a counter, `jobs_total{result}`, where the drop reads as the reset it genuinely is.

**The five error-stream checks** (`ips_errors`, `certificate_notification_errors`, `fhir_job_errors`, `report_errors`, `patient_communication_errors`) published a row count that saturated at 101, because the metric reused the row-reporting cap from `wrap()` — a bound chosen to keep the JSON payload to canopy small. A host with a real error flood flat-lined, and the graph stopped distinguishing bad from catastrophic.

The wrapping query now carries `count(*) OVER ()`, evaluated across the subquery before `LIMIT` truncates it, so the exact count comes back in the same round trip — no second query. Reported rows stay capped at 100. `RowSet::count()` consequently stops returning the string `"100+"` and always returns a number.

These five keep a one-hour windowed gauge rather than becoming counters: there's no cheap cumulative source (a full-table `count(*)` per sweep is the wrong trade), and accumulating doesn't work when the window is 60× the sweep interval — each error would be counted ~60 times. The window instead goes in the metric's description, which is the munin field label and the prometheus `HELP`, so it's on the metrics surface. Flagging that as a partial fix: the saturation is gone, the windowed-gauge shape isn't.

`tiered_rows_check` now takes the lookback directly instead of a `params` slice, since all five call sites computed the identical `Timestamp::now() - LOOKBACK_HOURS.hours()` bound.

**`sync_session_errors`** reads a one-minute window, and per the schema on a busy central there's no index that spans `sync_sessions` for errored rows — `sync_sessions_pending_snapshot_cleanup_idx` is predicated on `snapshot_dropped_at IS NULL`, which a plain `errors IS NOT NULL` query can't imply, so it'd be a seq scan over millions of rows every 60s. Neither a wider window nor a cumulative read is available, so the daemon accumulates: each sweep's count is added to a per-stream running total, published as `errors_total{stream}`. Zero extra query cost, and a daemon restart zeroes it — which is what a counter reset means.

With counts now exact, `error_total`'s truncation saturation is gone; it only existed to stand in for a capped count.

Spec sections added to MET for both, and the FHIR-workers paragraph reworded — it previously recorded these as deliberately non-monotonic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
