### PR TITLE
fix(alertd): grade fhir_workers on liveness only

### DIFF
--- a/.workhorse/specs/tamanu/fhir-jobs.md
+++ b/.workhorse/specs/tamanu/fhir-jobs.md
@@ -10,7 +10,7 @@ It is one of the doctor's healthchecks; see [CHK](healthchecks.md) for the frame
 ## Grading
 
 The check measures the pending queue: the number of FHIR jobs not yet worked through, and the age of the oldest such job.
-Jobs that have errored are excluded from both measures — they are a permanent record of past failures, not pending work, and are graded by the separate FHIR job-errors check.
+Jobs that have errored are excluded from both measures — they are a record of past failures, not pending work, and are graded by the separate FHIR job-errors check.
 
 The check fails when the pending queue is deep or its oldest job is old, warns at lower thresholds, and passes otherwise.
 It skips on a facility server, which runs no FHIR workers, and skips when the deployment has no FHIR jobs table.

--- a/.workhorse/specs/tamanu/fhir-workers.md
+++ b/.workhorse/specs/tamanu/fhir-workers.md
@@ -29,12 +29,14 @@ A worker's liveness is read the same way Tamanu itself reads it: a worker is liv
 
 The window is read from the setting so it tracks the deployment rather than a value baked into the check.
 
+A dropped worker is not itself a fault: the jobs it had grabbed return to the pool for a live worker to take, so materialisation carries on without it.
+Its row lingers until the deployment prunes the table, which is not something an operator can bring about from the outside, so the presence of dropped workers is reported as telemetry and does not enter the verdict.
+
 ## Outcomes
 
 For a central server with the FHIR worker enabled:
 
 - [ ] The check fails when no worker is live.
-- [ ] The check warns when at least one worker is live but one or more dropped workers are present.
-- [ ] The check passes when at least one worker is live and no dropped workers are present.
+- [ ] The check passes when at least one worker is live, whatever the number of dropped workers.
 
 A count of live workers cannot be asserted against a fixed expectation: the number of worker rows is emergent from deployment topology (a running server registers a `refresh` and a `resolver` worker, multiplied by however many server processes run), so the check grades the presence of liveness, not a specific worker count.

--- a/.workhorse/specs/tamanu/metrics.md
+++ b/.workhorse/specs/tamanu/metrics.md
@@ -83,7 +83,8 @@ The total size of all snapshot tables is a separate graph: it dwarfs the percent
 
 The FHIR-workers check ([CHK-FWK](fhir-workers.md)) reports the health of a central's FHIR materialisation workers, read from their heartbeats.
 
-It reports the count of live workers beside the count of dropped workers — those that stopped heartbeating without deregistering — as the two components of one graph.
+It reports the count of live workers on its own graph.
+It reports the count of dropped workers — those that stopped heartbeating without deregistering — separately and as a counter: those rows accumulate until the deployment prunes them, so what the number carries is the rate at which workers drop, and the fall when the table is pruned reads as the reset it is.
 It reports the age in seconds of the oldest live worker's heartbeat, so an operator sees how close the least-fresh worker is to the drop window, on its own graph.
 It reports the number of jobs the live workers have completed successfully and the number they have failed, summed across the live workers as one counter dimensioned by outcome, on one graph.
 A worker's counters run from the start of its process, so the sum only climbs while the same workers stay up and falls when one churns out of the live set; as a counter that fall reads as the reset it is, and an operator sees materialisation throughput rather than a lifetime tally that sawtooths.

--- a/crates/alertd/src/doctor/checks/fhir_jobs.rs
+++ b/crates/alertd/src/doctor/checks/fhir_jobs.rs
@@ -1,7 +1,7 @@
 //! FHIR job queue depth.
 //!
 //! Tamanu's `fhir.jobs` table is both queue and audit log: rows in status
-//! `Errored` intentionally stick around forever (they record past failures),
+//! `Errored` outlive the work they describe, as the record of a past failure,
 //! so the count of those is not a signal of current health. What we care
 //! about is the *active queue* — rows that workers haven't yet drained:
 //! `Queued`, `Grabbed`, `Started`.

--- a/crates/alertd/src/doctor/checks/fhir_workers.rs
+++ b/crates/alertd/src/doctor/checks/fhir_workers.rs
@@ -3,14 +3,19 @@
 //! Tamanu's FHIR workers register a row in `fhir.job_workers` and update its
 //! `updated_at` on a periodic heartbeat; job grabbing, completion, and
 //! stuck-job reclamation all gate on that heartbeat being within
-//! `fhir.worker.assumeDroppedAfter` (default 10 minutes). A worker that stops
-//! heartbeating stalls materialisation even while its service process looks up,
-//! which neither `tamanu_service` (process up) nor `fhir_jobs` (backlog) catches.
+//! `fhir.worker.assumeDroppedAfter` (default 10 minutes). Workers that have all
+//! stopped heartbeating stall materialisation even while their service processes
+//! look up, which neither `tamanu_service` (process up) nor `fhir_jobs`
+//! (backlog) catches.
 //!
 //! A live worker is one whose row isn't soft-deleted and whose heartbeat is
 //! within the window; a dropped worker is one that isn't soft-deleted but whose
 //! heartbeat has gone stale — it crashed or was killed without deregistering. A
 //! gracefully stopped worker has `deleted_at` set and counts as neither.
+//!
+//! Dropped workers don't enter the verdict: their grabbed jobs return to the
+//! pool for a live worker to take, and their rows sit there until the deployment
+//! prunes the table, so an operator has no way to act on them.
 
 use bestool_tamanu::ApiServerKind;
 
@@ -86,28 +91,18 @@ pub async fn run(ctx: CheckContext) -> Check {
 	let jobs_failure: f64 = row.try_get("jobs_failure").unwrap_or(0.0);
 
 	let summary = format!("{live} live, {dropped} dropped");
-	let check = match classify(live, dropped) {
+	let check = match classify(live) {
 		Verdict::Fail => Check::fail(NAME, summary, "no live FHIR worker is heartbeating"),
-		Verdict::Warn => Check::warning(
-			NAME,
-			summary,
-			format!("{dropped} worker(s) stopped heartbeating without deregistering"),
-		),
 		Verdict::Pass => Check::pass(NAME, summary),
 	};
 
 	let mut check = check
 		.with_detail("live", live)
 		.with_detail("dropped", dropped)
+		.with_stat(Stat::gauge("live", live as f64).help("Live FHIR workers"))
 		.with_stat(
-			Stat::gauge("live", live as f64)
-				.group("workers")
-				.help("Live FHIR workers"),
-		)
-		.with_stat(
-			Stat::gauge("dropped", dropped as f64)
-				.group("workers")
-				.help("FHIR workers with a stale heartbeat"),
+			Stat::counter("dropped_total", dropped as f64)
+				.help("FHIR workers that stopped heartbeating without deregistering"),
 		)
 		.with_stat(
 			Stat::counter("jobs_total", jobs_success)
@@ -132,17 +127,13 @@ pub async fn run(ctx: CheckContext) -> Check {
 
 enum Verdict {
 	Pass,
-	Warn,
 	Fail,
 }
 
-/// Grade worker liveness: no live worker fails, a dropped (crashed) worker
-/// warns, otherwise pass.
-fn classify(live: i64, dropped: i64) -> Verdict {
+/// Grade worker liveness: no live worker fails, otherwise pass.
+fn classify(live: i64) -> Verdict {
 	if live == 0 {
 		Verdict::Fail
-	} else if dropped > 0 {
-		Verdict::Warn
 	} else {
 		Verdict::Pass
 	}
@@ -154,30 +145,22 @@ mod tests {
 	use crate::doctor::check::CheckStatus;
 	use crate::doctor::checks::test_support::{central_ctx, facility_ctx};
 
-	fn verdict(live: i64, dropped: i64) -> &'static str {
-		match classify(live, dropped) {
+	fn verdict(live: i64) -> &'static str {
+		match classify(live) {
 			Verdict::Pass => "pass",
-			Verdict::Warn => "warn",
 			Verdict::Fail => "fail",
 		}
 	}
 
 	#[test]
 	fn no_live_worker_fails() {
-		assert_eq!(verdict(0, 0), "fail");
-		assert_eq!(verdict(0, 2), "fail");
+		assert_eq!(verdict(0), "fail");
 	}
 
 	#[test]
-	fn dropped_worker_warns_when_some_are_live() {
-		assert_eq!(verdict(1, 1), "warn");
-		assert_eq!(verdict(2, 3), "warn");
-	}
-
-	#[test]
-	fn all_live_passes() {
-		assert_eq!(verdict(1, 0), "pass");
-		assert_eq!(verdict(2, 0), "pass");
+	fn a_live_worker_passes() {
+		assert_eq!(verdict(1), "pass");
+		assert_eq!(verdict(2), "pass");
 	}
 
 	#[tokio::test]
@@ -193,11 +176,11 @@ mod tests {
 		};
 		let check = super::run(ctx).await;
 		assert_eq!(check.name, "fhir_workers");
-		// Enabled or not, the outcome is a real grade or a skip — never a panic.
+		// Enabled or not, the outcome is a real grade or a skip — never a panic,
+		// and never a warning: liveness is pass-or-fail.
 		assert!(matches!(
 			check.status,
 			CheckStatus::Pass
-				| CheckStatus::Warning(_)
 				| CheckStatus::Fail(_)
 				| CheckStatus::Skip(_)
 				| CheckStatus::Broken(_)


### PR DESCRIPTION
🤖 A deployment reported `fhir_workers` warning with "1935 worker(s) stopped heartbeating without deregistering", and there was nothing an operator could do to clear it.

A dropped worker row is the expected residue of a restart or a crash. The jobs it had grabbed go back in the pool for a live worker to take, so materialisation carries on; the row itself lingers until the deployment prunes the table, which Tamanu was never doing (a separate fix for that is going up against tamanu). Warning on its presence latched a warning with no path back to pass, for a condition that isn't a fault.

`fhir_workers` now grades liveness alone: fail when no worker is heartbeating, pass when at least one is, whatever the number of dropped workers. `classify` takes only the live count, so the grading can't drift back.

The dropped count is still reported, as `dropped_total` on its own graph, and as a counter rather than a gauge: the rows accumulate until they're pruned, so the rate of change is the signal, and the fall when a prune happens reads as the reset it is. `live` moves to its own graph alongside it.

Also drops the word "permanent" from the `fhir_jobs` description of errored jobs, which stops being true once Tamanu expires them. The reason they're excluded from the queue measures is unchanged: they record past failures rather than pending work.
