### PR TITLE
fix(tamanu): resolve the running version from the image label

### DIFF
--- a/crates/tamanu/src/versions.rs
+++ b/crates/tamanu/src/versions.rs
@@ -123,9 +123,23 @@ pub fn parse_image_tag(image: &str) -> Option<&str> {
 	if tag.is_empty() { None } else { Some(tag) }
 }
 
+/// The version a running container reports, preferring the image's
+/// `org.opencontainers.image.version` label over its tag.
+///
+/// A deployment pinned to a commit runs an image tagged `sha-<commit>`, which
+/// carries no version; the label does, so a SHA-pinned deployment is still
+/// discoverable.
+pub fn version_of_running_image<'a>(image: &'a str, label: &'a str) -> Option<&'a str> {
+	let label = label.trim();
+	if !label.is_empty() && label != "<no value>" {
+		return Some(label);
+	}
+	parse_image_tag(image)
+}
+
 /// Returns a map from systemd unit name (e.g. `tamanu-central-api@1.service`)
-/// to the running container's image tag. Containers without an image tag, or
-/// not labelled as systemd-managed, are skipped.
+/// to the running container's version. Containers whose version can't be read,
+/// or that aren't labelled as systemd-managed, are skipped.
 ///
 /// `Ok(map)` means podman answered — an empty map then genuinely means "no
 /// tamanu containers are running". `Err(reason)` means we couldn't ask at all:
@@ -145,7 +159,7 @@ pub async fn running_versions_linux() -> Result<HashMap<String, String>, String>
 		.args([
 			"ps",
 			"--format",
-			"{{.Labels.PODMAN_SYSTEMD_UNIT}}\t{{.Image}}",
+			"{{.Labels.PODMAN_SYSTEMD_UNIT}}\t{{.Image}}\t{{index .Labels \"org.opencontainers.image.version\"}}",
 		])
 		.output()
 		.await;
@@ -168,7 +182,8 @@ pub async fn running_versions_linux() -> Result<HashMap<String, String>, String>
 
 	let mut out = HashMap::new();
 	for line in output.lines() {
-		let Some((unit, image)) = line.split_once('\t') else {
+		let mut fields = line.split('\t');
+		let (Some(unit), Some(image)) = (fields.next(), fields.next()) else {
 			continue;
 		};
 		let unit = unit.trim();
@@ -176,11 +191,15 @@ pub async fn running_versions_linux() -> Result<HashMap<String, String>, String>
 		if unit.is_empty() || image.is_empty() {
 			continue;
 		}
-		let Some(tag) = parse_image_tag(image) else {
-			warn!(unit, image, "container image carries no parseable tag");
+		let Some(version) = version_of_running_image(image, fields.next().unwrap_or_default())
+		else {
+			warn!(
+				unit,
+				image, "container image carries no version label or tag"
+			);
 			continue;
 		};
-		out.insert(unit.to_string(), tag.to_string());
+		out.insert(unit.to_string(), version.to_string());
 	}
 	Ok(out)
 }
@@ -519,6 +538,43 @@ TAMANU_VERSION = v2.10.0
 		assert_eq!(
 			parse_image_tag("ghcr.io/beyondessential/tamanu-central:v2.10.0"),
 			Some("v2.10.0")
+		);
+	}
+
+	#[test]
+	fn version_of_running_image_prefers_label() {
+		// a commit-pinned deployment: the tag carries no version, the label does
+		assert_eq!(
+			version_of_running_image(
+				"ghcr.io/beyondessential/tamanu-facility:sha-fe5fc00c",
+				"2.62.0"
+			),
+			Some("2.62.0")
+		);
+		// the label wins over a versioned tag too, both being the same build
+		assert_eq!(
+			version_of_running_image("ghcr.io/beyondessential/tamanu-central:v2.10.0", "2.10.0"),
+			Some("2.10.0")
+		);
+	}
+
+	#[test]
+	fn version_of_running_image_falls_back_to_tag() {
+		// images built before the label existed, and podman's empty-label rendering
+		assert_eq!(
+			version_of_running_image("ghcr.io/beyondessential/tamanu-central:v2.10.0", ""),
+			Some("v2.10.0")
+		);
+		assert_eq!(
+			version_of_running_image(
+				"ghcr.io/beyondessential/tamanu-central:v2.10.0",
+				"<no value>"
+			),
+			Some("v2.10.0")
+		);
+		assert_eq!(
+			version_of_running_image("ghcr.io/beyondessential/tamanu-central", ""),
+			None
 		);
 	}
 


### PR DESCRIPTION
`bestool tamanu <anything>` can't resolve the active version on a deployment pinned to a commit rather than a release, which makes every subcommand fail on such a host, `psql` included:

```
× cannot determine the active Tamanu version: no running container, database
  record, or env file matches a config dir under /etc/tamanu; use --root
```

`try_find_tamanu` derives candidate versions from `/etc/tamanu/<version>` directory names via a semver regex, so a dir named `sha-<commit>` never becomes a candidate, and the env file's matching `sha-<commit>` can never match one. `--root` doesn't help: same regex, and a config dir has no `package.json` to fall back to.

The images already carry the answer. A commit-pinned container is tagged `sha-fe5fc00c…` but labelled `org.opencontainers.image.version=2.62.0`, and `running_versions_linux` was reading the one part of the reference that doesn't carry a version. It now asks podman for that label and prefers it over the tag, falling back to the tag for images built before the label existed.

That restores the running-container signal, which is the most authoritative of the three and enough on its own: a commit-pinned host with containers up now resolves.

Found while deploying an arbitrary commit to a demo (Tamanu TAM-7029). It failed `tamanu-single-upgrade`'s "Roll the frontend service" at the one moment no container was running, which aborted the play before its later drop-reporting-schema and migrate steps and left the box with new code on an old schema.

Not fixed here, and worth deciding separately: with no container running, a commit-pinned host still can't resolve, since the env-file and config-dir signals remain semver-only. The complementary fix is on the ops side, naming the config dir with the semver (`v2.62.0`) while pinning the image tag separately, so bestool never sees a non-semver dir.